### PR TITLE
Fix lazy loading for AxonIO

### DIFF
--- a/neo/io/axonio.py
+++ b/neo/io/axonio.py
@@ -255,15 +255,18 @@ class AxonIO(BaseIO):
 
                 if (fSynchTimeUnit != 0) and (mode == 1):
                     length /= fSynchTimeUnit
-                subdata = data[pos:pos+length]
+
+                if not lazy:
+                    subdata = data[pos:pos+length]
+                    subdata = subdata.reshape((subdata.size/nbchannel,
+                                               nbchannel)).astype('f')
+                    if dt == np.dtype('i2'):
+                        if version < 2.:
+                            reformat_integer_V1(subdata, nbchannel, header)
+                        elif version >= 2.:
+                            reformat_integer_V2(subdata, nbchannel, header)
+
                 pos += length
-                subdata = subdata.reshape((subdata.size/nbchannel,
-                                           nbchannel)).astype('f')
-                if dt == np.dtype('i2'):
-                    if version < 2.:
-                        reformat_integer_V1(subdata, nbchannel, header)
-                    elif version >= 2.:
-                        reformat_integer_V2(subdata, nbchannel, header)
 
                 if version < 2.:
                     chans = [chan_num for chan_num in
@@ -299,7 +302,7 @@ class AxonIO(BaseIO):
                                           name=str(name),
                                           channel_index=int(num))
                     if lazy:
-                        anaSig.lazy_shape = subdata.shape[0]
+                        anaSig.lazy_shape = length / nbchannel
                     seg.analogsignals.append(anaSig)
                 bl.segments.append(seg)
 


### PR DESCRIPTION
No matter whether lazy loading was requested or not, all of the data was
still read from the file. The lazy setting only affected whether the
data was put into the AnalogSignal object(s) or not.