### PR TITLE
Improved neo.io.get_io method

### DIFF
--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -205,14 +205,9 @@ def get_io(filename):
     """
     Return a Neo IO instance, guessing the type based on the filename suffix.
     """
-    extension = os.path.splitext(filename)[1]
-    if extension in (".ras", ".v", ".gsyn"):
-        return PyNNTextIO(filename=filename)
-    elif extension in (".h5",):
-        return NeoHdf5IO(filename=filename)
-    elif extension in (".pkl", ".pickle"):
-        return PickleIO(filename=filename)
-    elif extension == ".mat":
-        return NeoMatlabIO(filename=filename)
-    else: # function to be improved later
-        raise IOError("file extension %s not registered" % extension)
+    extension = os.path.splitext(filename)[1][1:]
+    for io in iolist:
+        if extension in io.extensions:
+            return io(filename=filename)
+
+    raise IOError("file extension %s not registered" % extension)

--- a/neo/io/pynnio.py
+++ b/neo/io/pynnio.py
@@ -209,7 +209,7 @@ class PyNNTextIO(BasePyNNIO):
     Reads/writes data from/to PyNN StandardTextFile format
     """
     name = "PyNN StandardTextFile"
-    extensions = ['txt', 'v', 'ras']
+    extensions = ['v', 'ras', 'gsyn']
 
     def _read_metadata(self):
         metadata = {}


### PR DESCRIPTION
Similar to what Samuel suggested in #26. Spyke Viewer also does it this way. I've changed the extensions of the PyNN text file to be in line with the previous get_io implementation from @apdavison. Are you okay with this?
