### PR TITLE
time_slice of analogsignalarray also accepts None as t_start and t_stop values

### DIFF
--- a/neo/core/analogsignalarray.py
+++ b/neo/core/analogsignalarray.py
@@ -224,12 +224,21 @@ class AnalogSignalArray(BaseAnalogSignal):
         the nearest sampling bins.
         '''
 
-        t_start = t_start.rescale(self.sampling_period.units)
-        t_stop = t_stop.rescale(self.sampling_period.units)
-        i = (t_start - self.t_start) / self.sampling_period
-        j = (t_stop - self.t_start) / self.sampling_period
-        i = int(np.rint(i.magnitude))
-        j = int(np.rint(j.magnitude))
+        # checking start time and transforming to start index
+        if t_start == None:
+            i = 0
+        else:
+            t_start = t_start.rescale(self.sampling_period.units)
+            i = (t_start - self.t_start) / self.sampling_period
+            i = int(np.rint(i.magnitude))
+
+        # checking stop time and transforming to stop index
+        if t_stop == None:
+            j = len(self)
+        else:
+            t_stop = t_stop.rescale(self.sampling_period.units)
+            j = (t_stop - self.t_start) / self.sampling_period
+            j = int(np.rint(j.magnitude))
 
         if (i < 0) or (j > len(self)):
             raise ValueError('t_start, t_stop have to be withing the analog \

--- a/neo/test/coretest/test_analogsignalarray.py
+++ b/neo/test/coretest/test_analogsignalarray.py
@@ -554,6 +554,46 @@ class TestAnalogSignalArrayArrayMethods(unittest.TestCase):
         assert_arrays_equal(result, targ)
         assert_same_sub_schema(result, targ)
 
+    def test__time_slice__no_explicit_time(self):
+        self.signal2.t_start = 10.0 * pq.ms
+        assert_neo_object_is_compliant(self.signal2)
+
+        t1 = 2 * pq.s + 10.0 * pq.ms
+        t2 = 4 * pq.s + 10.0 * pq.ms
+
+        for t_start,t_stop in [(t1,None),(None,None),(None,t2)]:
+
+            t_start_targ = t1 if t_start!=None else self.signal2.t_start
+            t_stop_targ = t2 if t_stop!=None else self.signal2.t_stop
+
+            result = self.signal2.time_slice(t_start, t_stop)
+            self.assertIsInstance(result, AnalogSignalArray)
+            assert_neo_object_is_compliant(result)
+            self.assertEqual(result.name, 'spam')
+            self.assertEqual(result.description, 'eggs')
+            self.assertEqual(result.file_origin, 'testfile.txt')
+            self.assertEqual(result.annotations, {'arg1': 'test'})
+
+            targ_ind = np.where((self.signal2.times >= t_start_targ) &
+                                (self.signal2.times < t_stop_targ))
+            targ_array = self.signal2.magnitude[targ_ind]
+
+            targ = AnalogSignalArray(targ_array,
+                                     t_start=t_start_targ.rescale(pq.ms),
+                                     sampling_rate=1.0*pq.Hz, units='mV',
+                                     name='spam', description='eggs',
+                                     file_origin='testfile.txt', arg1='test')
+            assert_neo_object_is_compliant(result)
+
+            assert_neo_object_is_compliant(self.signal2)
+            self.assertEqual(self.signal2.t_start, 10.0 * pq.ms)
+            self.assertAlmostEqual(result.t_stop, t_stop_targ, delta=1e-12*pq.ms)
+            self.assertAlmostEqual(result.t_start, t_start_targ, delta=1e-12*pq.ms)
+            assert_arrays_almost_equal(result.times, targ.times, 1e-12*pq.ms)
+            self.assertEqual(result.sampling_rate, targ.sampling_rate)
+            assert_arrays_equal(result, targ)
+            assert_same_sub_schema(result, targ)
+
 
 class TestAnalogSignalArrayEquality(unittest.TestCase):
     def test__signals_with_different_data_complement_should_be_not_equal(self):


### PR DESCRIPTION
Analogsignalarray.time_slice() does not require two quantities as input (t_start and t_stop), but also accepts None for any of them. If None is provided as t_start (t_stop) no shortening of the signal is performed at the beginning (end) of the signal.