### PR TITLE
fixed tdtio problem where only one site in a tank was being read

### DIFF
--- a/neo/io/tdtio.py
+++ b/neo/io/tdtio.py
@@ -225,8 +225,8 @@ class TdtIO(BaseIO):
                             if lazy:
                                 anasig.lazy_shape = shape
                             seg.analogsignals.append(anasig)
-            bl.create_many_to_one_relationship()
-            return bl
+        bl.create_many_to_one_relationship()
+        return bl
             
 
 


### PR DESCRIPTION
Due to an issue with indentation, read_block(...) only ran through one directory in a TDT tank, and only returned a block with one segment. It should return a block with multiple segments, when multiple directories exist in the TDT tank. This pull request fixes that problem.
