### PR TITLE
Implementation of read_segment for TdtIO

### DIFF
--- a/neo/io/tdtio.py
+++ b/neo/io/tdtio.py
@@ -35,7 +35,7 @@ def get_chunks(sizes, offsets, big_array):
     # offsets are octect count
     # sizes are not!!
     # so need this (I really do not knwo why...):
-    sizes = (sizes -10)  * 4 # 
+    sizes = (sizes -10)  * 4 #
     all = np.concatenate([ big_array[o:o+s] for s, o in itertools.izip(sizes, offsets) ])
     return all
 
@@ -55,32 +55,29 @@ class TdtIO(BaseIO):
         >>> print bl.segments[0].eventarrays
         []
     """
-
-
-
     is_readable        = True
     is_writable        = False
 
-    supported_objects  = [Block, Segment , AnalogSignal, EventArray ]
-    readable_objects   = [Block]
+    supported_objects  = [Block, Segment , AnalogSignal, EventArray]
+    readable_objects   = [Block, Segment]
     writeable_objects  = []
 
     has_header         = False
     is_streameable     = False
 
     read_params        = {
-                        Block : [
-                                ],
-                        }
+                         Block : [],
+                         Segment : []
+                         }
 
     write_params       = None
 
     name               = 'TDT'
-    extensions          = [ ]
+    extensions         = [ ]
 
     mode = 'dir'
 
-    def __init__(self , dirname = None) :
+    def __init__(self , dirname=None) :
         """
         This class read a WinEDR wcp file.
 
@@ -94,140 +91,156 @@ class TdtIO(BaseIO):
         if self.dirname.endswith('/'):
             self.dirname = self.dirname[:-1]
 
-    def read_block(self,
-                                        lazy = False,
-                                        cascade = True,
-                                ):
+    def read_segment(self, blockname=None, lazy=False, cascade=True):
+        """
+        Read a single segment from the tank. Note that TDT blocks are Neo
+        segments, and TDT tanks are Neo blocks, so here the 'blockname' argument
+        refers to the TDT block's name, which will be the Neo segment name.
+        """
+        if not blockname:
+            blockname = os.listdir(self.dirname)[0]
+
+        if blockname == 'TempBlk': return None
+
+        subdir = os.path.join(self.dirname, blockname)
+        if not os.path.isdir(subdir): return None
+
+        seg = Segment(name=blockname)
+
+        tankname = os.path.basename(self.dirname)
+
+        #TSQ is the global index
+        tsq_filename = os.path.join(subdir, tankname+'_'+blockname+'.tsq')
+        dt = [('size','int32'),
+                    ('evtype','int32'),
+                    ('code','S4'),
+                    ('channel','uint16'),
+                    ('sortcode','uint16'),
+                    ('timestamp','float64'),
+                    ('eventoffset','int64'),
+                    ('dataformat','int32'),
+                    ('frequency','float32'),
+                ]
+        tsq = np.fromfile(tsq_filename, dtype=dt)
+
+        #0x8801: 'EVTYPE_MARK' give the global_start
+        global_t_start = tsq[tsq['evtype']==0x8801]['timestamp'][0]
+
+        #TEV is the old data file
+        try:
+            tev_filename = os.path.join(subdir, tankname+'_'+blockname+'.tev')
+            #tev_array = np.memmap(tev_filename, mode = 'r', dtype = 'uint8') # if memory problem use this instead
+            tev_array = np.fromfile(tev_filename, dtype='uint8')
+        except IOError:
+            tev_filename = None
+
+        for type_code, type_label in tdt_event_type:
+            mask1 = tsq['evtype']==type_code
+            codes = np.unique(tsq[mask1]['code'])
+
+            for code in codes:
+                mask2 = mask1 & (tsq['code']==code)
+                channels = np.unique(tsq[mask2]['channel'])
+
+                for channel in channels:
+                    mask3 = mask2 & (tsq['channel']==channel)
+
+                    if type_label in ['EVTYPE_STRON', 'EVTYPE_STROFF']:
+                        if lazy:
+                            times = [ ]*pq.s
+                            labels = np.array([ ], dtype=str)
+                        else:
+                            times = (tsq[mask3]['timestamp'] - global_t_start) * pq.s
+                            labels = tsq[mask3]['eventoffset'].view('float64').astype('S')
+                        ea = EventArray(times           = times,
+                                        name            = code ,
+                                        channel_index   = int(channel),
+                                        labels          = labels
+                                        )
+                        if lazy:
+                            ea.lazy_shape = np.sum(mask3)
+                        seg.eventarrays.append(ea)
+
+                    elif type_label == 'EVTYPE_SNIP':
+                        sortcodes = np.unique(tsq[mask3]['sortcode'])
+                        for sortcode in sortcodes:
+                            mask4 = mask3 & (tsq['sortcode']==sortcode)
+                            nb_spike = np.sum(mask4)
+                            sr = tsq[mask4]['frequency'][0]
+                            waveformsize = tsq[mask4]['size'][0]-10
+                            if lazy:
+                                times = [ ]*pq.s
+                                waveforms = None
+                            else:
+                                times = (tsq[mask4]['timestamp'] - global_t_start) * pq.s
+                                dt = np.dtype(data_formats[ tsq[mask3]['dataformat'][0]])
+                                waveforms = get_chunks(tsq[mask4]['size'],tsq[mask4]['eventoffset'], tev_array).view(dt)
+                                waveforms = waveforms.reshape(nb_spike, -1, waveformsize)
+                                waveforms = waveforms * pq.mV
+                            if nb_spike > 0:
+                             #   t_start = (tsq['timestamp'][0] - global_t_start) * pq.s # this hould work but not
+                                t_start = 0 *pq.s
+                                t_stop = (tsq['timestamp'][-1] - global_t_start) * pq.s
+
+                            else:
+                                t_start = 0 *pq.s
+                                t_stop = 0 *pq.s
+                            st = SpikeTrain(times           = times,
+                                            name            = 'Chan{} Code{}'.format(channel,sortcode),
+                                            t_start         = t_start,
+                                            t_stop          = t_stop,
+                                            waveforms       = waveforms,
+                                            left_sweep      = waveformsize/2./sr * pq.s,
+                                            sampling_rate   = sr * pq.Hz,
+                                            )
+                            st.annotate(channel_index=channel)
+                            if lazy:
+                                st.lazy_shape = nb_spike
+                            seg.spiketrains.append(st)
+
+                    elif type_label == 'EVTYPE_STREAM':
+                        dt = np.dtype(data_formats[ tsq[mask3]['dataformat'][0]])
+                        shape = np.sum(tsq[mask3]['size']-10)
+                        sr = tsq[mask3]['frequency'][0]
+                        if lazy:
+                            signal = [ ]
+                        else:
+                            if PY3K:
+                                signame = code.decode('ascii')
+                            else:
+                                signame = code
+                            sev_filename = os.path.join(subdir, tankname+'_'+blockname+'_'+signame+'_ch'+str(channel)+'.sev')
+                            try:
+                                #sig_array = np.memmap(sev_filename, mode = 'r', dtype = 'uint8') # if memory problem use this instead
+                                sig_array = np.fromfile(sev_filename, dtype='uint8')
+                            except IOError:
+                                sig_array = tev_array
+                            signal = get_chunks(tsq[mask3]['size'],tsq[mask3]['eventoffset'],  sig_array).view(dt)
+
+                        anasig = AnalogSignal(signal        = signal* pq.V,
+                                              name          = '{} {}'.format(code, channel),
+                                              sampling_rate = sr * pq.Hz,
+                                              t_start       = (tsq[mask3]['timestamp'][0] - global_t_start) * pq.s,
+                                              channel_index = int(channel)
+                                              )
+                        if lazy:
+                            anasig.lazy_shape = shape
+                        seg.analogsignals.append(anasig)
+        return seg
+
+    def read_block(self, lazy=False, cascade=True):
         bl = Block()
         tankname = os.path.basename(self.dirname)
         bl.file_origin = tankname
+
         if not cascade : return bl
+
         for blockname in os.listdir(self.dirname):
-            if blockname == 'TempBlk': continue
-            subdir = os.path.join(self.dirname,blockname)
-            if not os.path.isdir(subdir): continue
+            seg = self.read_segment(blockname, lazy, cascade)
+            bl.segments.append(seg)
 
-            seg = Segment(name = blockname)
-            bl.segments.append( seg)
-
-
-            #TSQ is the global index
-            tsq_filename = os.path.join(subdir, tankname+'_'+blockname+'.tsq')
-            dt = [('size','int32'),
-                        ('evtype','int32'),
-                        ('code','S4'),
-                        ('channel','uint16'),
-                        ('sortcode','uint16'),
-                        ('timestamp','float64'),
-                        ('eventoffset','int64'),
-                        ('dataformat','int32'),
-                        ('frequency','float32'),
-                    ]
-            tsq = np.fromfile(tsq_filename, dtype = dt)
-            
-            #0x8801: 'EVTYPE_MARK' give the global_start
-            global_t_start = tsq[tsq['evtype']==0x8801]['timestamp'][0]
-           
-            #TEV is the old data file
-            if os.path.exists(os.path.join(subdir, tankname+'_'+blockname+'.tev')):
-                tev_filename = os.path.join(subdir, tankname+'_'+blockname+'.tev')
-                #tev_array = np.memmap(tev_filename, mode = 'r', dtype = 'uint8') # if memory problem use this instead
-                tev_array = np.fromfile(tev_filename, dtype = 'uint8')
-                
-            else:
-                tev_filename = None
-
-
-            for type_code, type_label in tdt_event_type:
-                mask1 = tsq['evtype']==type_code
-                codes = np.unique(tsq[mask1]['code'])
-                
-                for code in codes:
-                    mask2 = mask1 & (tsq['code']==code)
-                    channels = np.unique(tsq[mask2]['channel'])
-                    
-                    for channel in channels:
-                        mask3 = mask2 & (tsq['channel']==channel)
-                        
-                        if type_label in ['EVTYPE_STRON', 'EVTYPE_STROFF']:
-                            if lazy:
-                                times = [ ]*pq.s
-                                labels = np.array([ ], dtype = str)
-                            else:
-                                times = (tsq[mask3]['timestamp'] - global_t_start) * pq.s
-                                labels = tsq[mask3]['eventoffset'].view('float64').astype('S')
-                            ea = EventArray(times = times, name = code , channel_index = int(channel), labels = labels)
-                            if lazy:
-                                ea.lazy_shape = np.sum(mask3)
-                            seg.eventarrays.append(ea)
-                        
-                        elif type_label == 'EVTYPE_SNIP':
-                            sortcodes = np.unique(tsq[mask3]['sortcode'])
-                            for sortcode in sortcodes:
-                                mask4 = mask3 & (tsq['sortcode']==sortcode)
-                                nb_spike = np.sum(mask4)
-                                sr = tsq[mask4]['frequency'][0]
-                                waveformsize = tsq[mask4]['size'][0]-10
-                                if lazy:
-                                    times = [ ]*pq.s
-                                    waveforms = None
-                                else:
-                                    times = (tsq[mask4]['timestamp'] - global_t_start) * pq.s
-                                    dt = np.dtype(data_formats[ tsq[mask3]['dataformat'][0]])                                    
-                                    waveforms = get_chunks(tsq[mask4]['size'],tsq[mask4]['eventoffset'], tev_array).view(dt)
-                                    waveforms = waveforms.reshape(nb_spike, -1, waveformsize)
-                                    waveforms = waveforms * pq.mV
-                                if nb_spike>0:
-                                 #   t_start = (tsq['timestamp'][0] - global_t_start) * pq.s # this hould work but not
-                                    t_start = 0 *pq.s
-                                    t_stop = (tsq['timestamp'][-1] - global_t_start) * pq.s
-                                    
-                                else:
-                                    t_start = 0 *pq.s
-                                    t_stop = 0 *pq.s
-                                st = SpikeTrain(times = times, 
-                                                                name = 'Chan{} Code{}'.format(channel,sortcode),
-                                                                t_start = t_start,
-                                                                t_stop = t_stop,
-                                                                waveforms = waveforms,
-                                                                left_sweep = waveformsize/2./sr * pq.s,
-                                                                sampling_rate = sr * pq.Hz,
-                                                                )
-                                st.annotate(channel_index = channel)
-                                if lazy:
-                                    st.lazy_shape = nb_spike
-                                seg.spiketrains.append(st)
-                        
-                        elif type_label == 'EVTYPE_STREAM':
-                            dt = np.dtype(data_formats[ tsq[mask3]['dataformat'][0]])
-                            shape = np.sum(tsq[mask3]['size']-10)
-                            sr = tsq[mask3]['frequency'][0]
-                            if lazy:
-                                signal = [ ]
-                            else:
-                                if PY3K:
-                                    signame = code.decode('ascii')
-                                else:
-                                    signame = code
-                                sev_filename = os.path.join(subdir, tankname+'_'+blockname+'_'+signame+'_ch'+str(channel)+'.sev')
-                                if os.path.exists(sev_filename):
-                                    #sig_array = np.memmap(sev_filename, mode = 'r', dtype = 'uint8') # if memory problem use this instead
-                                    sig_array = np.fromfile(sev_filename, dtype = 'uint8')
-                                else:
-                                    sig_array = tev_array
-                                signal = get_chunks(tsq[mask3]['size'],tsq[mask3]['eventoffset'],  sig_array).view(dt)
-                            
-                            anasig = AnalogSignal(signal = signal* pq.V,
-                                                                    name = '{} {}'.format(code, channel),
-                                                                    sampling_rate= sr * pq.Hz,
-                                                                    t_start = (tsq[mask3]['timestamp'][0] - global_t_start) * pq.s,
-                                                                    channel_index = int(channel))
-                            if lazy:
-                                anasig.lazy_shape = shape
-                            seg.analogsignals.append(anasig)
         bl.create_many_to_one_relationship()
         return bl
-            
 
 
 tdt_event_type = [
@@ -239,9 +252,7 @@ tdt_event_type = [
     (0x8201, 'EVTYPE_SNIP'),
     #(0x8801, 'EVTYPE_MARK'),
     ]
- 
 
-            
 
 data_formats = {
         0 : np.float32,
@@ -250,4 +261,3 @@ data_formats = {
         3 : np.int8,
         4 : np.float64,
         }
-


### PR DESCRIPTION
I had some experimental collaborators who were saving all their data in a single TDT DataTank, so that `read_block`, the only read method for TdtIO, attempted to read > 100GB into memory. To get around this, I needed a method for reading individual segments. So in my fork I have

1. Implemented `TdtIO.read_segment`, which takes a `blockname` argument (block being the TDT block, the Neo segment) to specify which block. This was done by factoring the segment-reading code out of a for loop in read_block into its own function.
2. Made some formatting changes for better PEP8 compliance.
3. Used try/except blocks instead of conditionals when checking if a file exists. This is better practice (avoids a race condition).

The new code passes the TdtIO unit test.

Alternatively, I considered implementing `load_lazy_object`, which would have you call `read_block(lazy=True, cascade=True)`, then pass in segment objects to `load_lazy_object`. However it turned out that the call to `read_block` is _very_ slow since it parses all the data files in the tank. It's much faster to `os.listdir` the DataTank to see the segment names. and use `read_segment`, as I have implemented it.