### PR TITLE
Add StimfitIO, including unit tests, to neo.io

### DIFF
--- a/doc/source/whatisnew.rst
+++ b/doc/source/whatisnew.rst
@@ -6,6 +6,7 @@ Release notes
 What's new in version 0.4.0?
 ----------------------------
 
+  * added StimfitIO
 
 What's new in version 0.3.3?
 ----------------------------

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -56,6 +56,8 @@ Classes:
 
 .. autoclass:: neo.io.RawBinarySignalIO
 
+.. autoclass:: neo.io.StimfitIO
+
 .. autoclass:: neo.io.TdtIO
 
 .. autoclass:: neo.io.WinEdrIO
@@ -92,6 +94,7 @@ from neo.io.pynnio import PyNNNumpyIO
 from neo.io.pynnio import PyNNTextIO
 from neo.io.rawbinarysignalio import RawBinarySignalIO
 from neo.io.spike2io import Spike2IO
+from neo.io.stimfitio import StimfitIO
 from neo.io.tdtio import TdtIO
 from neo.io.winedrio import WinEdrIO
 from neo.io.winwcpio import WinWcpIO
@@ -122,6 +125,7 @@ iolist = [AlphaOmegaIO,
           PyNNTextIO,
           RawBinarySignalIO,
           Spike2IO,
+          StimfitIO,
           TdtIO,
           WinEdrIO,
           WinWcpIO]

--- a/neo/io/stimfitio.py
+++ b/neo/io/stimfitio.py
@@ -1,0 +1,151 @@
+"""
+README
+===============================================================================
+This is an adapter to represent stfio objects as neo objects.
+
+stfio is a standalone file i/o Python module that ships with the Stimfit
+program (http://www.stimfit.org). It's a Python wrapper around Stimfit's file
+i/o library (libstfio) that natively provides support for the following file
+types:
+
+ - ABF (Axon binary file format; pClamp 6--9)
+ - ABF2 (Axon binary file format 2; pClamp 10+)
+ - ATF (Axon text file format)
+ - AXGX/AXGD (Axograph X file format)
+ - CFS (Cambridge electronic devices filing system)
+ - HEKA (HEKA binary file format)
+ - HDF5 (Hierarchical data format 5; only hdf5 files written by Stimfit or
+   stfio are supported)
+
+In addition, libstfio can use the biosig file i/o library as an additional file
+handling backend (http://biosig.sourceforge.net/), extending support to more
+than 30 additional file formats (http://pub.ist.ac.at/~schloegl/biosig/TESTED).
+
+Based on exampleio.py and axonio.py from neo.io
+
+08 Feb 2014, C. Schmidt-Hieber, University College London
+"""
+
+# needed for python 3 compatibility
+from __future__ import absolute_import
+
+import sys
+
+import numpy as np
+import quantities as pq
+
+from neo.io.baseio import BaseIO
+from neo.core import Block, Segment, AnalogSignal
+
+try:
+    import stfio
+except ImportError as err:
+    HAS_STFIO = False
+    STFIO_ERR = err
+else:
+    HAS_STFIO = True
+    STFIO_ERR = None
+
+
+class StimfitIO(BaseIO):
+    """
+    Class for converting a stfio Recording to a neo object.
+    Provides a standardized representation of the data as defined by the neo
+    project; this is useful to explore the data with an increasing number of
+    electrophysiology software tools that rely on the neo standard.
+
+    Example usage:
+        >>> import neo
+        >>> neo_obj = neo.io.StimfitIO("file.abf")
+        or
+        >>> import stfio
+        >>> stfio_obj = stfio.read("file.abf")
+        >>> neo_obj = neo.io.StimfitIO(stfio_obj)
+    """
+
+    is_readable = True
+    is_writable = False
+
+    supported_objects = [Block, Segment, AnalogSignal]
+    readable_objects = [Block]
+    writeable_objects = []
+
+    has_header = False
+    is_streameable = False
+
+    read_params = {Block: []}
+    write_params = None
+
+    name = 'Stimfit'
+    extensions = ['abf', 'dat', 'axgx', 'axgd', 'cfs']
+
+    mode = 'file'
+
+    def __init__(self, filename=None):
+        """
+        Arguments:
+            filename : Either a filename or a stfio Recording object
+        """
+        if not HAS_STFIO:
+            raise STFIO_ERR
+
+        BaseIO.__init__(self)
+
+        if hasattr(filename, 'lower'):
+            self.filename = filename
+            self.stfio_rec = None
+        else:
+            self.stfio_rec = filename
+            self.filename = None
+
+    def read_block(self, lazy=False, cascade=True):
+
+        if self.filename is not None:
+            self.stfio_rec = stfio.read(self.filename)
+
+        bl = Block()
+        bl.description = self.stfio_rec.file_description
+        bl.annotate(comment=self.stfio_rec.comment)
+        try:
+            bl.rec_datetime = self.stfio_rec.datetime
+        except:
+            bl.rec_datetime = None
+
+        if not cascade:
+            return bl
+
+        dt = np.round(self.stfio_rec.dt * 1e-3, 9) * pq.s  # ms to s
+        sampling_rate = 1.0/dt
+        t_start = 0 * pq.s
+
+        # iterate over sections first:
+        for j, recseg in enumerate(self.stfio_rec[0]):
+            seg = Segment(index=j)
+            length = len(recseg)
+
+            # iterate over channels:
+            for i, recsig in enumerate(self.stfio_rec):
+                name = recsig.name
+                unit = recsig.yunits
+                try:
+                    pq.Quantity(1, unit)
+                except:
+                    unit = ''
+
+                if lazy:
+                    signal = pq.Quantity([], unit)
+                else:
+                    signal = pq.Quantity(recsig[j], unit)
+                anaSig = AnalogSignal(signal, sampling_rate=sampling_rate,
+                                      t_start=t_start, name=str(name),
+                                      channel_index=i)
+                if lazy:
+                    anaSig.lazy_shape = length
+                seg.analogsignals.append(anaSig)
+
+            bl.segments.append(seg)
+            t_start = t_start + length * dt
+
+        bl.create_many_to_one_relationship()
+
+        return bl

--- a/neo/test/iotest/test_stimfitio.py
+++ b/neo/test/iotest/test_stimfitio.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+Tests of neo.io.stimfitio
+"""
+
+# needed for python 3 compatibility
+from __future__ import absolute_import
+
+import sys
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from neo.io import StimfitIO
+from neo.io.stimfitio import HAS_STFIO
+from neo.test.iotest.common_io_test import BaseTestIO
+
+
+@unittest.skipIf(sys.version_info[0] > 2, "not Python 3 compatible")
+@unittest.skipUnless(HAS_STFIO, "requires stfio")
+class TestStimfitIO(BaseTestIO, unittest.TestCase):
+    files_to_test = ['File_stimfit_1.h5',
+                     'File_stimfit_2.h5',
+                     'File_stimfit_3.h5',
+                     'File_stimfit_4.h5',
+                     'File_stimfit_5.h5',
+                     'File_stimfit_6.h5',
+                     ]
+    files_to_download = files_to_test
+    ioclass = StimfitIO
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Notes
- Requires the [latest python-stfio code](https://github.com/neurodroid/stimfit)
- Only tested with the [latest biosig code](http://biosig.sourceforge.net/) (may work with earlier versions though)
  
  ```
  git clone git://git.code.sf.net/p/biosig/code biosig-code
  ```
- Build the stfio module using
  
  ```
  ./configure --enable-module --with-biosig
  make
  sudo make install
  ```
- ~~Unit tests are currently "hijacking" AxonIO abf test files. Since these are not yet in the stimfit subdirectory on G-Node (https://portal.g-node.org/neo/axon/), they need to be manually copied into the temp folder.~~
### Issues
- datetime isn't producing a correct representation yet. We're working on it.
- ~~Tests take a long time compared to AxonIO.~~
- ~~t_start isn't set correctly; all segments have the same t_start (the total duration of the file). Not sure why this is the case; t_start is set correctly in l.114 of stimfitio.py, but it somehow gets overwritten~~
- Events are not currently converted.
- Only reads entire files.
