### PR TITLE
fix travis badge and add coveralls badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,10 @@ checks for dimensional consistency and automatic unit conversion.
 Code status
 -----------
 
-.. image:: https://secure.travis-ci.org/NeuralEnsemble/python-neo.png?branch=master
-   :target: https://travis-ci.org/NeuralEnsemble/python-neo.png
+.. image:: https://travis-ci.org/NeuralEnsemble/python-neo.png?branch=master
+   :target: https://travis-ci.org/NeuralEnsemble/python-neo
+.. image:: https://coveralls.io/repos/NeuralEnsemble/python-neo/badge.png
+   :target: https://coveralls.io/r/NeuralEnsemble/python-neo
 
 More information
 ----------------


### PR DESCRIPTION
Update the travis badge to the new url, and add a coveralls code coverage badge.
