### PR TITLE
t_stop and t_start property for segments

### DIFF
--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -103,6 +103,40 @@ class Segment(Container):
         self.rec_datetime = rec_datetime
         self.index = index
 
+    # t_start attribute is handled as a property so type checking can be done
+    @property
+    def t_start(self):
+        '''
+        Time when first signal begins.
+        '''
+        t_starts = [sig.t_start for sig in self.analogsignalarrays + self.analogsignals +  self.spiketrains]
+        t_starts += [e.times[0] for e in self.epocharrays + self.eventarrays + self.irregularlysampledsignals]
+        t_starts += [e.time for e in self.events + self.epochs + self.spikes]
+
+        # t_start is not defined if no children are present
+        if len(t_starts)==0:
+            return None
+
+        t_start = min(t_starts)
+        return t_start
+
+    # t_stop attribute is handled as a property so type checking can be done
+    @property
+    def t_stop(self):
+        '''
+        Time when last signal ends.
+        '''
+        t_stops = [sig.t_stop for sig in self.analogsignalarrays + self.analogsignals +  self.spiketrains]
+        t_stops += [e.times[-1] for e in self.epocharrays + self.eventarrays + self.irregularlysampledsignals]
+        t_stops += [e.time for e in self.events + self.epochs + self.spikes]
+
+        # t_stop is not defined if no children are present
+        if len(t_stops)==0:
+            return None
+
+        t_stop = max(t_stops)
+        return t_stop
+
     def take_spikes_by_unit(self, unit_list=None):
         '''
         Return :class:`Spike` objects in the :class:`Segment` that are also in

--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -110,7 +110,7 @@ class Segment(Container):
         Time when first signal begins.
         '''
         t_starts = [sig.t_start for sig in self.analogsignalarrays + self.analogsignals +  self.spiketrains]
-        t_starts += [e.times[0] for e in self.epocharrays + self.eventarrays + self.irregularlysampledsignals]
+        t_starts += [e.times[0] for e in self.epocharrays + self.eventarrays + self.irregularlysampledsignals if len(e.times)>0]
         t_starts += [e.time for e in self.events + self.epochs + self.spikes]
 
         # t_start is not defined if no children are present
@@ -127,7 +127,7 @@ class Segment(Container):
         Time when last signal ends.
         '''
         t_stops = [sig.t_stop for sig in self.analogsignalarrays + self.analogsignals +  self.spiketrains]
-        t_stops += [e.times[-1] for e in self.epocharrays + self.eventarrays + self.irregularlysampledsignals]
+        t_stops += [e.times[-1] for e in self.epocharrays + self.eventarrays + self.irregularlysampledsignals if len(e.times)>0]
         t_stops += [e.time for e in self.events + self.epochs + self.spikes]
 
         # t_stop is not defined if no children are present

--- a/neo/test/coretest/test_segment.py
+++ b/neo/test/coretest/test_segment.py
@@ -246,6 +246,33 @@ class TestSegment(unittest.TestCase):
         self.check_creation(self.seg1)
         self.check_creation(self.seg2)
 
+    def test_times(self):
+
+        for seg in [self.seg1,self.seg2]:
+            # calculate target values for t_start and t_stop
+            t_starts, t_stops = [], []
+            for children in [seg.analogsignals,seg.analogsignalarrays,
+                             seg.epochs,seg.epocharrays,
+                             seg.events,seg.eventarrays,
+                             seg.irregularlysampledsignals,
+                             seg.spikes,seg.spiketrains]:
+                for child in children:
+                    if hasattr(child,'t_start'):
+                        t_starts.append(child.t_start)
+                    if hasattr(child,'t_stop'):
+                        t_stops.append(child.t_stop)
+                    if hasattr(child,'time'):
+                        t_starts.append(child.time)
+                        t_stops.append(child.time)
+                    if hasattr(child,'times'):
+                        t_starts.append(child.times[0])
+                        t_stops.append(child.times[-1])
+            targ_t_start = min(t_starts)
+            targ_t_stop = max(t_stops)
+
+            self.assertEqual(seg.t_start,targ_t_start)
+            self.assertEqual(seg.t_stop,targ_t_stop)
+
     def test__merge(self):
         seg1a = fake_neo(Block, seed=self.seed1, n=self.nchildren).segments[0]
         assert_same_sub_schema(self.seg1, seg1a)


### PR DESCRIPTION
I recently discovered the absence of t_start and t_stop properties of segments. Since segments are meant to cover a specific time window, I think it could be useful to include the t_start and t_stop properties also for segments.
 My implementation calculates t_start and  t_stop for a segment based on the earliest (latest) signal, which is linked to this segment. Probably there are more efficient implementations, but this could be a starting point.