### PR TITLE
Changed "== None" to "is None" to avoid element-wise comparison warning.

### DIFF
--- a/neo/core/analogsignalarray.py
+++ b/neo/core/analogsignalarray.py
@@ -225,7 +225,7 @@ class AnalogSignalArray(BaseAnalogSignal):
         '''
 
         # checking start time and transforming to start index
-        if t_start == None:
+        if t_start is None:
             i = 0
         else:
             t_start = t_start.rescale(self.sampling_period.units)
@@ -233,7 +233,7 @@ class AnalogSignalArray(BaseAnalogSignal):
             i = int(np.rint(i.magnitude))
 
         # checking stop time and transforming to stop index
-        if t_stop == None:
+        if t_stop is None:
             j = len(self)
         else:
             t_stop = t_stop.rescale(self.sampling_period.units)


### PR DESCRIPTION
Numpy warns that in version 1.9 all comparisons of the type "== None" are element-wise.  Since t_start and t_stop can be quantities arrays, they trigger this warning when they are compared to None using "==".  Since t_stop can be None, but can never be a quantity array with None (e.g. [None] * ms), element-wise comparison should never be needed so this change can eliminate the warning.   