### PR TITLE
make brainwaresrcio handle cases with no spikes in a segment

### DIFF
--- a/neo/io/brainwaresrcio.py
+++ b/neo/io/brainwaresrcio.py
@@ -903,7 +903,18 @@ class BrainwareSrcIO(BaseIO):
         # the first Segment
         trains = self._read_by_id()
         if not trains:
-            trains = zip(unassigned_spikes)
+            if unassigned_spikes:
+                # if there are no assigned spikes,
+                # just use the unassigned spikes
+                trains = zip(unassigned_spikes)
+            else:
+                # if there are no spiketrains at all,
+                # create an empty spike train
+                train = self._default_spiketrain.copy()
+                train.file_origin = self.__file_origin
+                if self.__lazy:
+                    train.lazy_shape = (0,)
+                trains = [[train]]
         elif hasattr(trains[0], 'dtype'):
             #workaround for some broken files
             trains = [unassigned_spikes +

--- a/neo/test/iotest/test_brainwaref32io.py
+++ b/neo/test/iotest/test_brainwaref32io.py
@@ -109,7 +109,10 @@ class BrainwareF32IOTestCase(BaseTestIO, unittest.TestCase):
 
     # These are the files it tries to read and test for compliance
     files_to_test = ['block_300ms_4rep_1clust_part_ch1.f32',
+                     'block_500ms_5rep_empty_fullclust_ch1.f32',
+                     'block_500ms_5rep_empty_partclust_ch1.f32',
                      'interleaved_500ms_5rep_ch2.f32',
+                     'interleaved_500ms_5rep_nospikes_ch1.f32',
                      'multi_500ms_mulitrep_ch1.f32',
                      'random_500ms_12rep_noclust_part_ch2.f32',
                      'sequence_500ms_5rep_ch2.f32']

--- a/neo/test/iotest/test_brainwaresrcio.py
+++ b/neo/test/iotest/test_brainwaresrcio.py
@@ -267,7 +267,10 @@ class BrainwareSrcIOTestCase(BaseTestIO, unittest.TestCase):
 
     # These are the files it tries to read and test for compliance
     files_to_test = ['block_300ms_4rep_1clust_part_ch1.src',
+                     'block_500ms_5rep_empty_fullclust_ch1.src',
+                     'block_500ms_5rep_empty_partclust_ch1.src',
                      'interleaved_500ms_5rep_ch2.src',
+                     'interleaved_500ms_5rep_nospikes_ch1.src',
                      'interleaved_500ms_7rep_noclust_ch1.src',
                      'long_170s_1rep_1clust_ch2.src',
                      'multi_500ms_mulitrep_ch1.src',
@@ -276,7 +279,10 @@ class BrainwareSrcIOTestCase(BaseTestIO, unittest.TestCase):
 
     # these are reference files to compare to
     files_to_compare = ['block_300ms_4rep_1clust_part_ch1',
+                        'block_500ms_5rep_empty_fullclust_ch1',
+                        'block_500ms_5rep_empty_partclust_ch1',
                         'interleaved_500ms_5rep_ch2',
+                        'interleaved_500ms_5rep_nospikes_ch1',
                         'interleaved_500ms_7rep_noclust_ch1',
                         '',
                         'multi_500ms_mulitrep_ch1',
@@ -294,6 +300,7 @@ class BrainwareSrcIOTestCase(BaseTestIO, unittest.TestCase):
 
     def setUp(self):
         warnings.filterwarnings('ignore', message='Negative sequence count.*')
+        warnings.filterwarnings('ignore', message='unknown ID:*')
         super(BrainwareSrcIOTestCase, self).setUp()
 
     def test_reading_same(self):


### PR DESCRIPTION
There was a recent bug a colleague of mine encountered in brainwaresrcio.  I tracked it to a problem when the io class is given a segment with no spikes at all.  This commit fixes the problem.  I don't have a test file yet, I will add one in a few days.

I would like to backport this fix to the 0.3 branch, then tag a 0.3.2.1 or 0.3.3 release including this and the fix for issue #113.  I don't think basic bugfixes like these should have to wait for 0.4, but I am not sure it justifies a 0.3.3 update (but a 0.3.3 update would probably be simpler to understand).
