### PR TITLE
Update neuroshareapiio.py

### DIFF
--- a/neo/io/neuroshareapiio.py
+++ b/neo/io/neuroshareapiio.py
@@ -307,7 +307,7 @@ class NeuroshareapiIO(BaseIO):
             #transform t_start into index (reading will start from this index)           
             startat = int(t_start*self.metadata["sampRate"])
             #get the number of bins to read in
-            bins = int((segment_duration+t_start) * self.metadata["sampRate"])
+            bins = int(segment_duration * self.metadata["sampRate"])
             
             #if the number of bins to read is bigger than 
             #the total number of bins, read only till the end of analog object


### PR DESCRIPTION
There was a small bug in read_analogsignal function. When only a chunk of a file was read (say from second 5 to second 11), the function would read more than the chunk specified. It would start at second 5, but then read 5+6 seconds of data, instead of only 6 seconds.