### PR TITLE
[WIP] Implement _repr_pretty_ for IPython

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -246,6 +246,27 @@ class BaseAnalogSignal(BaseNeo, pq.Quantity):
     def __rsub__(self, other):
         return self.__mul__(-1) + other
 
+    def _repr_pretty_(self, pp, cycle):
+        pp.text(" ".join([self.__class__.__name__,
+                          "in",
+                          str(self.units),
+                          "with",
+                          "x".join(map(str, self.shape)),
+                          str(self.dtype),
+                          "values",
+                         ]))
+        if self._has_repr_pretty_attrs_():
+            pp.breakable()
+            self._repr_pretty_attrs_(pp, cycle)
+
+        for line in ["sampling rate: {0}".format(self.sampling_rate),
+                     "time: {0} to {1}".format(self.t_start, self.t_stop),
+                    ]:
+            if line:
+                pp.breakable()
+                with pp.group(indent=1):
+                    pp.text(line)
+
 
 class AnalogSignal(BaseAnalogSignal):
     """

--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -97,3 +97,27 @@ class BaseNeo(object):
         """
         _check_annotations(annotations)
         self.annotations.update(annotations)
+
+    _repr_pretty_attrs_keys_ = ["name", "description", "annotations"]
+
+    def _has_repr_pretty_attrs_(self):
+        return any(getattr(self, k) for k in self._repr_pretty_attrs_keys_)
+
+    def _repr_pretty_attrs_(self, pp, cycle):
+        first = True
+        for key in self._repr_pretty_attrs_keys_:
+            value = getattr(self, key)
+            if value:
+                if first:
+                    first = False
+                else:
+                    pp.breakable()
+                with pp.group(indent=1):
+                    pp.text("{0}: ".format(key))
+                    pp.pretty(value)
+
+    def _repr_pretty_(self, pp, cycle):
+        pp.text(self.__class__.__name__)
+        if self._has_repr_pretty_attrs_():
+            pp.breakable()
+            self._repr_pretty_attrs_(pp, cycle)

--- a/neo/core/block.py
+++ b/neo/core/block.py
@@ -92,3 +92,28 @@ class Block(BaseNeo):
                     lookup[obj.name].merge(obj)
                 else:
                     getattr(self, container).append(obj)
+
+    _repr_pretty_attrs_keys_ = [
+        "name", "description", "annotations",
+        "file_origin", "file_datetime", "rec_datetime", "index"]
+
+    def _repr_pretty_(self, pp, cycle):
+        pp.text("{0} with {1} segments and {1} groups".format(
+            self.__class__.__name__,
+            len(self.segments),
+            len(self.recordingchannelgroups),
+        ))
+        if self._has_repr_pretty_attrs_():
+            pp.breakable()
+            self._repr_pretty_attrs_(pp, cycle)
+
+        if self.segments:
+            pp.breakable()
+            pp.text("# Segments")
+            pp.breakable()
+            for (i, seg) in enumerate(self.segments):
+                if i > 0:
+                    pp.breakable()
+                pp.text("{0}: ".format(i))
+                with pp.indent(3):
+                    pp.pretty(seg)

--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -166,3 +166,47 @@ class Segment(BaseNeo):
                                  "irregularlysampledsignals", "spikes",
                                  "spiketrains", "epocharrays", "eventarrays",
                                  "analogsignalarrays"))
+
+    def _repr_pretty_(self, pp, cycle):
+        pp.text(self.__class__.__name__)
+        pp.text(" with ")
+        first = True
+        for (value, readable) in [
+                (self.analogsignals, "analogs"),
+                (self.analogsignalarrays, "analog arrays"),
+                (self.events, "events"),
+                (self.eventarrays, "event arrays"),
+                (self.epochs, "epochs"),
+                (self.epocharrays, "epoch arrays"),
+                (self.irregularlysampledsignals, "epoch arrays"),
+                (self.spikes, "spikes"),
+                (self.spiketrains, "spike trains"),
+                ]:
+            if value:
+                if first:
+                    first = False
+                else:
+                    pp.text(", ")
+                pp.text("{0} {1}".format(len(value), readable))
+        if self._has_repr_pretty_attrs_():
+            pp.breakable()
+            self._repr_pretty_attrs_(pp, cycle)
+
+        if self.analogsignals:
+            pp.breakable()
+            pp.text("# Analog signals (N={0})".format(len(self.analogsignals)))
+            for (i, asig) in enumerate(self.analogsignals):
+                pp.breakable()
+                pp.text("{0}: ".format(i))
+                with pp.indent(3):
+                    pp.pretty(asig)
+
+        if self.analogsignalarrays:
+            pp.breakable()
+            pp.text("# Analog signal arrays (N={0})"
+                    .format(len(self.analogsignalarrays)))
+            for asarr in self.analogsignalarrays:
+                pp.breakable()
+                pp.text("{0}: ".format(i))
+                with pp.indent(3):
+                    pp.pretty(asarr)


### PR DESCRIPTION
This PR adds `_repr_pretty_` method [1] to NEO objects to make NEO work nicely with IPython.

[1] http://ipython.org/ipython-doc/dev/api/generated/IPython.lib.pretty.html

It is a work in progress.  Any advice is welcome.

Sample IPython session:

``` python
In [4]:
from neo.io import AxonIO
r = AxonIO(filename=filename)
bl = r.read()

In [5]:
bl.description = 'Sample data File_axon_3.abf'

In [6]:
bl
Out [6]:
Block with 5 segments and 5 groups
description: 'Sample data File_axon_3.abf'
annotations: {'abf_version': 1.8300000429153442}
file_origin: 'test.abf'
rec_datetime: datetime.datetime(1900, 1, 1, 14, 15, 28, 552000)
# Segments
0: Segment with 2 analogs
   # Analog signals (N=2)
   0: AnalogSignal in 1.0 mV with 20644 float32 values
      name: '10Vm      '
      annotations: {'channel_index': 0}
      sampling rate: 20000.0 Hz
      time: 0.0 s to 1.0322 s
   1: AnalogSignal in 1.0 pA with 20644 float32 values
      name: 'ImRK01G1b '
      annotations: {'channel_index': 1}
      sampling rate: 20000.0 Hz
      time: 0.0 s to 1.0322 s
1: Segment with 2 analogs
   # Analog signals (N=2)
   0: AnalogSignal in 1.0 mV with 20644 float32 values
      name: '10Vm      '
      annotations: {'channel_index': 0}
      sampling rate: 20000.0 Hz
      time: 360.0 s to 361.0322 s
   1: AnalogSignal in 1.0 pA with 20644 float32 values
      name: 'ImRK01G1b '
      annotations: {'channel_index': 1}
      sampling rate: 20000.0 Hz
      time: 360.0 s to 361.0322 s
2: Segment with 2 analogs
   # Analog signals (N=2)
   0: AnalogSignal in 1.0 mV with 20644 float32 values
      name: '10Vm      '
      annotations: {'channel_index': 0}
      sampling rate: 20000.0 Hz
      time: 720.0 s to 721.0322 s
   1: AnalogSignal in 1.0 pA with 20644 float32 values
      name: 'ImRK01G1b '
      annotations: {'channel_index': 1}
      sampling rate: 20000.0 Hz
      time: 720.0 s to 721.0322 s
3: Segment with 2 analogs
   # Analog signals (N=2)
   0: AnalogSignal in 1.0 mV with 20644 float32 values
      name: '10Vm      '
      annotations: {'channel_index': 0}
      sampling rate: 20000.0 Hz
      time: 1080.0 s to 1081.0322 s
   1: AnalogSignal in 1.0 pA with 20644 float32 values
      name: 'ImRK01G1b '
      annotations: {'channel_index': 1}
      sampling rate: 20000.0 Hz
      time: 1080.0 s to 1081.0322 s
4: Segment with 2 analogs
   # Analog signals (N=2)
   0: AnalogSignal in 1.0 mV with 20644 float32 values
      name: '10Vm      '
      annotations: {'channel_index': 0}
      sampling rate: 20000.0 Hz
      time: 1440.0 s to 1441.0322 s
   1: AnalogSignal in 1.0 pA with 20644 float32 values
      name: 'ImRK01G1b '
      annotations: {'channel_index': 1}
      sampling rate: 20000.0 Hz
      time: 1440.0 s to 1441.0322 s

In [7]:
bl.segments[0].analogsignals[0]
Out [7]:
AnalogSignal in 1.0 mV with 20644 float32 values
name: '10Vm      '
annotations: {'channel_index': 0}
sampling rate: 20000.0 Hz
time: 0.0 s to 1.0322 s
```

In Out [6] and Out [7], you can see useful information instead of something like <neo.core.block.Block object at 0x498e590> or <AnalogSignal(array([-15.5, -28. , -28.5, ..., -28. , -28. , -28.5], dtype=float32) \* mV, [0.0 s, 1.0322 s], sampling rate: 20000.0 Hz)>.
