### PR TITLE
Fix namespace errors in analogsignal/spiketrain

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -161,10 +161,10 @@ class BaseAnalogSignal(BaseNeo, pq.Quantity):
             to_u = self.units
             signal = np.array(self)
         else:
-            to_u = Quantity(1.0, to_dims)
-            from_u = Quantity(1.0, self.dimensionality)
+            to_u = pq.Quantity(1.0, to_dims)
+            from_u = pq.Quantity(1.0, self.dimensionality)
             try:
-                cf = get_conversion_factor(from_u, to_u)
+                cf = pq.unitquantity.get_conversion_factor(from_u, to_u)
             except AssertionError:
                 raise ValueError(
                     'Unable to convert between units of "%s" and "%s"'

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -194,10 +194,10 @@ class SpikeTrain(BaseNeo, pq.Quantity):
             to_u = self.units
             spikes = numpy.array(self)
         else:
-            to_u = Quantity(1.0, to_dims)
-            from_u = Quantity(1.0, self.dimensionality)
+            to_u = pq.Quantity(1.0, to_dims)
+            from_u = pq.Quantity(1.0, self.dimensionality)
             try:
-                cf = get_conversion_factor(from_u, to_u)
+                cf = pq.unitquantity.get_conversion_factor(from_u, to_u)
             except AssertionError:
                 raise ValueError(
                     'Unable to convert between units of "%s" and "%s"'


### PR DESCRIPTION
I assume these methods are from the quantities module.

Maybe you cau use static analysis tool such as pyflakes to detect namespace error.  Also, I suggest the pep8 script to check PEP8 compliance if you are planning to follow it.
