### PR TITLE
remove no-longer-needed channel_indexes and channel_names from brainwaref32io

### DIFF
--- a/neo/io/brainwaref32io.py
+++ b/neo/io/brainwaref32io.py
@@ -169,8 +169,6 @@ class BrainwareF32IO(BaseIO):
 
         # create the objects to store other objects
         rcg = RecordingChannelGroup(file_origin=self._filename)
-        rcg.channel_indexes = np.array([], dtype=np.int)
-        rcg.channel_names = np.array([], dtype='S')
         self.__unit = Unit(file_origin=self._filename)
 
         # load objects into their containers


### PR DESCRIPTION
I fixed a bug where RecordingChannelGroup was initialized with non-compliant channel_indexes and channel_names.  So I removed a workaround for the bug in BrainwareF32IO.
