### PR TITLE
NeoHDF5IO compatible with removed Spike, EventArray, EpochArray

### DIFF
--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -83,7 +83,7 @@ from neo.io.brainwaresrcio import BrainwareSrcIO
 from neo.io.exampleio import ExampleIO
 from neo.io.klustakwikio import KlustaKwikIO
 #from neo.io.micromedio import MicromedIO
-#from neo.io.hdf5io import NeoHdf5IO
+from neo.io.hdf5io import NeoHdf5IO
 #from neo.io.neomatlabio import NeoMatlabIO
 #from neo.io.neuroexplorerio import NeuroExplorerIO
 from neo.io.neuroscopeio import NeuroScopeIO
@@ -114,7 +114,7 @@ iolist = [AlphaOmegaIO,
           ExampleIO,
           KlustaKwikIO,
           #MicromedIO,
-          #NeoHdf5IO,
+          NeoHdf5IO,
           #NeoMatlabIO,
           #NeuroExplorerIO,
           NeuroScopeIO,


### PR DESCRIPTION
The first changes to make NeoHDF5IO compatible with Neo 0.4. I've also fixed all PEP8 issues in the file and I think the transition to 0.4 would be a good time to do that for all IOs.

This version is partially backward compatible with old Neo HDF5 files: it will load them without error and get the data for all unchanged data objects. Existing EpochArrays and EventArrays are converted to the new Epochs and Events, respectively. Existing Epochs, Events and Spikes are ignored.
