### PR TITLE
Added fourth iteration of BlackrockIO module with new features.

### DIFF
--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -2192,11 +2192,12 @@ class BlackrockIO(BaseIO):
         # read recordingchannelgroup
         if channels:
             for i, ch_idx in enumerate(channels):
-                if ch_idx in units.keys() and not \
+                if units and ch_idx in units.keys() and not \
                         isinstance(units[ch_idx], types.NoneType):
                     ch_units = units[ch_idx]
                 else:
                     ch_units = None
+
                 rcg = self.__read_recordingchannelgroup(
                     channel_idx=ch_idx,
                     index=i,

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1035,10 +1035,8 @@ class BlackrockIO(BaseIO):
         """
         tp = []
         if self._avail_files['nev']:
-            print 'nev', self.__get_nev_rec_times()[0]
             tp.extend(self.__get_nev_rec_times()[0])
         for nsx_i in self._avail_nsx:
-            print nsx_i, self.__nsx_rec_times[self.__nsx_spec[nsx_i]](nsx_i)[0]
             tp.extend(self.__nsx_rec_times[self.__nsx_spec[nsx_i]](nsx_i)[0])
 
         return min(tp)

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1744,8 +1744,9 @@ class BlackrockIO(BaseIO):
             st.left_sweep = self.__get_left_sweep_waveforms()
 
         # add additional annotations
-        st.annotate(ch_idx=int(channel_idx))
-        st.annotate(unit_id=int(unit_id))
+        st.annotate(
+            ch_idx=int(channel_idx),
+            unit_id=int(unit_id))
 
         return st
 
@@ -1874,6 +1875,30 @@ class BlackrockIO(BaseIO):
         if self._avail_files['nev']:
             rcg.channel_names = self.__nev_params(
                 'channel_labels')[channel_idx]
+
+            # additional annotations from nev
+            get_idx = list(
+                self.__nev_ext_header['NEUEVWAV']['electrode_id']).index(
+                    channel_idx)
+            rcg.annotate(
+                connector_ID=self.__nev_ext_header[
+                    'NEUEVWAV']['physical_connector'][get_idx],
+                connector_pinID=self.__nev_ext_header[
+                    'NEUEVWAV']['connector_pin'][get_idx],
+                dig_factor=self.__nev_ext_header[
+                    'NEUEVWAV']['digitization_factor'][get_idx],
+                connector_pin=self.__nev_ext_header[
+                    'NEUEVWAV']['connector_pin'][get_idx],
+                energy_threshold=self.__nev_ext_header[
+                    'NEUEVWAV']['energy_threshold'][get_idx] * pq.uV,
+                hi_threshold=self.__nev_ext_header[
+                    'NEUEVWAV']['hi_threshold'][get_idx] * pq.uV,
+                lo_threshold=self.__nev_ext_header[
+                    'NEUEVWAV']['lo_threshold'][get_idx] * pq.uV,
+                nb_sorted_units=self.__nev_ext_header[
+                    'NEUEVWAV']['nb_sorted_units'][get_idx],
+                waveform_size=self.__waveform_size[self.__nev_spec](
+                    )[channel_idx] * self.__nev_params('waveform_time_unit'))
 
         rcg.description = \
             "Container for units and groups analogsignals across segments."

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1236,7 +1236,8 @@ class BlackrockIO(BaseIO):
             'timestamp_resolution': 30000,
             'bytes_in_headers':
                 self.__nsx_basic_header[nsx_nb].dtype.itemsize +
-                self.__nsx_ext_header[nsx_nb].dtype.itemsize,
+                self.__nsx_ext_header[nsx_nb].dtype.itemsize *
+                self.__nsx_basic_header[nsx_nb]['channel_count'],
             'sampling_rate':
                 30000 / self.__nsx_basic_header[nsx_nb]['period'] * pq.Hz,
             'time_unit': pq.CompoundUnit("1.0/{0}*s".format(
@@ -1923,7 +1924,7 @@ class BlackrockIO(BaseIO):
                 nb_sorted_units=self.__nev_ext_header[
                     'NEUEVWAV']['nb_sorted_units'][get_idx],
                 waveform_size=self.__waveform_size[self.__nev_spec](
-                    )[channel_idx] * self.__nev_params('waveform_time_unit'))
+                )[channel_idx] * self.__nev_params('waveform_time_unit'))
 
         rcg.description = \
             "Container for units and groups analogsignals across segments."
@@ -2020,8 +2021,8 @@ class BlackrockIO(BaseIO):
 
         seg = Segment(file_origin=self.filename)
         seg.annotate(
-                t_min=n_start,
-                t_max=n_stop)
+            t_min=n_start,
+            t_max=n_stop)
 
         # set user defined annotations if they were provided
         if isinstance(index, types.NoneType):
@@ -2284,11 +2285,11 @@ class BlackrockIO(BaseIO):
                 for seg in bl.segments:
                     if ch_units:
                         for un in rcg.units:
-                                sts = seg.filter(
-                                    targdict={'name': un.name},
-                                    objects='SpikeTrain')
-                                for st in sts:
-                                    un.spiketrains.append(st)
+                            sts = seg.filter(
+                                targdict={'name': un.name},
+                                objects='SpikeTrain')
+                            for st in sts:
+                                un.spiketrains.append(st)
 
                     anasigs = seg.filter(
                         targdict={'ch_idx': ch_idx},

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1801,14 +1801,15 @@ class BlackrockIO(BaseIO):
             'databl_t_stop', nsx_nb, n_start, n_stop)
 
         elids_nsx = list(self.__nsx_ext_header[nsx_nb]['electrode_id'])
+        print elids_nsx
         if channel_idx in elids_nsx:
-            ch_idx = elids_nsx.index(channel_idx)
+            idx_ch = elids_nsx.index(channel_idx)
         else:
             return None
 
         description = \
             "AnalogSignal from channel: {0}, label: {1}, nsx: {2}".format(
-                channel_idx, labels[ch_idx], nsx_nb)
+                channel_idx, labels[idx_ch], nsx_nb)
 
         data_times = np.arange(
             t_start.item(), t_stop.item(),
@@ -1816,32 +1817,32 @@ class BlackrockIO(BaseIO):
         mask = (data_times >= n_start) & (data_times < n_stop)
         data_times = data_times[mask].astype(float)
 
-        sig_ch = signal[dbl_idx][:, ch_idx][mask].astype(float)
+        sig_ch = signal[dbl_idx][:, idx_ch][mask].astype(float)
 
         # transform dig value to pysical value
-        sym_ana = (max_ana[ch_idx] == -min_ana[ch_idx])
-        sym_dig = (max_dig[ch_idx] == -min_dig[ch_idx])
+        sym_ana = (max_ana[idx_ch] == -min_ana[idx_ch])
+        sym_dig = (max_dig[idx_ch] == -min_dig[idx_ch])
         if sym_ana and sym_dig:
-            sig_ch *= float(max_ana[ch_idx]) / float(max_dig[ch_idx])
+            sig_ch *= float(max_ana[idx_ch]) / float(max_dig[idx_ch])
         else:
             # general case
-            sig_ch -= min_dig[ch_idx]
-            sig_ch *= float(max_ana[ch_idx] - min_ana) / \
-                float(max_dig[ch_idx] - min_dig)
-            sig_ch += float(min_ana[ch_idx])
+            sig_ch -= min_dig[idx_ch]
+            sig_ch *= float(max_ana[idx_ch] - min_ana) / \
+                float(max_dig[idx_ch] - min_dig)
+            sig_ch += float(min_ana[idx_ch])
 
         anasig = AnalogSignal(
-            signal=pq.Quantity(sig_ch, units[ch_idx], copy=False),
+            signal=pq.Quantity(sig_ch, units[idx_ch], copy=False),
             sampling_rate=sampling_rate,
             t_start=data_times[0].rescale(nsx_time_unit),
-            name=labels[ch_idx],
+            name=labels[idx_ch],
             description=description,
             file_origin='.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb]))
 
         anasig.annotate(
             nsx=nsx_nb,
             ch_idx=channel_idx,
-            ch_label=labels[ch_idx])
+            ch_label=labels[idx_ch])
 
         if lazy:
             anasig.lazy_shape = np.shape(sig_ch)

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1147,8 +1147,15 @@ class BlackrockIO(BaseIO):
         Returns labels for all channels for file spec 2.1
         """
         elids = self.__nev_ext_header['NEUEVWAV']['electrode_id']
+        labels = []
 
-        return dict([(i, str(i)) for i in elids])
+        for elid in elids:
+            if elid < 129:
+                labels.append('chan%i' % elid)
+            else:
+                labels.append('ainp%i' % (elid - 129 + 1))
+
+        return dict(zip(elids, labels))
 
     def __get_channel_labels_variant_b(self):
         """

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1,19 +1,26 @@
 # -*- coding: utf-8 -*-
 """
-Module for reading binary files from Blackrock format.
+Module for reading data from files in the Blackrock format.
 
 This work is based on:
   * Chris Rodgers - first version
-  * Michael Denker, Lyuba Zehl - second version.
+  * Michael Denker, Lyuba Zehl - second version
   * Samuel Garcia - third version
+  * Lyuba Zehl, Michael Denker - fourth version
 
-It supports reading only.
+This IO supports reading only.
 This IO is able to read:
   * the nev file which contains spikes
   * ns1, ns2, .., ns6 files that contain signals at different sampling rates
 
-The neural data channels are 1 - 128. The analog inputs are 129 - 144.
-            
+This IO can handle the following Blackrock file specifications:
+  * 2.1
+  * 2.2
+  * 2.3
+
+The neural data channels are 1 - 128.
+The analog inputs are 129 - 144. (129 - 137 AC coupled, 138 - 144 DC coupled)
+
 spike- and event-data; 30000 Hz
 "ns1": "analog data: 500 Hz",
 "ns2": "analog data: 1000 Hz",
@@ -23,480 +30,2207 @@ spike- and event-data; 30000 Hz
 "ns6": "analog data: 30000 Hz (no digital filter)"
 
 TODO:
-  * synchro video
-  * tracking
-  * Units for spiketrain
-
+  * videosync events (file spec 2.3)
+  * tracking events (file spec 2.3)
+  * buttontrigger events (file spec 2.3)
+  * config events (file spec 2.3)
+  * check left sweep settings of Blackrock
+  * check nsx offsets (file spec 2.1)
+  * add info of nev ext header (NSASEXEX) to non-neural events
+    (file spec 2.1 and 2.2)
+  * read sif file information
+  * read ccf file information
+  * fix reading of periodic sampling events (non-neural event type)
+    (file spec 2.1 and 2.2)
 """
 
 from __future__ import division
-import logging
-import struct
 import datetime
 import os
+import re
+import types
 
 import numpy as np
 import quantities as pq
 
+import neo
 from neo.io.baseio import BaseIO
 from neo.core import (Block, Segment, SpikeTrain, Unit, Event,
                       RecordingChannelGroup, AnalogSignal)
 
+if __name__ == '__main__':
+    pass
+
 
 class BlackrockIO(BaseIO):
     """
-    
+    Class for reading data in from a file set recorded by the Blackrock
+    (Cerebus) recording system.
+
+    Upon initialization, the class is linked to the available set of Blackrock
+    files. Data can be read as a neo Block or neo Segment object using the
+    read_block or read_segment function, respectively.
+
+    Note: This routine will handle files according to specification 2.1, 2.2,
+    and 2.3. Recording pauses that may occur in file specifications 2.2 and
+    2.3 are automatically extracted and the data set is split into different
+    segments.
+
+    Inherits from:
+            neo.io.BaseIO
+
+    The Blackrock data format consists not of a single file, but a set of
+    different files. This constructor associates itself with a set of files
+    that constitute a common data set. By default, all files belonging to
+    the file set have the same base name, but different extensions.
+    However, by using the override parameters, individual filenames can
+    be set.
+
+    Args:
+        filename (string):
+            File name (without extension) of the set of Blackrock files to
+            associate with. Any .nsX or .nev, .sif, or .ccf extensions are
+            ignored when parsing this parameter.
+        nsx_override (string):
+            File name of the .nsX files (without extension). If None,
+            _filenames is used.
+            Default: None.
+        nev_override (string):
+            File name of the .nev file (without extension). If None,
+            _filenames is used.
+            Default: None.
+        sif_override (string):
+            File name of the .sif file (without extension). If None,
+            _filenames is used.
+            Default: None.
+        ccf_override (string):
+            File name of the .ccf file (without extension). If None,
+            _filenames is used.
+            Default: None.
+        verbose (boolean):
+            If True, the class will output additional diagnostic
+            information on stdout.
+            Default: False
+
+    Returns:
+        -
+
+    Examples:
+        >>> a = BlackrockIO('myfile')
+
+            Loads a set of file consisting of files myfile.ns1, ...,
+            myfile.ns6, and myfile.nev
+
+
+        >>> b = BlackrockIO('myfile', nev_override='sorted')
+
+            Loads the analog data from the set of files myfile.ns1, ...,
+            myfile.ns6, but reads spike/event data from sorted.nev
     """
-    is_readable        = True
-    is_writable        = False
+    # Class variables demonstrating capabilities of this IO
+    is_readable = True
+    is_writable = False
 
-    supported_objects  = [Block, Segment, AnalogSignal, RecordingChannelGroup, 
-                          SpikeTrain, Unit]
-    readable_objects    = [Block, Segment]
+    # This IO can only manipulate continuous data, spikes, and events
+    supported_objects = [
+        neo.Block, neo.Segment, neo.Event, neo.AnalogSignal, neo.SpikeTrain,
+        neo.Unit, neo.RecordingChannelGroup]
+    readable_objects = [neo.Block, neo.Segment]
+    writeable_objects = []
 
-    name               = 'Blackrock'
-    extensions = ['ns' + str(i) for i in range(1, 10)] + ['nev', 'sif']
-    
+    # TODO: Not sure what header and streamable does
+    has_header = False
+    is_streameable = False
+
+    # TODO: Not sure if this is needed
+    read_params = {
+        neo.Block: [
+            ('nsx_to_load', {
+                'value': 'none',
+                'label': "List of nsx files (ids, int) to read."}),
+            ('n_starts', {
+                'value': None,
+                'label': "List of n_start points (Quantity) to create "
+                         "segments from."}),
+            ('n_stops', {
+                'value': None,
+                'label': "List of n_stop points (Quantity) to create "
+                         "segments from."}),
+            ('channels', {
+                'value': 'none',
+                'label': "List of channels (ids, int) to load data from."}),
+            ('units', {
+                'value': 'none',
+                'label': "Dictionary for units (values, list of int) to load "
+                         "for each channel (key, int)."}),
+            ('load_waveforms', {
+                'value': False,
+                'label': "States if waveforms should be loaded and attached "
+                         "to spiketrain"}),
+            ('load_events', {
+                'value': False,
+                'label': "States if events should be loaded."})],
+        neo.Segment: [
+            ('n_start', {
+                'label': "Start time point (Quantity) for segment"}),
+            ('n_stop', {
+                'label': "Stop time point (Quantity) for segment"}),
+            ('nsx_to_load', {
+                'value': 'none',
+                'label': "List of nsx files (ids, int) to read."}),
+            ('channels', {
+                'value': 'none',
+                'label': "List of channels (ids, int) to load data from."}),
+            ('units', {
+                'value': 'none',
+                'label': "Dictionary for units (values, list of int) to load "
+                         "for each channel (key, int)."}),
+            ('load_waveforms', {
+                'value': False,
+                'label': "States if waveforms should be loaded and attached "
+                         "to spiketrain"}),
+            ('load_events', {
+                'value': False,
+                'label': "States if events should be loaded."})]}
+
+    write_params = {}
+
+    name = 'Blackrock IO'
+    description = "This IO reads .nev/.nsX file of the Blackrock " + \
+        "(Cerebus) recordings system."
+    # The possible file extensions of the Cerebus system and their content:
+    #     ns1: contains analog data; sampled at 500 Hz (+ digital filters)
+    #     ns2: contains analog data; sampled at 1000 Hz (+ digital filters)
+    #     ns3: contains analog data; sampled at 2000 Hz (+ digital filters)
+    #     ns4: contains analog data; sampled at 10000 Hz (+ digital filters)
+    #     ns5: contains analog data; sampled at 30000 Hz (+ digital filters)
+    #     ns6: contains analog data; sampled at 30000 Hz (no digital filters)
+    #     nev: contains spike- and event-data; sampled at 30000 Hz
+    #     sif: contains institution and patient info (XML)
+    #     ccf: contains Cerebus configurations
+    extensions = ['ns' + str(_) for _ in range(1, 7)]
+    extensions.extend(['nev', 'sif', 'ccf'])
+
     mode = 'file'
 
-    read_params = {
-        Block: [('load_waveforms' , { 'value' : True } ) , ],
-        Segment : [('load_waveforms' , { 'value' : False } ) ,],
-        }
-
-
-    def __init__(self, filename) :
+    def __init__(self, filename, nsx_override=None, nev_override=None,
+                 sif_override=None, ccf_override=None, verbose=False):
         """
+        Initialize the BlackrockIO class.
         """
         BaseIO.__init__(self)
-        
-        # remove extension because there is bunch of files : nev, ns1, ..., ns5, nsf
+
+        # Remember choice whether to print diagnostic messages or not
+        self._verbose = verbose
+
+        # remove extension from base _filenames
         for ext in self.extensions:
-            if filename.endswith('.'+ext):
-                filename = filename.strip('.'+ext)
-        self.filename = filename
-        
-    def read_block(self, lazy=False, cascade=True, load_waveforms = False):
+            self.filename = re.sub(
+                os.path.extsep + ext + '$', '', filename)
+
+        # remove extensions from overrides
+        self._filenames = {}
+        if nsx_override:
+            self._filenames['nsx'] = re.sub(
+                os.path.extsep + 'ns[1,2,3,4,5,6]$', '', nsx_override)
+        else:
+            self._filenames['nsx'] = self.filename
+        if nev_override:
+            self._filenames['nev'] = re.sub(
+                os.path.extsep + 'nev$', '', nev_override)
+        else:
+            self._filenames['nev'] = self.filename
+        if sif_override:
+            self._filenames['sif'] = re.sub(
+                os.path.extsep + 'sif$', '', sif_override)
+        else:
+            self._filenames['sif'] = self.filename
+        if ccf_override:
+            self._filenames['ccf'] = re.sub(
+                os.path.extsep + 'ccf$', '', ccf_override)
+        else:
+            self._filenames['ccf'] = self.filename
+
+        # check which files are available
+        self._avail_files = dict.fromkeys(self.extensions, False)
+        self._avail_nsx = []
+        for ext in self.extensions:
+            if ext.startswith('ns'):
+                file2check = ''.join(
+                    [self._filenames['nsx'], os.path.extsep, ext])
+            else:
+                file2check = ''.join(
+                    [self._filenames[ext], os.path.extsep, ext])
+
+            if os.path.exists(file2check):
+                self._print_verbose("Found " + file2check + ".")
+                self._avail_files[ext] = True
+                if ext.startswith('ns'):
+                    self._avail_nsx.append(int(ext[-1]))
+
+        # These dictionaries are used internally to map the file specification
+        # revision of the nsx and nev files to one of the reading routines
+        self.__nsx_header_reader = {
+            '2.1': self.__read_nsx_header_variant_a,
+            '2.2': self.__read_nsx_header_variant_b,
+            '2.3': self.__read_nsx_header_variant_b}
+        self.__nsx_dataheader_reader = {
+            '2.1': self.__read_nsx_dataheader_variant_a,
+            '2.2': self.__read_nsx_dataheader_variant_b,
+            '2.3': self.__read_nsx_dataheader_variant_b}
+        self.__nsx_data_reader = {
+            '2.1': self.__read_nsx_data_variant_a,
+            '2.2': self.__read_nsx_data_variant_b,
+            '2.3': self.__read_nsx_data_variant_b}
+        self.__nev_header_reader = {
+            '2.1': self.__read_nev_header_variant_a,
+            '2.2': self.__read_nev_header_variant_b,
+            '2.3': self.__read_nev_header_variant_c}
+        self.__nev_data_reader = {
+            '2.1': self.__read_nev_data_variant_a,
+            '2.2': self.__read_nev_data_variant_a,
+            '2.3': self.__read_nev_data_variant_b}
+        self.__nsx_params = {
+            '2.1': self.__get_nsx_param_variant_a,
+            '2.2': self.__get_nsx_param_variant_b,
+            '2.3': self.__get_nsx_param_variant_b}
+        self.__nsx_databl_param = {
+            '2.1': self.__get_nsx_databl_param_variant_a,
+            '2.2': self.__get_nsx_databl_param_variant_b,
+            '2.3': self.__get_nsx_databl_param_variant_b}
+        self.__waveform_size = {
+            '2.1': self.__get_waveform_size_variant_a,
+            '2.2': self.__get_waveform_size_variant_a,
+            '2.3': self.__get_waveform_size_variant_b}
+        self.__channel_labels = {
+            '2.1': self.__get_channel_labels_variant_a,
+            '2.2': self.__get_channel_labels_variant_b,
+            '2.3': self.__get_channel_labels_variant_b}
+        self.__nsx_rec_times = {
+            '2.1': self.__get_nsx_rec_times_variant_a,
+            '2.2': self.__get_nsx_rec_times_variant_b,
+            '2.3': self.__get_nsx_rec_times_variant_b}
+        self.__nonneural_evtypes = {
+            '2.1': self.__get_nonneural_evtypes_variant_a,
+            '2.2': self.__get_nonneural_evtypes_variant_a,
+            '2.3': self.__get_nonneural_evtypes_variant_b}
+
+        # Load file spec and headers of available nev file
+        if self._avail_files['nev']:
+            # read nev file specification
+            self.__nev_spec = self.__extract_nev_file_spec()
+
+            # read nev headers
+            self.__nev_basic_header, self.__nev_ext_header = \
+                self.__nev_header_reader[self.__nev_spec]()
+
+        # Load file spec and headers of available nsx files
+        self.__nsx_spec = {}
+        self.__nsx_basic_header = {}
+        self.__nsx_ext_header = {}
+        self.__nsx_data_header = {}
+        for nsx_nb in self._avail_nsx:
+            # read nsx file specification
+            self.__nsx_spec[nsx_nb] = self.__extract_nsx_file_spec(nsx_nb)
+
+            # read nsx headers
+            self.__nsx_basic_header[nsx_nb], self.__nsx_ext_header[nsx_nb] = \
+                self.__nsx_header_reader[self.__nsx_spec[nsx_nb]](nsx_nb)
+
+            # Read nsx data header(s) for nsx
+            self.__nsx_data_header[nsx_nb] = self.__nsx_dataheader_reader[
+                self.__nsx_spec[nsx_nb]](nsx_nb)
+
+    def _print_verbose(self, text):
         """
+        Print a verbose diagnostic message (string).
         """
-        # Create block
-        bl = Block(file_origin=self.filename)
+        if self._verbose:
+            print('BlackrockIO: ' + text)
+
+    def __extract_nsx_file_spec(self, nsx_nb):
+        """
+        Extract file specification from an .nsx file.
+        """
+        filename = '.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb])
+
+        # Header structure of files specification 2.2 and higher. For files 2.1
+        # and lower, the entries ver_major and ver_minor are not supported.
+        dt0 = [
+            ('file_id', 'S8'),
+            ('ver_major', 'uint8'),
+            ('ver_minor', 'uint8')]
+
+        nsx_file_id = np.fromfile(filename, count=1, dtype=dt0)[0]
+        if nsx_file_id['file_id'] == 'NEURALSG':
+            spec = '2.1'
+        elif nsx_file_id['file_id'] == 'NEURALCD':
+            spec = '{0}.{1}'.format(
+                nsx_file_id['ver_major'], nsx_file_id['ver_minor'])
+        else:
+            raise IOError('Unsupported NSX file type.')
+
+        return spec
+
+    def __extract_nev_file_spec(self):
+        """
+        Extract file specification from an .nsx file
+        """
+        filename = '.'.join([self._filenames['nsx'], 'nev'])
+        # Header structure of files specification 2.2 and higher. For files 2.1
+        # and lower, the entries ver_major and ver_minor are not supported.
+        dt0 = [
+            ('file_id', 'S8'),
+            ('ver_major', 'uint8'),
+            ('ver_minor', 'uint8')]
+
+        nev_file_id = np.fromfile(filename, count=1, dtype=dt0)[0]
+        if nev_file_id['file_id'] == 'NEURALEV':
+            spec = '{0}.{1}'.format(
+                nev_file_id['ver_major'], nev_file_id['ver_minor'])
+        else:
+            raise IOError('NEV file type {0} is not supported'.format(
+                nev_file_id['file_id']))
+
+        return spec
+
+    def __read_nsx_header_variant_a(self, nsx_nb):
+        """
+        Extract nsx header information from a 2.1 .nsx file
+        """
+        filename = '.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb])
+
+        # basic header (file_id: NEURALCD)
+        dt0 = [
+            ('file_id', 'S8'),
+            # label of sampling groun (e.g. "1kS/s" or "LFP Low")
+            ('label', 'S16'),
+            # number of 1/30000 seconds between data points
+            # (e.g., if sampling rate "1 kS/s", period equals "30")
+            ('period', 'uint32'),
+            ('channel_count', 'uint32')]
+
+        nsx_basic_header = np.fromfile(filename, count=1, dtype=dt0)[0]
+
+        # "extended" header (last field of file_id: NEURALCD)
+        # (to facilitate compatibility with higher file specs)
+        offset_dt0 = np.dtype(dt0).itemsize
+        shape = nsx_basic_header['channel_count']
+        # originally called channel_id in Blackrock user manual
+        # (to facilitate compatibility with higher file specs)
+        dt1 = [('electrode_id', 'uint32')]
+
+        nsx_ext_header = np.memmap(
+            filename, shape=shape, offset=offset_dt0, dtype=dt1)
+
+        return nsx_basic_header, nsx_ext_header
+
+    def __read_nsx_header_variant_b(self, nsx_nb):
+        """
+        Extract nsx header information from a 2.2 or 2.3 .nsx file
+        """
+        filename = '.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb])
+
+        # basic header (file_id: NEURALCD)
+        dt0 = [
+            ('file_id', 'S8'),
+            # file specification split into major and minor version number
+            ('ver_major', 'uint8'),
+            ('ver_minor', 'uint8'),
+            # bytes of basic & extended header
+            ('bytes_in_headers', 'uint32'),
+            # label of the sampling group (e.g., "1 kS/s" or "LFP low")
+            ('label', 'S16'),
+            ('comment', 'S256'),
+            ('period', 'uint32'),
+            ('timestamp_resolution', 'uint32'),
+            # time origin: 2byte uint16 values for ...
+            ('year', 'uint16'),
+            ('month', 'uint16'),
+            ('weekday', 'uint16'),
+            ('day', 'uint16'),
+            ('hour', 'uint16'),
+            ('minute', 'uint16'),
+            ('second', 'uint16'),
+            ('millisecond', 'uint16'),
+            # number of channel_count match number of extended headers
+            ('channel_count', 'uint32')]
+
+        nsx_basic_header = np.fromfile(filename, count=1, dtype=dt0)[0]
+
+        # extended header (type: CC)
+        offset_dt0 = np.dtype(dt0).itemsize
+        shape = nsx_basic_header['channel_count']
+        dt1 = [
+            ('type', 'S2'),
+            ('electrode_id', 'uint16'),
+            ('electrode_label', 'S16'),
+            # used front-end amplifier bank (e.g., A, B, C, D)
+            ('physical_connector', 'uint8'),
+            # used connector pin (e.g., 1-37 on bank A, B, C or D)
+            ('connector_pin', 'uint8'),
+            # digital and analog value ranges of the signal
+            ('min_digital_val', 'int16'),
+            ('max_digital_val', 'int16'),
+            ('min_analog_val', 'int16'),
+            ('max_analog_val', 'int16'),
+            # units of the analog range values ("mV" or "uV")
+            ('units', 'S16'),
+            # filter settings used to create nsx from source signal
+            ('hi_freq_corner', 'uint32'),
+            ('hi_freq_order', 'uint32'),
+            ('hi_freq_type', 'uint16'),  # 0=None, 1=Butterworth
+            ('lo_freq_corner', 'uint32'),
+            ('lo_freq_order', 'uint32'),
+            ('lo_freq_type', 'uint16')]  # 0=None, 1=Butterworth
+
+        nsx_ext_header = np.memmap(
+            filename, shape=shape, offset=offset_dt0, dtype=dt1)
+
+        return nsx_basic_header, nsx_ext_header
+
+    def __read_nsx_dataheader(self, nsx_nb, offset):
+        """
+        Reads data header following the given offset of an nsx file.
+        """
+        filename = '.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb])
+
+        # dtypes data header
+        dt2 = [
+            ('header', 'uint8'),
+            ('timestamp', 'uint32'),
+            ('nb_data_points', 'uint32')]
+
+        return np.memmap(filename, dtype=dt2, shape=1, offset=offset)[0]
+
+    def __read_nsx_dataheader_variant_a(
+            self, nsx_nb, filesize=None, offset=None):
+        """
+        Reads None for the nsx data header of file spec 2.1. Introduced to
+        facilitate compatibility with higher file spec.
+        """
+
+        return None
+
+    def __read_nsx_dataheader_variant_b(
+            self, nsx_nb, filesize=None, offset=None, ):
+        """
+        Reads the nsx data header for each data block following the offset of
+        file spec 2.2 and 2.3.
+        """
+        filename = '.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb])
+
+        filesize = self.__get_file_size(filename)
+
+        data_header = {}
+        index = 0
+
+        if isinstance(offset, types.NoneType):
+            offset = self.__nsx_basic_header[nsx_nb]['bytes_in_headers']
+
+        while offset < filesize:
+            index += 1
+
+            dh = self.__read_nsx_dataheader(nsx_nb, offset)
+            data_header[index] = {
+                'header': dh['header'],
+                'timestamp': dh['timestamp'],
+                'nb_data_points': dh['nb_data_points'],
+                'offset_to_data_block': offset + dh.dtype.itemsize}
+
+            # data size = number of data points * (2bytes * number of channels)
+            data_size = dh['nb_data_points'] * \
+                self.__nsx_basic_header[nsx_nb]['channel_count'] * 2
+            # define new offset (to possible next data block)
+            offset = data_header[index]['offset_to_data_block'] + data_size
+
+        return data_header
+
+    def __read_nsx_data_variant_a(self, nsx_nb):
+        """
+        Extract nsx data from a 2.1 .nsx file
+        """
+        filename = '.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb])
+
+        # get shape of data
+        shape = (
+            self.__nsx_databl_param['2.1']('nb_data_points', nsx_nb),
+            self.__nsx_basic_header[nsx_nb]['channel_count'])
+        offset = self.__nsx_params['2.1']('bytes_in_headers', nsx_nb)
+
+        # read nsx data
+        # store as dict for compatibility with higher file specs
+        data = {1: np.memmap(
+            filename, dtype='int16', shape=shape, offset=offset)}
+
+        return data
+
+    def __read_nsx_data_variant_b(self, nsx_nb):
+        """
+        Extract nsx data (blocks) from a 2.2 or 2.3 .nsx file. Blocks can arise
+        if the recording was paused by the user.
+        """
+        filename = '.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb])
+
+        data = {}
+        for data_bl in self.__nsx_data_header[nsx_nb].keys():
+            # get shape and offset of data
+            shape = (
+                self.__nsx_data_header[nsx_nb][data_bl]['nb_data_points'],
+                self.__nsx_basic_header[nsx_nb]['channel_count'])
+            offset = \
+                self.__nsx_data_header[nsx_nb][data_bl]['offset_to_data_block']
+
+            # read data
+            data[data_bl] = np.memmap(
+                filename, dtype='int16', shape=shape, offset=offset)
+
+        return data
+
+    def __read_nev_header(self, ext_header_variants):
+        """
+        Extract nev header information from a 2.1 .nsx file
+        """
+        filename = '.'.join([self._filenames['nev'], 'nev'])
+
+        # basic hedaer
+        dt0 = [
+            # Set to "NEURALEV"
+            ('file_type_id', 'S8'),
+            ('ver_major', 'uint8'),
+            ('ver_minor', 'uint8'),
+            # Flags
+            ('additionnal_flags', 'uint16'),
+            # File index of first data sample
+            ('bytes_in_headers', 'uint32'),
+            # Number of bytes per data packet (sample)
+            ('bytes_in_data_packets', 'uint32'),
+            # Time resolution of time stamps in Hz
+            ('timestamp_resolution', 'uint32'),
+            # Sampling frequency of waveforms in Hz
+            ('sample_resolution', 'uint32'),
+            ('year', 'uint16'),
+            ('month', 'uint16'),
+            ('weekday', 'uint16'),
+            ('day', 'uint16'),
+            ('hour', 'uint16'),
+            ('minute', 'uint16'),
+            ('second', 'uint16'),
+            ('millisecond', 'uint16'),
+            ('application_to_create_file', 'S32'),
+            ('comment_field', 'S256'),
+            # Number of extended headers
+            ('nb_ext_headers', 'uint32')]
+
+        nev_basic_header = np.fromfile(filename, count=1, dtype=dt0)[0]
+
+        # extended header
+        # this consist in N block with code 8bytes + 24 data bytes
+        # the data bytes depend on the code and need to be converted
+        # cafilename_nsx, segse by case
+        shape = nev_basic_header['nb_ext_headers']
+        offset_dt0 = np.dtype(dt0).itemsize
+
+        # This is the common structure of the beginning of extended headers
+        dt1 = [
+            ('packet_id', 'S8'),
+            ('info_field', 'S24')]
+
+        raw_ext_header = np.memmap(
+            filename, offset=offset_dt0, dtype=dt1, shape=shape)
+
+        nev_ext_header = {}
+        for packet_id in ext_header_variants.keys():
+            mask = (raw_ext_header['packet_id'] == packet_id)
+            dt2 = self.__nev_ext_header_types()[packet_id][
+                ext_header_variants[packet_id]]
+
+            nev_ext_header[packet_id] = raw_ext_header.view(dt2)[mask]
+
+        return nev_basic_header, nev_ext_header
+
+    def __read_nev_header_variant_a(self):
+        """
+        Extract nev header information from a 2.1 .nev file
+        """
+
+        ext_header_variants = {
+            'NEUEVWAV': 'a',
+            'ARRAYNME': 'a',
+            'ECOMMENT': 'a',
+            'CCOMMENT': 'a',
+            'MAPFILE': 'a',
+            'NSASEXEV': 'a'}
+
+        return self.__read_nev_header(ext_header_variants)
+
+    def __read_nev_header_variant_b(self):
+        """
+        Extract nev header information from a 2.2 .nev file
+        """
+
+        ext_header_variants = {
+            'NEUEVWAV': 'b',
+            'ARRAYNME': 'a',
+            'ECOMMENT': 'a',
+            'CCOMMENT': 'a',
+            'MAPFILE': 'a',
+            'NEUEVLBL': 'a',
+            'NEUEVFLT': 'a',
+            'DIGLABEL': 'a',
+            'NSASEXEV': 'a'}
+
+        return self.__read_nev_header(ext_header_variants)
+
+    def __read_nev_header_variant_c(self):
+        """
+        Extract nev header information from a 2.3 .nev file
+        """
+
+        ext_header_variants = {
+            'NEUEVWAV': 'b',
+            'ARRAYNME': 'a',
+            'ECOMMENT': 'a',
+            'CCOMMENT': 'a',
+            'MAPFILE': 'a',
+            'NEUEVLBL': 'a',
+            'NEUEVFLT': 'a',
+            'DIGLABEL': 'a',
+            'VIDEOSYN': 'a',
+            'TRACKOBJ': 'a'}
+
+        return self.__read_nev_header(ext_header_variants)
+
+    def __read_nev_data(self, nev_data_masks, nev_data_types):
+        """
+        Extract nev data from a 2.1 or 2.2 .nev file
+        """
+        filename = '.'.join([self._filenames['nev'], 'nev'])
+        data_size = self.__nev_basic_header['bytes_in_data_packets']
+        header_size = self.__nev_basic_header['bytes_in_headers']
+
+        # read all raw data packets and markers
+        dt0 = [
+            ('timestamp', 'uint32'),
+            ('packet_id', 'uint16'),
+            ('value', 'S{0}'.format(data_size - 6))]
+
+        raw_data = np.memmap(filename, offset=header_size, dtype=dt0)
+
+        masks = self.__nev_data_masks(raw_data['packet_id'])
+        types = self.__nev_data_types(data_size)
+
+        data = {}
+        for k, v in nev_data_masks.items():
+            data[k] = raw_data.view(types[k][nev_data_types[k]])[masks[k][v]]
+
+        return data
+
+    def __read_nev_data_variant_a(self):
+        """
+        Extract nev data from a 2.1 & 2.2 .nev file
+        """
+        nev_data_masks = {
+            'NonNeural': 'a',
+            'Spikes': 'a'}
+
+        nev_data_types = {
+            'NonNeural': 'a',
+            'Spikes': 'a'}
+
+        return self.__read_nev_data(nev_data_masks, nev_data_types)
+
+    def __read_nev_data_variant_b(self):
+        """
+        Extract nev data from a 2.3 .nev file
+        """
+        nev_data_masks = {
+            'NonNeural': 'a',
+            'Spikes': 'b',
+            'Comments': 'a',
+            'VideoSync': 'a',
+            'TrackingEvents': 'a',
+            'ButtonTrigger': 'a',
+            'ConfigEvent': 'a'}
+
+        nev_data_types = {
+            'NonNeural': 'b',
+            'Spikes': 'a',
+            'Comments': 'a',
+            'VideoSync': 'a',
+            'TrackingEvents': 'a',
+            'ButtonTrigger': 'a',
+            'ConfigEvent': 'a'}
+
+        return self.__read_nev_data(nev_data_masks, nev_data_types)
+
+    def __nev_ext_header_types(self):
+        """
+        Defines extended header types for different .nev file specifications.
+        """
+        nev_ext_header_types = {
+            'NEUEVWAV': {
+                # Version>=2.1
+                'a': [
+                    ('packet_id', 'S8'),
+                    ('electrode_id', 'uint16'),
+                    ('physical_connector', 'uint8'),
+                    ('connector_pin', 'uint8'),
+                    ('digitization_factor', 'uint16'),
+                    ('energy_threshold', 'uint16'),
+                    ('hi_threshold', 'int16'),
+                    ('lo_threshold', 'int16'),
+                    ('nb_sorted_units', 'uint8'),
+                    # number of bytes per waveform sample
+                    ('bytes_per_waveform', 'uint8'),
+                    ('unused', 'S10')],
+                # Version>=2.3
+                'b': [
+                    ('packet_id', 'S8'),
+                    ('electrode_id', 'uint16'),
+                    ('physical_connector', 'uint8'),
+                    ('connector_pin', 'uint8'),
+                    ('digitization_factor', 'uint16'),
+                    ('energy_threshold', 'uint16'),
+                    ('hi_threshold', 'int16'),
+                    ('lo_threshold', 'int16'),
+                    ('nb_sorted_units', 'uint8'),
+                    # number of bytes per waveform sample
+                    ('bytes_per_waveform', 'uint8'),
+                    # number of samples for each waveform
+                    ('spike_width', 'uint16'),
+                    ('unused', 'S8')]},
+            'ARRAYNME': {
+                'a': [
+                    ('packet_id', 'S8'),
+                    ('electrode_array_name', 'S24')]},
+            'ECOMMENT': {
+                'a': [
+                    ('packet_id', 'S8'),
+                    ('extra_comment', 'S24')]},
+            'CCOMMENT': {
+                'a': [
+                    ('packet_id', 'S8'),
+                    ('continued_comment', 'S24')]},
+            'MAPFILE': {
+                'a': [
+                    ('packet_id', 'S8'),
+                    ('mapFile', 'S24')]},
+            'NEUEVLBL': {
+                'a': [
+                    ('packet_id', 'S8'),
+                    ('electrode_id', 'uint16'),
+                    # label of this electrode
+                    ('label', 'S16'),
+                    ('unused', 'S6')]},
+            'NEUEVFLT': {
+                'a': [
+                    ('packet_id', 'S8'),
+                    ('electrode_id', 'uint16'),
+                    ('hi_freq_corner', 'uint32'),
+                    ('hi_freq_order', 'uint32'),
+                    # 0=None 1=Butterworth
+                    ('hi_freq_type', 'uint16'),
+                    ('lo_freq_corner', 'uint32'),
+                    ('lo_freq_order', 'uint32'),
+                    # 0=None 1=Butterworth
+                    ('lo_freq_type', 'uint16'),
+                    ('unused', 'S2')]},
+            'DIGLABEL': {
+                'a': [
+                    ('packet_id', 'S8'),
+                    # Read name of digital
+                    ('label', 'S16'),
+                    # 0=serial, 1=parallel
+                    ('mode', 'uint8'),
+                    ('unused', 'S7')]},
+            'NSASEXEV': {
+                'a': [
+                    ('packet_id', 'S8'),
+                    # Read frequency of periodic packet generation
+                    ('frequency', 'uint16'),
+                    # Read if digital input triggers events
+                    ('digital_input_config', 'uint8'),
+                    # Read if analog input triggers events
+                    ('analog_channel_1_config', 'uint8'),
+                    ('analog_channel_1_edge_detec_val', 'uint16'),
+                    ('analog_channel_2_config', 'uint8'),
+                    ('analog_channel_2_edge_detec_val', 'uint16'),
+                    ('analog_channel_3_config', 'uint8'),
+                    ('analog_channel_3_edge_detec_val', 'uint16'),
+                    ('analog_channel_4_config', 'uint8'),
+                    ('analog_channel_4_edge_detec_val', 'uint16'),
+                    ('analog_channel_5_config', 'uint8'),
+                    ('analog_channel_5_edge_detec_val', 'uint16'),
+                    ('unused', 'S6')]},
+            'VIDEOSYN': {
+                'a': [
+                    ('packet_id', 'S8'),
+                    ('video_source_id', 'uint16'),
+                    ('video_source', 'S16'),
+                    ('frame_rate', 'float32'),
+                    ('unused', 'S2')]},
+            'TRACKOBJ': {
+                'a': [
+                    ('packet_id', 'S8'),
+                    ('trackable_type', 'uint16'),
+                    ('trackable_id', 'uint16'),
+                    ('point_count', 'uint16'),
+                    ('video_source', 'S16'),
+                    ('unused', 'S2')]}}
+
+        return nev_ext_header_types
+
+    def __nev_data_masks(self, packet_ids):
+        """
+        Defines data masks for different .nev file specifications depending on
+        the given packet identifiers.
+        """
+        __nev_data_masks = {
+            'NonNeural': {
+                'a': (packet_ids == 0)},
+            'Spikes': {
+                # Version 2.1 & 2.2
+                'a': (0 < packet_ids) & (packet_ids <= 255),
+                # Version>=2.3
+                'b': (0 < packet_ids) & (packet_ids <= 2048)},
+            'Comments': {
+                'a': (packet_ids == 0xFFFF)},
+            'VideoSync': {
+                'a': (packet_ids == 0xFFFE)},
+            'TrackingEvents': {
+                'a': (packet_ids == 0xFFFD)},
+            'ButtonTrigger': {
+                'a': (packet_ids == 0xFFFC)},
+            'ConfigEvent': {
+                'a': (packet_ids == 0xFFFB)}}
+
+        return __nev_data_masks
+
+    def __nev_data_types(self, data_size):
+        """
+        Defines data types for different .nev file specifications depending on
+        the given packet identifiers.
+        """
+        __nev_data_types = {
+            'NonNeural': {
+                # Version 2.1 & 2.2
+                'a': [
+                    ('timestamp', 'uint32'),
+                    ('packet_id', 'uint16'),
+                    ('packet_insertion_reason', 'uint8'),
+                    ('reserved', 'uint8'),
+                    ('digital_input', 'uint16'),
+                    ('analog_input_channel_1', 'int16'),
+                    ('analog_input_channel_2', 'int16'),
+                    ('analog_input_channel_3', 'int16'),
+                    ('analog_input_channel_4', 'int16'),
+                    ('analog_input_channel_5', 'int16'),
+                    ('unused', 'S{0}'.format(data_size - 20))],
+                # Version>=2.3
+                'b': [
+                    ('timestamp', 'uint32'),
+                    ('packet_id', 'uint16'),
+                    ('packet_insertion_reason', 'uint8'),
+                    ('reserved', 'uint8'),
+                    ('digital_input', 'uint16'),
+                    ('unused', 'S{0}'.format(data_size - 10))]},
+            'Spikes': {
+                'a': [
+                    ('timestamp', 'uint32'),
+                    ('packet_id', 'uint16'),
+                    ('unit_class_nb', 'uint8'),
+                    ('reserved', 'uint8'),
+                    ('waveform', 'S{0}'.format(data_size - 8))]},
+            'Comments': {
+                'a': [
+                    ('timestamp', 'uint32'),
+                    ('packet_id', 'uint16'),
+                    ('char_set', 'uint8'),
+                    ('flag', 'uint8'),
+                    ('data', 'uint32'),
+                    ('comment', 'S{0}'.format(data_size - 12))]},
+            'VideoSync': {
+                'a': [
+                    ('timestamp', 'uint32'),
+                    ('packet_id', 'uint16'),
+                    ('video_file_nb', 'uint16'),
+                    ('video_frame_nb', 'uint32'),
+                    ('video_elapsed_time', 'uint32'),
+                    ('video_source_id', 'uint32'),
+                    ('unused', 'int8', (data_size - 20, ))]},
+            'TrackingEvents': {
+                'a': [
+                    ('timestamp', 'uint32'),
+                    ('packet_id', 'uint16'),
+                    ('parent_id', 'uint16'),
+                    ('node_id', 'uint16'),
+                    ('node_count', 'uint16'),
+                    ('point_count', 'uint16'),
+                    ('tracking_points', 'uint16', ((data_size - 14) / 2, ))]},
+            'ButtonTrigger': {
+                'a': [
+                    ('timestamp', 'uint32'),
+                    ('packet_id', 'uint16'),
+                    ('trigger_type', 'uint16'),
+                    ('unused', 'int8', (data_size - 8, ))]},
+            'ConfigEvent': {
+                'a': [
+                    ('timestamp', 'uint32'),
+                    ('packet_id', 'uint16'),
+                    ('config_change_type', 'uint16'),
+                    ('config_changed', 'S{0}'.format(data_size - 8))]}}
+
+        return __nev_data_types
+
+    def __nev_params(self, param_name):
+        """
+        Returns wanted nev parameter.
+        """
+        nev_parameters = {
+            'bytes_in_data_packets':
+                self.__nev_basic_header['bytes_in_data_packets'],
+            'rec_datetime': datetime.datetime(
+                year=self.__nev_basic_header['year'],
+                month=self.__nev_basic_header['month'],
+                day=self.__nev_basic_header['day'],
+                hour=self.__nev_basic_header['hour'],
+                minute=self.__nev_basic_header['minute'],
+                second=self.__nev_basic_header['second'],
+                microsecond=self.__nev_basic_header['millisecond']),
+            'max_res': self.__nev_basic_header['timestamp_resolution'],
+            'channel_ids': self.__nev_ext_header['NEUEVWAV']['electrode_id'],
+            'channel_labels': self.__channel_labels[self.__nev_spec](),
+            'event_unit': pq.CompoundUnit("1.0/{0} * s".format(
+                self.__nev_basic_header['timestamp_resolution'])),
+            'nb_units': dict(zip(
+                self.__nev_ext_header['NEUEVWAV']['electrode_id'],
+                self.__nev_ext_header['NEUEVWAV']['nb_sorted_units'])),
+            'data_size': self.__nev_basic_header['bytes_in_data_packets'],
+            'waveform_size': self.__waveform_size[self.__nev_spec](),
+            'waveform_dtypes': self.__get_waveforms_dtype(),
+            'waveform_sampling_rate':
+                self.__nev_basic_header['sample_resolution'] * pq.Hz,
+            'waveform_time_unit': pq.CompoundUnit("1.0/{0} * s".format(
+                self.__nev_basic_header['sample_resolution'])),
+            'waveform_unit': pq.uV}
+
+        return nev_parameters[param_name]
+
+    def __get_file_size(self, filename):
+        """
+        Returns the file size in bytes for the given file.
+        """
+        filebuf = open(filename, 'rb')
+        filebuf.seek(0, os.SEEK_END)
+        file_size = filebuf.tell()
+        filebuf.close()
+
+        return file_size
+
+    def __get_min_time(self):
+        """
+        Returns the smallest time that can be determined from the recording for
+        use as the lower bound n in an interval [n,m).
+        """
+        tp = []
+        if self._avail_files['nev']:
+            tp.extend(self.__get_nev_rec_times()[0])
+        for nsx_i in self._avail_nsx:
+            tp.extend(self.__nsx_rec_times[self.__nsx_spec[nsx_i]](nsx_i)[0])
+
+        return min(tp)
+
+    def __get_max_time(self):
+        """
+        Returns the largest time that can be determined from the recording for
+        use as the upper bound m in an interval [n,m).
+        """
+        tp = []
+        if self._avail_files['nev']:
+            tp.extend(self.__get_nev_rec_times()[1])
+        for nsx_i in self._avail_nsx:
+            tp.extend(self.__nsx_rec_times[self.__nsx_spec[nsx_i]](nsx_i)[1])
+
+        return max(tp)
+
+    def __get_nev_rec_times(self):
+        """
+        Extracts minimum and maximum time points from a nev file.
+        """
+        filename = '.'.join([self._filenames['nev'], 'nev'])
+
+        dt = [('timestamp', 'uint32')]
+        offset = \
+            self.__get_file_size(filename) - \
+            self.__nev_params('bytes_in_data_packets')
+        last_data_packet = np.memmap(filename, offset=offset, dtype=dt)[0]
+
+        n_starts = [0 * self.__nev_params('event_unit')]
+        n_stops = [
+            last_data_packet['timestamp'] * self.__nev_params('event_unit')]
+
+        return n_starts, n_stops
+
+    def __get_nsx_rec_times_variant_a(self, nsx_nb):
+        """
+        Extracts minimum and maximum time points from a 2.1 nsx file.
+        """
+        filename = '.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb])
+
+        t_unit = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'time_unit', nsx_nb)
+        highest_res = self.__nev_params('event_unit')
+
+        bytes_in_headers = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'bytes_in_headers', nsx_nb)
+        nb_data_points = \
+            (self.__get_file_size(filename) - bytes_in_headers) / \
+            (2 * self.__nsx_basic_header[nsx_nb]['channel_count']) - 1
+
+        # add n_start
+        n_starts = [(0 * t_unit).rescale(highest_res)]
+        # add n_stop
+        n_stops = [(nb_data_points * t_unit).rescale(highest_res)]
+
+        return n_starts, n_stops
+
+    def __get_nsx_rec_times_variant_b(self, nsx_nb):
+        """
+        Extracts minimum and maximum time points from a 2.2 or 2.3 nsx file.
+        """
+        t_unit = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'time_unit', nsx_nb)
+        highest_res = self.__nev_params('event_unit')
+
+        n_starts = []
+        n_stops = []
+        # add n-start and n_stop for all data blocks
+        for data_bl in self.__nsx_data_header[nsx_nb].keys():
+            ts0 = self.__nsx_data_header[nsx_nb][data_bl]['timestamp']
+            nbdp = self.__nsx_data_header[nsx_nb][data_bl]['nb_data_points']
+
+            # add n_start
+            start = ts0 * t_unit
+            n_starts.append(start.rescale(highest_res))
+            # add n_stop
+            stop = start + nbdp * t_unit
+            n_stops.append(stop.rescale(highest_res))
+
+        return sorted(n_starts), sorted(n_stops)
+
+    def __get_waveforms_dtype(self):
+        """
+        Extracts the actual waveform dtype set for each channel.
+        """
+        # Blackrock code giving the approiate dtype
+        conv = {0: 'int8', 1: 'int8', 2: 'int16', 4: 'int32'}
+
+        # get all electrode ids from nev ext header
+        all_el_ids = self.__nev_ext_header['NEUEVWAV']['electrode_id']
+
+        # get the dtype of waveform (this is stupidly complicated)
+        if self.__is_set(
+                np.array(self.__nev_basic_header['additionnal_flags']), 0):
+            dtype_waveforms = dict((k, 'int16') for k in all_el_ids)
+        else:
+            # extract bytes per waveform
+            waveform_bytes = \
+                self.__nev_ext_header['NEUEVWAV']['bytes_per_waveform']
+            # extract dtype for waveforms fro each electrode
+            dtype_waveforms = dict(zip(all_el_ids, conv[waveform_bytes]))
+
+        return dtype_waveforms
+
+    def __get_channel_labels_variant_a(self):
+        """
+        Returns labels for all channels for file spec 2.1
+        """
+        elids = self.__nev_ext_header['NEUEVWAV']['electrode_id']
+
+        return dict([(i, str(i)) for i in elids])
+
+    def __get_channel_labels_variant_b(self):
+        """
+        Returns labels for all channels for file spec 2.2 and 2.3
+        """
+        elids = self.__nev_ext_header['NEUEVWAV']['electrode_id']
+        labels = self.__nev_ext_header['NEUEVLBL']['label']
+
+        return dict(zip(elids, labels))
+
+    def __get_waveform_size_variant_a(self):
+        """
+        Returns wavform sizes for all channels for file spec 2.1 and 2.2
+        """
+        wf_dtypes = self.__get_waveforms_dtype()
+        nb_bytes_wf = self.__nev_basic_header['bytes_in_data_packets'] - 8
+
+        wf_sizes = dict([
+            (ch, nb_bytes_wf / np.dtype(dt).itemsize) for ch, dt in
+            wf_dtypes.items()])
+
+        return wf_sizes
+
+    def __get_waveform_size_variant_b(self):
+        """
+        Returns wavform sizes for all channels for file spec 2.3
+        """
+        elids = self.__nev_ext_header['NEUEVWAV']['electrode_id']
+        spike_widths = self.__nev_ext_header['NEUEVWAV']['spike_width']
+
+        return dict(zip(elids, spike_widths))
+
+    def __get_left_sweep_waveforms(self):
+        """
+        Returns left sweep of waveforms for each channel. Left sweep is defined
+        as the time from the beginning of the waveform to the trigger time of
+        the corresponding spike.
+        """
+        # TODO: not sure if this is the actual setting for Blackrock
+        wf_t_unit = self.__nev_params('waveform_time_unit')
+        all_ch = self.__nev_params('channel_ids')
+        wf_size = self.__nev_params('waveform_size')
+
+        wf_left_sweep = dict(
+            [(ch, (wfs / 2) * wf_t_unit) for ch, wfs in zip(all_ch, wf_size)])
+
+        return wf_left_sweep
+
+    def __get_nsx_param_variant_a(self, param_name, nsx_nb):
+        """
+        Returns parameter (param_name) for a given nsx (nsx_nb) for file spec
+        2.1.
+        """
+        # (several are assumed from Blackrock manual)
+        nsx_parameters = {
+            'units': np.array(
+                ['mV'] * self.__nsx_basic_header[nsx_nb]['channel_count']),
+            'min_analog_val': np.array(
+                [-5000] * self.__nsx_basic_header[nsx_nb]['channel_count']),
+            'max_analog_val': np.array(
+                [5000] * self.__nsx_basic_header[nsx_nb]['channel_count']),
+            'min_digital_val': np.array(
+                [-8192] * self.__nsx_basic_header[nsx_nb]['channel_count']),
+            'max_digital_val': np.array(
+                [8192] * self.__nsx_basic_header[nsx_nb]['channel_count']),
+            'timestamp_resolution': 30000,
+            'bytes_in_headers':
+                self.__nsx_basic_header[nsx_nb].dtype.itemsize +
+                self.__nsx_ext_header[nsx_nb].dtype.itemsize,
+            'sampling_rate':
+                30000 / self.__nsx_basic_header[nsx_nb]['period'] * pq.Hz,
+            'time_unit': pq.CompoundUnit("1.0/{0}*s".format(
+                30000 / self.__nsx_basic_header[nsx_nb]['period']))}
+
+        return nsx_parameters[param_name]
+
+    def __get_nsx_param_variant_b(self, param_name, nsx_nb):
+        """
+        Returns parameter (param_name) for a given nsx (nsx_nb) for file spec
+        2.2 and 2.3.
+        """
+        nsx_parameters = {
+            'units':
+                self.__nsx_ext_header[nsx_nb]['units'],
+            'min_analog_val':
+                self.__nsx_ext_header[nsx_nb]['min_analog_val'],
+            'max_analog_val':
+                self.__nsx_ext_header[nsx_nb]['max_analog_val'],
+            'min_digital_val':
+                self.__nsx_ext_header[nsx_nb]['min_digital_val'],
+            'max_digital_val':
+                self.__nsx_ext_header[nsx_nb]['max_digital_val'],
+            'timestamp_resolution':
+                self.__nsx_basic_header[nsx_nb]['timestamp_resolution'],
+            'bytes_in_headers':
+                self.__nsx_basic_header[nsx_nb]['bytes_in_headers'],
+            'sampling_rate':
+                self.__nsx_basic_header[nsx_nb]['timestamp_resolution'] /
+                self.__nsx_basic_header[nsx_nb]['period'] * pq.Hz,
+            'time_unit': pq.CompoundUnit("1.0/{0}*s".format(
+                self.__nsx_basic_header[nsx_nb]['timestamp_resolution'] /
+                self.__nsx_basic_header[nsx_nb]['period']))}
+
+        return nsx_parameters[param_name]
+
+    def __get_nsx_databl_param_variant_a(
+            self, param_name, nsx_nb, n_start=None):
+        """
+        Returns data block parameter (param_name) for a given nsx (nsx_nb) for
+        file spec 2.1. Arg 'n_start' should not be specified! It is only set
+        for compatibility reasons with higher file spec.
+        """
+        filename = '.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb])
+
+        t_starts, t_stops = \
+            self.__nsx_rec_times[self.__nsx_spec[nsx_nb]](nsx_nb)
+
+        bytes_in_headers = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'bytes_in_headers', nsx_nb)
+
+        # extract parameters from nsx basic extended and data header
+        data_parameters = {
+            'nb_data_points':
+                (self.__get_file_size(filename) - bytes_in_headers) /
+                (2 * self.__nsx_basic_header[nsx_nb]['channel_count']) - 1,
+            'databl_idx': 1,
+            'databl_t_start': t_starts[0],
+            'databl_t_stop': t_stops[0]}
+
+        return data_parameters[param_name]
+
+    def __get_nsx_databl_param_variant_b(self, param_name, nsx_nb, n_start):
+        """
+        Returns data block parameter (param_name) for a given nsx (nsx_nb) with
+        a wanted n_start for file spec 2.2 and 2.3.
+        """
+        t_starts, t_stops = \
+            self.__nsx_rec_times[self.__nsx_spec[nsx_nb]](nsx_nb)
+
+        # data header
+        for d_bl in self.__nsx_data_header[nsx_nb].keys():
+            if t_starts[d_bl - 1] <= n_start < t_stops[d_bl - 1]:
+                # from "data header" with corresponding t_start and t_stop
+                data_parameters = {
+                    'nb_data_points':
+                        self.__nsx_data_header[nsx_nb][d_bl]['nb_data_points'],
+                    'databl_idx': d_bl,
+                    'databl_t_start': t_starts[d_bl - 1],
+                    'databl_t_stop': t_stops[d_bl - 1]}
+
+        return data_parameters[param_name]
+
+    def __get_nonneural_evtypes_variant_a(self, data):
+        """
+        Defines event types and the necessary parameters to extract them from
+        a 2.1 and 2.2 nev file.
+        """
+        # TODO: add annotations of nev ext header (NSASEXEX) to event types
+
+        # digital events
+        event_types = {
+            'digital_input_port': {
+                'name': 'digital_input_port',
+                'field': 'digital_input',
+                'mask': self.__is_set(data['packet_insertion_reason'], 0),
+                'desc': "Events of the digital input port"},
+            'serial_input_port': {
+                'name': 'serial_input_port',
+                'field': 'digital_input',
+                'mask':
+                    self.__is_set(data['packet_insertion_reason'], 0) &
+                    self.__is_set(data['packet_insertion_reason'], 7),
+                'desc': "Events of the serial input port"}}
+
+        # analog input events via threshold crossings
+        for ch in range(5):
+            event_types.update({
+                'analog_input_channel_{0}'.format(ch + 1): {
+                    'name': 'analog_input_channel_{0}'.format(ch + 1),
+                    'field': 'analog_input_channel_{0}'.format(ch + 1),
+                    'mask': self.__is_set(
+                        data['packet_insertion_reason'], ch + 1),
+                    'desc': "Values of analog input channel {0} in mV "
+                            "(+/- 5000)".format(ch + 1)}})
+
+        # TODO: define field and desc
+        event_types.update({
+            'periodic_sampling_events': {
+                'name': 'periodic_sampling_events',
+                'field': 'digital_input',
+                'mask': self.__is_set(data['packet_insertion_reason'], 6),
+                'desc': 'Periodic sampling event of a certain frequency'}})
+
+        return event_types
+
+    def __get_nonneural_evtypes_variant_b(self, data):
+        """
+        Defines event types and the necessary parameters to extract them from
+        a 2.3 nev file.
+        """
+        # digital events
+        event_types = {
+            'digital_input_port': {
+                'name': 'digital_input_port',
+                'field': 'digital_input',
+                'mask': self.__is_set(data['packet_insertion_reason'], 0),
+                'desc': "Events of the digital input port"},
+            'serial_input_port': {
+                'name': 'serial_input_port',
+                'field': 'digital_input',
+                'mask':
+                    self.__is_set(data['packet_insertion_reason'], 0) &
+                    self.__is_set(data['packet_insertion_reason'], 7),
+                'desc': "Events of the serial input port"}}
+
+        return event_types
+
+    def __get_unit_classification(self, un_id):
+        """
+        Returns the Blackrock unit classification of an online spike sorting
+        for the given unit id (un_id).
+        """
+        # Blackrock unit classification
+        if un_id == 0:
+            return 'unclassified'
+        elif 1 <= un_id <= 16:
+            return '{0}'.format(un_id)
+        elif 17 <= un_id <= 244:
+            return 'unused'
+        elif un_id == 255:
+            return 'noise'
+        else:
+            raise ValueError("Unit id {0} cannot be classified".format(un_id))
+
+    def __is_set(self, flag, pos):
+        """
+        Checks if bit is set at the given position for flag. If flag is an
+        array, an array will be returned.
+        """
+        return flag & (1 << pos) > 0
+
+    def __transform_nsx_to_load(self, nsx_to_load):
+        """
+        Transforms the input argument nsx_to_load to a list of integers.
+        """
+        if hasattr(nsx_to_load, "__len__") and len(nsx_to_load) == 0:
+            nsx_to_load = None
+        if isinstance(nsx_to_load, int):
+            nsx_to_load = [nsx_to_load]
+        if isinstance(nsx_to_load, str):
+            if nsx_to_load.lower() == 'none':
+                nsx_to_load = None
+            elif nsx_to_load.lower() == 'all':
+                nsx_to_load = self._avail_nsx
+            else:
+                raise ValueError("Invalid specification of nsx_to_load.")
+
+        if nsx_to_load:
+            for nsx_nb in nsx_to_load:
+                if not self._avail_files['ns' + str(nsx_nb)]:
+                    raise ValueError("ns%i is not available" % nsx_nb)
+
+        return nsx_to_load
+
+    def __transform_channels(self, channels, nsx_to_load):
+        """
+        Transforms the input argument channels to a list of integers.
+        """
+        all_channels = []
+        nsx_to_load = self.__transform_nsx_to_load(nsx_to_load)
+        if not isinstance(nsx_to_load, types.NoneType):
+            for nsx_nb in nsx_to_load:
+                all_channels.extend(
+                    self.__nsx_ext_header[nsx_nb]['electrode_id'])
+        else:
+            all_channels.extend(
+                self.__nev_ext_header['NEUEVWAV']['electrode_id'])
+        all_channels = np.unique(all_channels).tolist()
+
+        if hasattr(channels, "__len__") and len(channels) == 0:
+            channels = None
+        if isinstance(channels, int):
+            channels = [channels]
+        if isinstance(channels, str):
+            if channels.lower() == 'none':
+                channels = None
+            elif channels.lower() == 'all':
+                channels = all_channels
+            else:
+                raise ValueError("Invalid channel specification.")
+
+        if channels:
+            if len(set(all_channels) & set(channels)) < len(channels):
+                raise ValueError("Unknown channel id in channels.")
+
+        return channels
+
+    def __transform_units(self, units, channels):
+        """
+        Transforms the input argument nsx_to_load to a dictionary, where keys
+        (channels) are int, and values (units) are lists of integers.
+        """
+        if isinstance(units, dict):
+            for ch, u in units.items():
+                if ch not in channels:
+                    self._print_verbose(
+                        "Units contain a channel id which is not listed in "
+                        "channels")
+                if isinstance(u, int):
+                    units[ch] = [u]
+                if hasattr(u, '__len__') and len(u) == 0:
+                    units[ch] = None
+                if isinstance(u, str):
+                    if u.lower() == 'none':
+                        units[ch] = None
+                    elif u.lower() == 'all':
+                        units[ch] = range(256)
+                    else:
+                        raise ValueError("Invalid unit specification.")
+        else:
+            if hasattr(units, "__len__") and len(units) == 0:
+                units = None
+            if isinstance(units, str):
+                if units.lower() == 'none':
+                    units = None
+                elif units.lower() == 'all':
+                    units = range(256)
+                else:
+                    raise ValueError("Invalid unit specification.")
+            if isinstance(units, int):
+                units = [units]
+
+            if isinstance(channels, types.NoneType) \
+                    and not isinstance(units, types.NoneType):
+                raise ValueError(
+                    'At least one channel needs to be loaded to load units')
+
+            if units:
+                units = dict(zip(channels, [units] * len(channels)))
+
+        return units
+
+    def __transform_times(self, n, default_n):
+        """
+        Transforms the input argument n_start or n_stop (n) to a list of
+        quantities. In case n is None, it is set to a default value provided by
+        the given function (default_n).
+        """
+        highest_res = self.__nev_params('event_unit')
+
+        if isinstance(n, pq.Quantity):
+            n = [n.rescale(highest_res)]
+        elif hasattr(n, "__len__"):
+            n = [tp.rescale(highest_res) if not isinstance(tp, types.NoneType)
+                 else default_n for tp in n]
+        elif isinstance(n, types.NoneType):
+            n = [default_n]
+        else:
+            raise ValueError('Invalid specification of n_start/n_stop.')
+
+        return n
+
+    def __merge_time_ranges(
+            self, user_n_starts, user_n_stops, nsx_to_load):
+        """
+        Merges after a validation the user specified n_starts and n_stops with
+        the intrinsicly given n_starts and n_stops (from e.g, recording pauses)
+        of the file set.
+
+        Final n_starts and n_stops are chosen, so that the time range of each
+        resulting segment is set to the best meaningful maximum. This means
+        that the duration of the signals stored in the segments might be
+        smaller than the actually set duration of the segment.
+        """
+        self._print_verbose("######## INFO TIME SETTINGS ########")
+
+        # define the higest time resolution
+        # (for accurate manipulations of the time settings)
+        highest_res = self.__nev_params('event_unit')
+        user_n_starts = self.__transform_times(
+            user_n_starts, self.__get_min_time())
+        user_n_stops = self.__transform_times(
+            user_n_stops, self.__get_max_time())
+
+        # check if user provided as many n_starts as n_stops
+        if len(user_n_starts) != len(user_n_stops):
+            raise ValueError("n_starts and n_stops must be of equal length")
+
+        # if necessary reset max n_stop to max time of file set
+        if user_n_starts[0] < self.__get_min_time():
+            user_n_starts[0] = self.__get_min_time()
+            self._print_verbose(
+                "First entry of n_start is smaller than min time of the file "
+                "set: n_start[0] set to min time of file set")
+        if user_n_starts[-1] > self.__get_max_time():
+            user_n_starts = user_n_starts[:-1]
+            user_n_stops = user_n_stops[:-1]
+            self._print_verbose(
+                "Last entry of n_start is larger than max time of the file "
+                "set: last n_start and n_stop entry are excluded")
+        if user_n_stops[-1] > self.__get_max_time():
+            user_n_stops[-1] = self.__get_max_time()
+            self._print_verbose(
+                "Last entry of n_stop is larger than max time of the file "
+                "set: n_stop[-1] set to max time of file set")
+
+        # get intrinsic time settings of nsx files (incl. rec pauses)
+        n_starts_files = []
+        n_stops_files = []
+        if not isinstance(nsx_to_load, types.NoneType):
+            for nsx_nb in nsx_to_load:
+                start_stop = \
+                    self.__nsx_rec_times[self.__nsx_spec[nsx_nb]](nsx_nb)
+                n_starts_files.append(start_stop[0])
+                n_stops_files.append(start_stop[1])
+
+        # reducing n_starts from wanted nsx files to minima
+        # (keep recording pause if it occurs)
+        if len(n_starts_files) > 0:
+            if np.shape(n_starts_files)[1] > 1:
+                n_starts_files = [
+                    tp * highest_res for tp in np.min(n_starts_files, axis=1)]
+            else:
+                n_starts_files = [
+                    tp * highest_res for tp in np.min(n_starts_files, axis=0)]
+
+        # reducing n_starts from wanted nsx files to maxima
+        # (keep recording pause if it occurs)
+        if len(n_stops_files) > 0:
+            if np.shape(n_stops_files)[1] > 1:
+                n_stops_files = [
+                    tp * highest_res for tp in np.max(n_stops_files, axis=1)]
+            else:
+                n_stops_files = [
+                    tp * highest_res for tp in np.max(n_stops_files, axis=0)]
+
+        # merge user time settings with intrinsic nsx time settings
+        n_starts = []
+        n_stops = []
+        for start, stop in zip(user_n_starts, user_n_stops):
+            # check if start and stop of user create a positive time interval
+            if not start < stop:
+                raise ValueError(
+                    "t(i) in n_starts has to be smaller than t(i) in n_stops")
+
+            # Reduce n_starts_files to given intervals of user & add start
+            if len(n_starts_files) > 0:
+                mask = (n_starts_files > start) & (n_starts_files < stop)
+                red_n_starts_files = np.array(n_starts_files)[mask]
+                merged_n_starts = [start] + [
+                    tp * highest_res for tp in red_n_starts_files]
+            else:
+                merged_n_starts = [start]
+
+            # Reduce n_stops_files to given intervals of user & add stop
+            if len(n_stops_files) > 0:
+                mask = (n_stops_files > start) & (n_stops_files < stop)
+                red_n_stops_files = np.array(n_stops_files)[mask]
+                merged_n_stops = [
+                    tp * highest_res for tp in red_n_stops_files] + [stop]
+            else:
+                merged_n_stops = [stop]
+            # Define combined user and file n_starts and n_stops
+            # case one:
+            if len(merged_n_starts) == len(merged_n_stops):
+                if len(merged_n_starts) + len(merged_n_stops) == 2:
+                    n_starts.extend(merged_n_starts)
+                    n_stops.extend(merged_n_stops)
+                if len(merged_n_starts) + len(merged_n_stops) > 2:
+                    merged_n_starts.remove(merged_n_starts[1])
+                    n_starts.extend([merged_n_starts])
+                    merged_n_stops.remove(merged_n_stops[-2])
+                    n_stops.extend(merged_n_stops)
+            # case two:
+            elif len(merged_n_starts) < len(merged_n_stops):
+                n_starts.extend(merged_n_starts)
+                merged_n_stops.remove(merged_n_stops[-2])
+                n_stops.extend(merged_n_stops)
+            # case three:
+            elif len(merged_n_starts) > len(merged_n_stops):
+                merged_n_starts.remove(merged_n_starts[1])
+                n_starts.extend(merged_n_starts)
+                n_stops.extend(merged_n_stops)
+
+        if len(n_starts) > user_n_starts and len(n_stops) > user_n_stops:
+            self._print_verbose(
+                "Additional recording pauses were detected. There will be "
+                "more segments than the user expects.")
+
+        return n_starts, n_stops
+
+    def __read_event(self, n_start, n_stop, data, ev_dict, lazy=False):
+        """
+        Creates an event for non-neural experimental events in nev data.
+        """
+        event_unit = self.__nev_params('event_unit')
+
+        if lazy:
+            times = []
+            labels = np.array([], dtype='S')
+        else:
+            times = data['timestamp'][ev_dict['mask']] * event_unit
+            labels = data[ev_dict['field']][ev_dict['mask']].astype(str)
+
+        # mask for given time interval
+        mask = (times >= n_start) & (times < n_stop)
+        if np.sum(mask) > 0:
+            ev = Event(
+                times=times[mask].astype(float),
+                labels=labels[mask],
+                name=ev_dict['name'],
+                description=ev_dict['desc'])
+            if lazy:
+                ev.lazy_shape = np.sum(mask)
+        else:
+            ev = None
+
+        return ev
+
+    def __read_spiketrain(
+            self, n_start, n_stop, spikes, channel_id, unit_id,
+            load_waveforms=False, lazy=False):
+        """
+        Creates spiketrains for Spikes in nev data.
+        """
+        event_unit = self.__nev_params('event_unit')
+
+        # define a name for spiketrain
+        # (unique identifier: 1000 * elid + unit_nb)
+        name = "Unit {0}".format(1000 * channel_id + unit_id)
+        # define description for spiketrain
+        desc = 'SpikeTrain from channel: {0}, unit: {1}'.format(
+            channel_id, self.__get_unit_classification(unit_id))
+
+        # get spike times for given time interval
+        times = spikes['timestamp'] * event_unit
+        mask = (times >= n_start) & (times < n_stop)
+        times = times[mask].astype(float)
+
+        st = SpikeTrain(
+            times=times,
+            name=name,
+            description=desc,
+            file_origin='.'.join([self._filenames['nev'], 'nev']),
+            t_start=n_start,
+            t_stop=n_stop)
+
+        if lazy:
+            st.lazy_shape = np.shape(times)
+            st.times = []
+
+        # load waveforms if wanted
+        if load_waveforms and not lazy:
+            wf_dtype = self.__nev_params('waveform_dtypes')[channel_id]
+            wf_size = self.__nev_params('waveform_size')[channel_id]
+
+            waveforms = spikes['waveform'].flatten().view(wf_dtype)
+            waveforms = waveforms.reshape(spikes.size, 1, wf_size)
+
+            st.waveforms = waveforms[mask] * self.__nev_params('waveform_unit')
+            st.sampling_rate = self.__nev_params('waveform_sampling_rate')
+            st.left_sweep = self.__get_left_sweep_waveforms()
+
+        # add additional annotations
+        st.annotate(channel_index=int(channel_id))
+        st.annotate(unit_id=int(unit_id))
+
+        return st
+
+    def __read_analogsignal(
+            self, n_start, n_stop, signal, channel_id, nsx_nb, lazy=False):
+        """
+        Creates analogsignal for signal of channel in nsx data.
+        """
+        # get parameters
+        sampling_rate = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'sampling_rate', nsx_nb)
+        nsx_time_unit = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'time_unit', nsx_nb)
+        max_ana = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'max_analog_val', nsx_nb)
+        min_ana = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'min_analog_val', nsx_nb)
+        max_dig = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'max_digital_val', nsx_nb)
+        min_dig = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'min_digital_val', nsx_nb)
+        units = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+            'units', nsx_nb)
+
+        labels = self.__nev_params('channel_labels')
+
+        dbl_idx = self.__nsx_databl_param[self.__nsx_spec[nsx_nb]](
+            'databl_idx', nsx_nb, n_start)
+        t_start = self.__nsx_databl_param[self.__nsx_spec[nsx_nb]](
+            'databl_t_start', nsx_nb, n_start)
+        t_stop = self.__nsx_databl_param[self.__nsx_spec[nsx_nb]](
+            'databl_t_stop', nsx_nb, n_start)
+
+        elids_nsx = list(self.__nsx_ext_header[nsx_nb]['electrode_id'])
+        if channel_id in elids_nsx:
+            ch_idx = elids_nsx.index(channel_id)
+        else:
+            return None
+
+        description = \
+            "AnalogSignal from channel: {0}, label: {1}, nsx: {2}".format(
+                channel_id, labels[channel_id], nsx_nb)
+
+        data_times = np.arange(
+            t_start.item(), t_stop.item(),
+            self.__nsx_basic_header[nsx_nb]['period']) * t_start.units
+        mask = (data_times >= n_start) & (data_times < n_stop)
+        data_times = data_times[mask].astype(float)
+
+        sig_ch = signal[dbl_idx][:, ch_idx][mask].astype(float)
+
+        # transform dig value to pysical value
+        sym_ana = (max_ana[ch_idx] == -min_ana[ch_idx])
+        sym_dig = (max_dig[ch_idx] == -min_dig[ch_idx])
+        if sym_ana and sym_dig:
+            sig_ch *= float(max_ana[ch_idx]) / float(max_dig[ch_idx])
+        else:
+            # general case
+            sig_ch -= min_dig[ch_idx]
+            sig_ch *= float(max_ana[ch_idx] - min_ana) / \
+                float(max_dig[ch_idx] - min_dig)
+            sig_ch += float(min_ana[ch_idx])
+
+        anasig = AnalogSignal(
+            signal=pq.Quantity(sig_ch, units[ch_idx], copy=False),
+            sampling_rate=sampling_rate,
+            t_start=data_times[0].rescale(nsx_time_unit),
+            name=labels[channel_id],
+            description=description,
+            channel_index=channel_id,
+            file_origin='.'.join([self._filenames['nsx'], 'ns%i' % nsx_nb]))
+
+        anasig.annotate(nsx=nsx_nb)
+
+        if lazy:
+            anasig.lazy_shape = np.shape(sig_ch)
+            anasig.signal = []
+
+        return anasig
+
+    def __read_unit(self, unit_id, channel_id):
+        """
+        Creates unit with unit id for given channel id.
+        """
+        # define a name for spiketrain
+        # (unique identifier: 1000 * elid + unit_nb)
+        name = "Unit {0}".format(1000 * channel_id + unit_id)
+        # define description for spiketrain
+        desc = 'Unit from channel: {0}, id: {1}'.format(
+            channel_id, self.__get_unit_classification(unit_id))
+
+        un = Unit(
+            name=name,
+            description=desc,
+            file_origin='.'.join([self._filenames['nev'], 'nev']))
+
+        # add additional annotations
+        un.annotate(channel_index=int(channel_id))
+        un.annotate(unit_id=int(unit_id))
+
+        return un
+
+    def __read_recordingchannelgroup(
+            self, channels, index=None, units=None, cascade=True):
+        """
+        Returns a neo.core.recordingchannelgroup.RecordingChannelGroup with the
+        given index for the given channels containing a neo.core.unit.Unit
+        object list of the given units.
+        """
+        # Arg: channels
+        channels = self.__transform_channels(channels, nsx_to_load=[])
+        # Arg: units
+        units = self.__transform_units(units, channels)
+
+        if isinstance(channels, types.NoneType):
+            self._print_verbose("No channel is specified, therefore no "
+                                "recordingchannelgroup is loaded.")
+            return None
+
+        rcg = RecordingChannelGroup(
+            channel_indexes=np.array(channels),
+            file_origin=self.filename)
+
+        if not isinstance(index, types.NoneType):
+            rcg.index = index
+            rcg.name = "RecordingChannelGroup {0}".format(rcg.index)
+        else:
+            rcg.name = "RecordingChannelGroup"
+
+        if self._avail_files['nev']:
+            rcg.channel_names = [
+                self.__nev_params('channel_labels')[i] for i in channels]
+
+        rcg.description = \
+            "Container for units and groups analogsignals across segments."
+
         if not cascade:
-            return bl
-        
-        seg = self.read_segment(self.filename,lazy=lazy, cascade=cascade,
-                            load_waveforms = load_waveforms)
-        bl.segments.append(seg)
+            return rcg
 
-        # This creates RCG for attaching Units
-        for st in seg.spiketrains:
-            channel_id = st.annotations['channel_id']
-            index = None
-            for sig in seg.analogsignals:
-                if channel_id in sig.recordingchannelgroup.channel_ids:
-                    i = np.where(sig.recordingchannelgroup.channel_ids==channel_id)[0][0]
-                    index = sig.channel_indexes[i]
-                    break
-            if index is not None:
-                rcg = RecordingChannelGroup(name = 'Group {0}'.format(channel_id),
-                                            channel_indexes=np.array([index]),
-                                            channel_ids=np.array([channel_id]))
-                unit = Unit(name=st.name)
-                unit.spiketrains.append(st)
-                rcg.units.append(unit)
-                bl.recordingchannelgroups.append(rcg)
+        if self._avail_files['nev']:
+            # read nev data
+            nev_data = self.__nev_data_reader[self.__nev_spec]()
 
-        bl.create_many_to_one_relationship()
-        
-        return bl
+            if not isinstance(units, types.NoneType):
+                for ch_id in units.keys():
+                    # extract first data for channel
+                    ch_mask = (nev_data['Spikes']['packet_id'] == ch_id)
+                    data_ch = nev_data['Spikes'][ch_mask]
+                    if not isinstance(units[ch_id], types.NoneType):
+                        for un_id in units[ch_id]:
+                            if un_id in np.unique(data_ch['unit_class_nb']):
 
-    def read_segment(self, n_start=None, n_stop=None,
-                load_waveforms = False, nsx_num = None,
-                lazy=False, cascade=True):
-        """Reads one Segment.
+                                un = self.__read_unit(ch_id, un_id)
 
-        Arguments:
-            n_start : time in samples that the Segment begins
-            n_stop : time in samples that the Segment ends
+                                rcg.units.append(un)
 
-        Python indexing is used, so n_stop is not inclusive.
+        rcg.create_many_to_one_relationship()
 
-        Returns a Segment object containing the data.
+        return rcg
+
+    def read_segment(
+            self, n_start, n_stop, name=None, description=None, index=None,
+            nsx_to_load='none', channels='none', units='none',
+            load_waveforms=False, load_events=False, lazy=False, cascade=True):
         """
-        
+        Returns an annotated neo.core.segment.Segment.
+
+        Args:
+            n_start (Quantity):
+                Start time of maximum time range of signals contained in this
+                segment.
+            n_stop (Quantity):
+                Stop time of maximum time range of signals contained in this
+                segment.
+            name (None, string):
+                If None, name is set to default, otherwise it is set to user
+                input.
+            description (None, string):
+                If None, description is set to default, otherwise it is set to
+                user input.
+            index (None, int):
+                If not None, index of segment is set to user index.
+            nsx_to_load (int, list, str):
+                ID(s) of nsx file(s) from which to load data, e.g., if set to
+                5 only data from the ns5 file are loaded. If 'none' or empty
+                list, no nsx files and therefore no analog signals are loaded.
+                If 'all', data from all available nsx are loaded.
+            channels (int, list, str):
+                Channel id(s) from which to load data. If 'none' or empty list,
+                no channels and therefore no analog signal or spiketrains are
+                loaded. If 'all', all available channels are loaded.
+            units (int, list, str, dict):
+                ID(s) of unit(s) to load. If 'none' or empty list, no units and
+                therefore no spiketrains are loaded. If 'all', all available
+                units are loaded. If dict, the above can be specified
+                individually for each channel (keys), e.g. {1: 5, 2: 'all'}
+                loads unit 5 from channel 1 and all units from channel 2.
+            load_waveforms (boolean):
+                If True, waveforms are attached to all loaded spiketrains.
+            load_events (boolean):
+                If True, all recorded events are loaded.
+            lazy (boolean):
+                If True, only the shape of the data is loaded.
+            cascade (boolean):
+                If True, only the segment without children is returned.
+
+        Returns (neo.segment.Segment):
+            Annotations:
+                t_min (Quantity):
+                    Minimum time point possible for signals in segment
+                    (corresponds to n_start).
+                t_max (Quantity):
+                    Maximum time point possible for signals in segment
+                    (corresponds to n_stop).
+        """
+        self._print_verbose("######## INFO SEGMENT {0} ########".format(index))
+        self._print_verbose("n_start: {0}".format(n_start.rescale('s')))
+        self._print_verbose("n_stop: {0}".format(n_stop.rescale('s')))
+        # Make sure that input args are transformed into correct instances
+        # Arg: nsx_to_load
+        nsx_to_load = self.__transform_nsx_to_load(nsx_to_load)
+        # Arg: channels
+        channels = self.__transform_channels(channels, nsx_to_load)
+        # Arg: units
+        units = self.__transform_units(units, channels)
+
         seg = Segment(file_origin=self.filename)
+
+        # set user defined annotations if they were provided
+        if isinstance(index, types.NoneType):
+            seg.index = 0
+        else:
+            seg.index = index
+        if isinstance(name, types.NoneType):
+            seg.name = "Segment {0}".format(seg.index)
+        else:
+            seg.name = name
+        if isinstance(description, types.NoneType):
+            seg.description = "Segment containing data from t_min to t_max."
+        else:
+            seg.description = description
+
         if not cascade:
             return seg
 
-        filename_sif = self.filename + '.sif'
-        if os.path.exists(filename_sif):
-            sif_header = self.read_sif(filename_sif)
-        
-        for i in range(1,10):
-            if nsx_num is not None and nsx_num!=i: continue
-            filename_nsx = self.filename + '.ns'+str(i)
-            if os.path.exists(filename_nsx):
-                self.read_nsx(filename_nsx, seg, lazy, cascade)
+        if self._avail_files['nev']:
+            #            filename = self._filenames['nev'] + '.nev'
+            # annotate segment according to file headers
+            seg.rec_datetime = datetime.datetime(
+                year=self.__nev_basic_header['year'],
+                month=self.__nev_basic_header['month'],
+                day=self.__nev_basic_header['day'],
+                hour=self.__nev_basic_header['hour'],
+                minute=self.__nev_basic_header['minute'],
+                second=self.__nev_basic_header['second'],
+                microsecond=self.__nev_basic_header['millisecond'])
 
-        filename_nev = self.filename + '.nev'
-        if os.path.exists(filename_nev):
-            self.read_nev(filename_nev, seg, lazy, cascade, load_waveforms = load_waveforms)
+            # read nev data
+            nev_data = self.__nev_data_reader[self.__nev_spec]()
+
+            # read non-neural experimental events
+            if load_events:
+                ev_dict = self.__nonneural_evtypes[self.__nev_spec](
+                    nev_data['NonNeural'])
+
+                for ev_type in ev_dict.keys():
+
+                    ev = self.__read_event(
+                        n_start, n_stop, nev_data['NonNeural'],
+                        ev_dict[ev_type], lazy)
+
+                    if not isinstance(ev, types.NoneType):
+                        seg.events.append(ev)
+
+                # TODO: not yet implemented (only avail in nev_spec 2.3)
+                # videosync events
+                # trackingevents events
+                # buttontrigger events
+                # configevent events
+
+            # get spiketrain
+            if not isinstance(units, types.NoneType):
+                for ch_id in units.keys():
+                    # extract first data for channel
+                    ch_mask = (nev_data['Spikes']['packet_id'] == ch_id)
+                    data_ch = nev_data['Spikes'][ch_mask]
+                    if not isinstance(units[ch_id], types.NoneType):
+                        for un_id in units[ch_id]:
+                            if un_id in np.unique(data_ch['unit_class_nb']):
+                                # extract then data for unit if unit exists
+                                un_mask = (data_ch['unit_class_nb'] == un_id)
+                                data_un = data_ch[un_mask]
+
+                                st = self.__read_spiketrain(
+                                    n_start, n_stop, data_un, ch_id, un_id,
+                                    load_waveforms, lazy)
+
+                                seg.spiketrains.append(st)
+                            else:
+                                self._print_verbose(
+                                    "Unit {0} on channel {1} does not "
+                                    "exist".format(un_id, ch_id))
+                    else:
+                        self._print_verbose(
+                            "Channel {0} has no units".format(ch_id))
+
+        if not isinstance(nsx_to_load, types.NoneType):
+            for nsx_nb in nsx_to_load:
+                # read nsx data
+                nsx_data = \
+                    self.__nsx_data_reader[self.__nsx_spec[nsx_nb]](nsx_nb)
+
+                # read analogsignals
+                for ch_id in channels:
+
+                    anasig = self.__read_analogsignal(
+                        n_start, n_stop, nsx_data, ch_id, nsx_nb, lazy)
+
+                    if not isinstance(anasig, types.NoneType):
+                        seg.analogsignals.append(anasig)
+
+        # TODO: not yet implemented
+#        if self._avail_files['sif']:
+#            sif_header = self._read_sif(self._filenames['sif'] + '.sif')
+
+        # TODO: not yet implemented
+#        if self._avail_files['ccf']:
+#            ccf_header = self._read_sif(self._filenames['ccf'] + '.ccf')
+
+        seg.create_many_to_one_relationship()
 
         return seg
 
-    def read_nev(self, filename_nev, seg, lazy, cascade, load_waveforms = False):
-        # basic hedaer
-        dt = [('header_id','S8'),
-                    ('ver_major','uint8'),
-                    ('ver_minor','uint8'),
-                    ('additionnal_flag', 'uint16'), # Read flags, currently basically unused
-                    ('header_size', 'uint32'), #i.e. index of first data
-                    ('packet_size', 'uint32'),# Read number of packet bytes, i.e. byte per sample
-                    ('sampling_rate', 'uint32'),# Read time resolution in Hz of time stamps, i.e. data packets
-                    ('waveform_sampling_rate', 'uint32'),# Read sampling frequency of waveforms in Hz
-                    ('window_datetime', 'S16'),
-                    ('application', 'S32'), # 
-                    ('comments', 'S256'), # comments
-                    ('num_ext_header', 'uint32') #Read number of extended headers
-                    
-                ]
-        nev_header = h = np.fromfile(filename_nev, count = 1, dtype = dt)[0]
-        version = '{0}.{1}'.format(h['ver_major'], h['ver_minor'])
-        assert h['header_id'].decode('ascii') == 'NEURALEV' or version == '2.1', 'Unsupported version {0}'.format(version)
-        version = '{0}.{1}'.format(h['ver_major'], h['ver_minor'])
-        seg.annotate(blackrock_version = version)
-        seg.rec_datetime = get_window_datetime(nev_header['window_datetime'])
-        sr = float(h['sampling_rate'])
-        wsr = float(h['waveform_sampling_rate'])
-        
-        if not cascade:
-            return
-        
-        # extented header
-        # this consist in N block with code 8bytes + 24 data bytes
-        # the data bytes depend on the code and need to be converted cafilename_nsx, segse by case
-        raw_ext_header = np.memmap(filename_nev, offset = np.dtype(dt).itemsize,
-                                                 dtype = [('code', 'S8'), ('data', 'S24')],  shape = h['num_ext_header'])
-        # this is for debuging
-        ext_header = {}
-        for code, dt_ext in ext_nev_header_codes.items():
-            sel = raw_ext_header['code']==code
-            ext_header[code] = raw_ext_header[sel].view(dt_ext)
-        
-        # channel label
-        neuelbl_header = ext_header['NEUEVLBL']
-        #not used# channel_labels = dict(zip(neuelbl_header['channel_id'], neuelbl_header['channel_label']))
-        
-        # TODO ext_header['DIGLABEL'] is there only one label ???? because no id in that case
-        # TODO ECOMMENT + CCOMMENT for annotations
-        # TODO NEUEVFLT for annotations
-        
-        
-        # read data packet and markers
-        dt0 =  [('samplepos', 'uint32'),
-                    ('id', 'uint16'), 
-                    ('value', 'S{0}'.format(h['packet_size']-6)),
-            ]
-        data = np.memmap( filename_nev, offset = h['header_size'], dtype = dt0)
-        all_ids = np.unique(data['id'])
-        
-        t_start = 0*pq.s
-        t_stop = data['samplepos'][-1]/sr*pq.s
-        
-        
-        
-        # read event (digital 9+ analog+comment)
-        def create_event_array_trig_or_analog(selection, name, labelmode = None):
-            if lazy:
-                times = [ ]
-                labels = np.array([ ], dtype = 'S')
-            else:
-                times = data_trigger['samplepos'][selection].astype(float)/sr
-                if labelmode == 'digital_port':
-                    labels = data_trigger['digital_port'][selection].astype('S2')
-                elif labelmode is None:
-                    label = None
-            ev = Event(times= times*pq.s,
-                       labels= labels,
-                       name=name)
-            if lazy:
-                ev.lazy_shape = np.sum(is_digital)
-            seg.events.append(ev)
+    def read_block(
+            self, index=None, name=None, description=None, nsx_to_load='none',
+            n_starts=None, n_stops=None, channels='none', units='none',
+            load_waveforms=False, load_events=False, lazy=False, cascade=True):
+        """
+        Args:
+            index (None, int):
+                If not None, index of block is set to user input.
+            name (None, str):
+                If None, name is set to default, otherwise it is set to user
+                input.
+            description (None, str):
+                If None, description is set to default, otherwise it is set to
+                user input.
+            nsx_to_load (int, list, str):
+                ID(s) of nsx file(s) from which to load data, e.g., if set to
+                5 only data from the ns5 file are loaded. If 'none' or empty
+                list, no nsx files and therefore no analog signals are loaded.
+                If 'all', data from all available nsx are loaded.
+            n_starts (None, Quantity, list):
+                Start times for data in each segment. Number of entries must be
+                equal to length of n_stops. If None, intrinsic recording start
+                times of files set are used.
+            n_stops (None, Quantity, list):
+                Stop times for data in each segment. Number of entries must be
+                equal to length of n_starts. If None, intrinsic recording stop
+                times of files set are used.
+            channels (int, list, str):
+                Channel id(s) from which to load data. If 'none' or empty list,
+                no channels and therefore no analog signal or spiketrains are
+                loaded. If 'all', all available channels are loaded.
+            units (int, list, str, dict):
+                ID(s) of unit(s) to load. If 'none' or empty list, no units and
+                therefore no spiketrains are loaded. If 'all', all available
+                units are loaded. If dict, the above can be specified
+                individually for each channel (keys), e.g. {1: 5, 2: 'all'}
+                loads unit 5 from channel 1 and all units from channel 2.
+            load_waveforms (boolean):
+                If True, waveforms are attached to all loaded spiketrains.
+            load_events (boolean):
+                If True, all recorded events are loaded.
+            lazy (bool):
+                If True, only the shape of the data is loaded.
+            cascade (bool or "lazy"):
+                If True, only the block without children is returned.
 
-        mask = (data['id']==0) 
-        dt_trig =  [('samplepos', 'uint32'),
-                    ('id', 'uint16'), 
-                    ('reason', 'uint8'), 
-                    ('reserved0', 'uint8'), 
-                    ('digital_port', 'uint16'), 
-                    ('reserved1', 'S{0}'.format(h['packet_size']-10)),
-                ]
-        data_trigger = data.view(dt_trig)[mask]
-        # Digital Triggers (PaquetID 0)
-        is_digital = (data_trigger ['reason']&1)>0
-        create_event_array_trig_or_analog(is_digital, 'Digital trigger', labelmode =  'digital_port' )
-        
-        # Analog Triggers (PaquetID 0)
-        if version in ['2.1', '2.2' ]:
-            for i in range(5):
-                is_analog = (data_trigger ['reason']&(2**(i+1)))>0
-                create_event_array_trig_or_analog(is_analog, 'Analog trigger {0}'.format(i), labelmode = None)
-        
-        # Comments
-        mask = (data['id']==0xFFF) 
-        dt_comments = [('samplepos', 'uint32'),
-                    ('id', 'uint16'), 
-                    ('charset', 'uint8'), 
-                    ('reserved0', 'uint8'), 
-                    ('color', 'uint32'), 
-                    ('comment', 'S{0}'.format(h['packet_size']-12)),
-                ]
-        data_comments = data.view(dt_comments)[mask]
-        if data_comments.size>0:
-            if lazy:
-                times = [ ]
-                labels = [ ]
-            else:
-                times = data_comments['samplepos'].astype(float)/sr
-                labels = data_comments['comment'].astype('S')
-            ev = Event(times= times*pq.s,
-                       labels= labels,
-                       name='Comments')
-            if lazy:
-                ev.lazy_shape = np.sum(is_digital)
-            seg.events.append(ev)
-        
-        
-        # READ Spike channel
-        channel_ids = all_ids[(all_ids>0) & (all_ids<=2048)]
+        Returns (neo.segment.Segment):
+            Annotations:
+                avail_file_set (list):
+                    List of extensions of all available files for the given
+                    recording.
+                avail_nsx (boolean):
+                    List of available nsx ids (int).
+                avail_nev (boolean):
+                    True if nev is available.
+                avail_sif (boolean):
+                    True if sif is available.
+                avail_ccf (boolean):
+                    True if ccf is available.
+                rec_pauses (boolean):
+                    True if at least one recording pause occurred.
+                nb_segments (int):
+                    Number of created segments after merging recording times
+                    specified by user with the intrinsic ones of the file set.
+        """
+        # Make sure that input args are transformed into correct instances
+        # Arg: nsx_to_load
+        nsx_to_load = self.__transform_nsx_to_load(nsx_to_load)
+        # Arg: channels
+        channels = self.__transform_channels(channels, nsx_to_load)
+        # Arg: units
+        units = self.__transform_units(units, channels)
 
-        # get the dtype of waveform (this is stupidly complicated)
-        if nev_header['additionnal_flag']&0x1:
-            #dtype_waveforms = { k:'int16' for k in channel_ids }
-            dtype_waveforms = dict( (k,'int16') for k in channel_ids)
+        # Create block
+        bl = Block(file_origin=self.filename)
+
+        # set user defined annotations if they were provided
+        if not isinstance(index, types.NoneType):
+            bl.index = index
+        if isinstance(name, types.NoneType):
+            bl.name = "Blackrock Data Block"
         else:
-            # there is a code electrodes by electrodes given the approiate dtype
-            neuewav_header = ext_header['NEUEVWAV']
-            dtype_waveform = dict(zip(neuewav_header['channel_id'], neuewav_header['num_bytes_per_waveform']))
-            dtypes_conv = { 0: 'int8', 1 : 'int8', 2: 'int16', 4 : 'int32' }
-            #dtype_waveforms = { k:dtypes_conv[v] for k,v in dtype_waveform.items() }
-            dtype_waveforms = dict( (k,dtypes_conv[v]) for k,v in dtype_waveform.items() )
-        
-        dt2 =   [('samplepos', 'uint32'),
-                    ('id', 'uint16'), 
-                    ('cluster', 'uint8'), 
-                    ('reserved0', 'uint8'), 
-                    ('waveform','uint8',(h['packet_size']-8, )),
-                ]
-        data_spike = data.view(dt2)
+            bl.name = name
+        if isinstance(description, types.NoneType):
+            bl.description = "Block of data from Blackrock file set."
+        else:
+            bl.description = description
 
-        for channel_id in channel_ids:
-            data_spike_chan = data_spike[data['id']==channel_id]
-            cluster_ids = np.unique(data_spike_chan['cluster'])
-            for cluster_id in cluster_ids:
-                if cluster_id==0: 
-                    name =  'unclassified'
-                elif cluster_id==255:
-                    name =  'noise'
-                else:
-                    name = 'Cluster {0}'.format(cluster_id)
-                name = 'Channel {0} '.format(channel_id)+name
-                
-                data_spike_chan_clus = data_spike_chan[data_spike_chan['cluster']==cluster_id]
-                n_spike = data_spike_chan_clus.size
-                waveforms, w_sampling_rate, left_sweep = None, None, None
-                if lazy:
-                    times = [ ]
-                else:
-                    times = data_spike_chan_clus['samplepos'].astype(float)/sr
-                    if load_waveforms:
-                        dtype_waveform = dtype_waveforms[channel_id]
-                        waveform_size = (h['packet_size']-8)/np.dtype(dtype_waveform).itemsize
-                        waveforms = data_spike_chan_clus['waveform'].flatten().view(dtype_waveform)
-                        waveforms = waveforms.reshape(n_spike,1, waveform_size)
-                        waveforms =waveforms*pq.uV
-                        w_sampling_rate = wsr*pq.Hz
-                        left_sweep = waveform_size//2/sr*pq.s
-                st = SpikeTrain(times =  times*pq.s, name = name,
-                                t_start = t_start, t_stop =t_stop,
-                                waveforms = waveforms, sampling_rate = w_sampling_rate, left_sweep = left_sweep)
-                st.annotate(channel_id=int(channel_id))
-                if lazy:
-                    st.lazy_shape = n_spike
-                seg.spiketrains.append(st)
-    
-    
-    def read_nsx(self, filename_nsx, seg, lazy, cascade):
-        # basic header
-        dt0 = [('header_id','S8'),
-                    ('ver_major','uint8'),
-                    ('ver_minor','uint8'),
-                    ('header_size', 'uint32'), #i.e. index of first data
-                    ('group_label', 'S16'),# Read number of packet bytes, i.e. byte per samplepos
-                    ('comments', 'S256'),
-                    ('period_ratio', 'uint32'),
-                    ('sampling_rate', 'uint32'),
-                    ('window_datetime', 'S16'),
-                    ('nb_channel', 'uint32'),
-                ]
-        nsx_header = h = np.fromfile(filename_nsx, count = 1, dtype = dt0)[0]
-        version = '{0}.{1}'.format(h['ver_major'], h['ver_minor'])
-        seg.annotate(blackrock_version = version)
-        seg.rec_datetime = get_window_datetime(nsx_header['window_datetime'])
-        nb_channel = h['nb_channel']
-        sr = float(h['sampling_rate'])/h['period_ratio']
+        if self._avail_files['nev']:
+            bl.rec_datetime = self.__nev_params('rec_datetime')
+
+        bl.annotate(
+            avail_file_set=[k for k, v in self._avail_files.items() if v])
+        bl.annotate(avail_nsx=self._avail_nsx)
+        bl.annotate(avail_nev=self._avail_files['nev'])
+        bl.annotate(avail_sif=self._avail_files['sif'])
+        bl.annotate(avail_ccf=self._avail_files['ccf'])
+        bl.annotate(rec_pauses=False)
+
+        # Test n_starts and n_stops user requirements and combine them if
+        # possible with file internal n_starts and n_stops from rec pauses.
+        n_starts, n_stops = \
+            self.__merge_time_ranges(n_starts, n_stops, nsx_to_load)
+
+        bl.annotate(nb_segments=len(n_starts))
 
         if not cascade:
-            return
-        
-        # extented header = channel information
-        dt1 = [('header_id','S2'),
-                    ('channel_id', 'uint16'),
-                    ('label', 'S16'),
-                    ('connector_id', 'uint8'),
-                    ('connector_pin', 'uint8'),
-                    ('min_digital_val', 'int16'),
-                    ('max_digital_val', 'int16'),
-                    ('min_analog_val', 'int16'),
-                    ('max_analog_val', 'int16'),
-                    ('units', 'S16'),
-                    ('hi_freq_corner',  'uint32'),
-                    ('hi_freq_order',  'uint32'),
-                    ('hi_freq_type',  'uint16'), #0=None 1=Butterworth
-                    ('lo_freq_corner',  'uint32'),
-                    ('lo_freq_order',  'uint32'),
-                    ('lo_freq_type',  'uint16'), #0=None 1=Butterworth
-            ]
-        channels_header = np.memmap(filename_nsx, shape=nb_channel,
-                                    offset=np.dtype(dt0).itemsize, dtype = dt1)
-        
-        #read data
-        dt2 = [('header_id','uint8'),
-                    ('n_start','uint32'),
-                    ('nb_sample','uint32'),
-                    ]
-        sample_header = sh =  np.memmap(filename_nsx, dtype = dt2, shape = 1,
-                        offset = nsx_header['header_size'])[0]
-        nb_sample = sample_header['nb_sample']
-        data = np.memmap(filename_nsx, dtype = 'int16', shape = (nb_sample, nb_channel),
-                        offset = nsx_header['header_size'] +np.dtype(dt2).itemsize )
+            return bl
 
-        # create neo objects
-        neural_data_channels = channels_header['channel_id'] < 129
-        analog_input_channels = channels_header['channel_id'] > 128
+        # read segment
+        for seg_idx, (n_start, n_stop) in enumerate(zip(n_starts, n_stops)):
+            seg = self.read_segment(
+                n_start, n_stop, index=seg_idx, nsx_to_load=nsx_to_load,
+                channels=channels, units=units, load_waveforms=load_waveforms,
+                load_events=load_events, lazy=lazy, cascade=cascade)
 
-        for channel_filter, name in ((neural_data_channels, "Neural data"),
-                                     (analog_input_channels, "Analog inputs")):
-            ch = channels_header[channel_filter]
-            units = ch['units']
-            assert (units == units[0]).all(), "Neural channel data not homogeneous, contact the Neo developers"
-            # todo: handle heterogeneous units
+            bl.segments.append(seg)
 
-            if lazy:
-                sig = []
-            else:
-                sig = data[:, channel_filter].astype(float)
-                # digital value to physical value
-                if ((ch['max_analog_val'] == -ch['min_analog_val']).all() and
-                    (ch['max_digital_val'] == -ch['min_digital_val']).all()):
-                    # when symmetric it is simple
-                    sig *= ch['max_analog_val']/ch['max_digital_val']
-                else:
-                    # general case
-                    sig -= ch['min_digital_val']
-                    sig *= (ch['max_analog_val'] - ch['min_analog_val'])/\
-                               (ch['max_digital_val'] - ch['min_digital_val'])
-                    sig += ch['min_analog_val']
+        # read recordingchannelgroup
+        rcg = self.__read_recordingchannelgroup(
+            channels=channels, units=units, cascade=cascade)
 
-            anasig = AnalogSignal(sig, units=units[0].decode('ascii'), copy=False,
-                                  sampling_rate=sr*pq.Hz,
-                                  t_start=sample_header['n_start']/sr*pq.s,
-                                  name=name,
-                                  file_origin=filename_nsx)
-            if lazy:
-                anasig.lazy_shape = nb_sample
-                channel_indexes = np.arange(anasig.lazy_shape)
-            else:
-                channel_indexes = np.arange(anasig.shape[1])
+        if not isinstance(rcg, types.NoneType):
 
-            # this assumes there is only ever a single segment
-            rcg = RecordingChannelGroup(channel_indexes=channel_indexes,
-                                        channel_ids=np.array(ch['channel_id']),
-                                        channel_names=np.array(ch['label']),
-                                        name=name,
-                                        file_origin=filename_nsx)
-            rcg.analogsignals.append(anasig)
-            anasig.recordingchannelgroup = rcg
-            seg.analogsignals.append(anasig)
+            bl.recordingchannelgroups.append(rcg)
 
-    def read_sif(self, filename_sif, seg, ):
-        pass
-        #TODO
+            if not isinstance(units, types.NoneType):
+                for un in bl.recordingchannelgroups[0].units:
+                    sts = bl.filter(
+                        targdict={'name': un.name},
+                        objects=neo.core.spiketrain.SpikeTrain)
+                    for st in sts:
+                        un.spiketrains.append(st)
 
+            anasig = bl.filter(objects=neo.core.analogsignal.AnalogSignal)
+            bl.recordingchannelgroups[0].analogsignals.append(anasig)
 
-def get_window_datetime(buf):
-    """This transform a buffer of 16 bytes window datetime type
-     n python datetime object
-    """
-    try:
-        buf = buffer(buf.copy())  # Python 2
-    except NameError:
-        buf = buf.copy()          # Python 3
-    dt = [('year', 'uint16'), ('mouth', 'uint16'), ('weekday', 'uint16'),
-                ('day', 'uint16'), ('hour', 'uint16'), ('min', 'uint16'),
-                ('sec', 'uint16'), ('usec', 'uint16'),]
-    assert len(buf) == np.dtype(dt).itemsize, 'This buffer do not have the good size for window date'
-    d = np.fromstring(buf, dtype = dt)[0]
-    thedatetime = datetime.datetime(d['year'], d['mouth'], d['day'],
-                d['hour'], d['min'], d['sec'], d['usec'])
-    return thedatetime
+        bl.create_many_to_one_relationship()
 
+        return bl
 
-# the extented header of nev file is composed of 8+24 bytes
-# the comments of the 24 bytes depend of the code of 8 bytes
-# this is conversion
-ext_nev_header_codes = [
-        ('ARRAYNME', [('ArrayName', 'S24')] ),
-        ('ECOMMENT', [('ExtendedComment', 'S24')] ),
-        ('CCOMMENT', [('ExtendedCommentComplement', 'S24')] ),
-        ('MAPFILE', [('MapFile', 'S24')] ),
-        ('NEUEVWAV', [('channel_id', 'uint16'),# Read electrode number
-                                    ('connector_id', 'uint8'),# Read physical connector (bank A-D)
-                                    ('connector_pin', 'uint8'),# Read connector sampling_ratepin (pin number on connector, 1-37)
-                                    ('digitization_factor', 'uint16'),# Read digitization factor in nV per LSB step
-                                    ('energy_threshold', 'uint16'),# Read energy threshold in nV per LSB step
-                                    ('amp_threshold_high', 'int16'),# Read high threshold in µV
-                                    ('amp_threshold_low', 'int16'),# Read low threshold in µV
-                                    ('num_sorted_units', 'uint8'),# Read number of sorted units
-                                    ('num_bytes_per_waveform', 'uint8'),# Read number of bytes per waveform sample
-                                                                                                        # 0 or 1 both imply 1 byte, so convert a 0 to 1 for
-                                                                                                        # simplification
-                                    ('spike_width','uint16'), #only for version>=2.3
-                                    ('unused', 'S8'),
-                                ]),
-        ('NEUEVLBL', [('channel_id', 'uint16'),
-                                    ('channel_label',  'S16'),
-                                    ('unused', 'S6'),
-                                ]),
-        ('NEUEVFLT', [('channel_id', 'uint16'),
-                                    ('hi_freq_corner',  'uint32'),
-                                    ('hi_freq_order',  'uint32'),
-                                    ('hi_freq_type',  'uint16'), #0=None 1=Butterworth
-                                    ('lo_freq_corner',  'uint32'),
-                                    ('lo_freq_order',  'uint32'),
-                                    ('lo_freq_type',  'uint16'), #0=None 1=Butterworth
-                                    ('unused', 'S2'),
-                                ]),
-        ('DIGLABEL', [('digital_channel_label', 'S16'),# Read name of digital
-                                    ('digital_channel_type',  'uint8'), # 0=serial, 1=parallel
-                                    ('unused', 'S7'),
-                                ]),
-        ('NSASEXEV', [('PeriodicPacketGenerator', 'uint16'),# Read frequency of periodic packet generation
-                                    ('DigitialChannelEnable',  'uint8'), # Read if digital input triggers events
-                                    ('AnalogChannel',  [ ('enable', 'uint8') , ('edge_detec', 'uint16')], (5,) ), # Read if analog input triggers events
-                                    ('unused', 'S6'),
-                                ]),                
-    ]
-ext_nev_header_codes = [ (code, [ ('code', 'S8'),  ]+dt) for code, dt in ext_nev_header_codes ]
-ext_nev_header_codes = dict(ext_nev_header_codes)
+    def __str__(self):
+        """
+        Prints summary of the Blackrock data file set.
+        """
+        output = "\nFile Origins for Blackrock File Set\n"\
+            "====================================\n"
+        for ftype in self._filenames.keys():
+            output += ftype + ':' + self._filenames[ftype] + '\n'
 
+        if self._avail_files['nev']:
+            output += "\nEvent Parameters (NEV)\n"\
+                "====================================\n"\
+                "Timestamp resolution (Hz): " +\
+                str(self.__nev_basic_header['timestamp_resolution']) +\
+                "\nWaveform resolution (Hz): " +\
+                str(self.__nev_basic_header['sample_resolution'])
+
+            if 'NEUEVWAV' in self.__nev_ext_header.keys():
+                avail_el = \
+                    self.__nev_ext_header['NEUEVWAV']['electrode_id']
+                con = \
+                    self.__nev_ext_header['NEUEVWAV']['physical_connector']
+                pin = \
+                    self.__nev_ext_header['NEUEVWAV']['connector_pin']
+                nb_units = \
+                    self.__nev_ext_header['NEUEVWAV']['nb_sorted_units']
+                output += "\n\nAvailable electrode IDs:\n"\
+                    "====================================\n"
+                for i, el in enumerate(avail_el):
+                    output += "Electrode ID %i: " % el
+                    output += "connector: %i, " % con[i]
+                    output += "pin: %i, " % pin[i]
+                    output += 'nb_units: %i\n' % nb_units[i]
+        for nsx_nb in self._avail_nsx:
+            analog_res = self.__nsx_params[self.__nsx_spec[nsx_nb]](
+                'sampling_rate', nsx_nb)
+            avail_el = [
+                el for el in self.__nsx_ext_header[nsx_nb]['electrode_id']]
+            output += "\nAnalog Parameters (NS" + str(nsx_nb) + ")"\
+                "\n===================================="
+            output += "\nResolution (Hz): %i" % analog_res
+            output += "\nAvailable channel IDs: " +\
+                ", " .join(["%i" % a for a in avail_el]) + "\n"
+
+        return output

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1084,9 +1084,9 @@ class BlackrockIO(BaseIO):
 
         bytes_in_headers = self.__nsx_params[self.__nsx_spec[nsx_nb]](
             'bytes_in_headers', nsx_nb)
-        nb_data_points = \
+        nb_data_points = int(
             (self.__get_file_size(filename) - bytes_in_headers) / \
-            (2 * self.__nsx_basic_header[nsx_nb]['channel_count']) - 1
+            (2 * self.__nsx_basic_header[nsx_nb]['channel_count']) - 1)
 
         # add n_start
         n_starts = [(0 * t_unit).rescale(highest_res)]
@@ -1271,9 +1271,9 @@ class BlackrockIO(BaseIO):
 
         # extract parameters from nsx basic extended and data header
         data_parameters = {
-            'nb_data_points':
+            'nb_data_points': int(
                 (self.__get_file_size(filename) - bytes_in_headers) /
-                (2 * self.__nsx_basic_header[nsx_nb]['channel_count']) - 1,
+                (2 * self.__nsx_basic_header[nsx_nb]['channel_count']) - 1),
             'databl_idx': 1,
             'databl_t_start': t_starts[0],
             'databl_t_stop': t_stops[0]}

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1805,7 +1805,6 @@ class BlackrockIO(BaseIO):
             'databl_t_stop', nsx_nb, n_start, n_stop)
 
         elids_nsx = list(self.__nsx_ext_header[nsx_nb]['electrode_id'])
-        print elids_nsx
         if channel_idx in elids_nsx:
             idx_ch = elids_nsx.index(channel_idx)
         else:

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1408,7 +1408,8 @@ class BlackrockIO(BaseIO):
         elif 1 <= un_id <= 16:
             return '{0}'.format(un_id)
         elif 17 <= un_id <= 244:
-            return 'unused'
+            raise ValueError(
+                "Unit id {0} is not used by daq system".format(un_id))
         elif un_id == 255:
             return 'noise'
         else:
@@ -1499,7 +1500,8 @@ class BlackrockIO(BaseIO):
                     if u.lower() == 'none':
                         units[ch] = None
                     elif u.lower() == 'all':
-                        units[ch] = range(256)
+                        units[ch] = range(17)
+                        units[ch].append(255)
                     else:
                         raise ValueError("Invalid unit specification.")
         else:
@@ -1509,7 +1511,8 @@ class BlackrockIO(BaseIO):
                 if units.lower() == 'none':
                     units = None
                 elif units.lower() == 'all':
-                    units = range(256)
+                    units = range(17)
+                    units.append(255)
                 else:
                     raise ValueError("Invalid unit specification.")
             if isinstance(units, int):

--- a/neo/test/iotest/test_blackrockio.py
+++ b/neo/test/iotest/test_blackrockio.py
@@ -137,7 +137,7 @@ class CommonTests(BaseTestIO, unittest.TestCase):
 
         self.assertEqual(len(block.segments), 1)
         self.assertEqual(len(block.segments[0].analogsignals), 8)
-        self.assertEqual(len(block.recordingchannelgroups), 1)
+        self.assertEqual(len(block.recordingchannelgroups), 8)
         self.assertEqual(len(block.recordingchannelgroups[0].units), 0)
         self.assertEqual(len(block.segments[0].events), 0)
         self.assertEqual(len(block.segments[0].spiketrains), 0)
@@ -151,8 +151,8 @@ class CommonTests(BaseTestIO, unittest.TestCase):
 
         self.assertEqual(len(block.segments), 2)
         self.assertEqual(len(block.segments[0].analogsignals), 0)
-        self.assertEqual(len(block.recordingchannelgroups), 1)
-        self.assertEqual(len(block.recordingchannelgroups[0].units), 2)
+        self.assertEqual(len(block.recordingchannelgroups), 8)
+        self.assertEqual(len(block.recordingchannelgroups[0].units), 1)
         self.assertEqual(len(block.segments[0].events), 0)
         self.assertEqual(len(block.segments[0].spiketrains), 2)
 

--- a/neo/test/iotest/test_blackrockio.py
+++ b/neo/test/iotest/test_blackrockio.py
@@ -16,13 +16,33 @@ try:
 except ImportError:
     import unittest
 
+from numpy.testing import assert_equal
+
 import numpy as np
 import quantities as pq
 
 from neo.io.blackrockio import BlackrockIO
 
 from neo.test.iotest.common_io_test import BaseTestIO
+from neo.test.iotest.tools import get_test_file_full_path
 
+# check scipy
+try:
+    from distutils import version
+    import scipy.io
+    import scipy.version
+except ImportError as err:
+    HAVE_SCIPY = False
+    SCIPY_ERR = err
+else:
+    if version.LooseVersion(scipy.version.version) < '0.8':
+        HAVE_SCIPY = False
+        SCIPY_ERR = ImportError("your scipy version is too old to support " +
+                                "MatlabIO, you need at least 0.8. " +
+                                "You have %s" % scipy.version.version)
+    else:
+        HAVE_SCIPY = True
+        SCIPY_ERR = None
 
 class CommonTests(BaseTestIO, unittest.TestCase):
     ioclass =BlackrockIO
@@ -37,11 +57,184 @@ class CommonTests(BaseTestIO, unittest.TestCase):
 
     files_to_test = ['FileSpec2.3001']
 
-    files_to_download = ['FileSpec2.3001.nev',
-                     'FileSpec2.3001.ns5',
-                     'FileSpec2.3001.ccf',
-                     'FileSpec2.3001.mat']
+    files_to_download = [
+        'FileSpec2.3001.nev',
+        'FileSpec2.3001.ns5',
+        'FileSpec2.3001.ccf',
+        'FileSpec2.3001.mat']
+
     ioclass = BlackrockIO
+
+    def test_inputs_V23(self):
+        """
+        Test various inputs to BlackrockIO.read_block with version 2.3 file
+        to check for parsing errors.
+        """
+
+        try:
+            b = BlackrockIO(
+                get_test_file_full_path(
+                    ioclass=BlackrockIO,
+                    filename='FileSpec2.3001',
+                    directory=self.local_test_dir, clean=False),
+                verbose=False)
+
+        except:
+            self.fail()
+
+        # Load data to maximum extent, one None is not given as list
+        block = b.read_block(
+            n_starts=[None], n_stops=None, channels=range(1, 9),
+            nsx_to_load=5, units='all', load_events=True,
+            load_waveforms=False)
+        lena = len(block.segments[0].analogsignals[0])
+        numspa = len(block.segments[0].spiketrains[0])
+
+        # Load data using a negative time and a time exceeding the end of the
+        # recording
+        too_large_tstop = block.segments[0].analogsignals[0].t_stop + 1 * pq.s
+        block = b.read_block(
+            n_starts=[-100 * pq.ms], n_stops=[too_large_tstop],
+            channels=range(1, 9), nsx_to_load=[5], units='all',
+            load_events=False, load_waveforms=False)
+        lenb = len(block.segments[0].analogsignals[0])
+        numspb = len(block.segments[0].spiketrains[0])
+
+        # Same length of analog signal?
+        # Both should have read the complete data set!
+        self.assertEqual(lena, lenb)
+
+        # Same length of spike train?
+        # Both should have read the complete data set!
+        self.assertEqual(numspa, numspb)
+
+        # n_starts and n_stops not given as list
+        # verifies identical length of returned signals given equal durations
+        # as input
+        ns5_unit = block.segments[0].analogsignals[0].sampling_period
+        block = b.read_block(
+            n_starts=100 * ns5_unit, n_stops=200 * ns5_unit,
+            channels=range(1, 9), nsx_to_load=5, units='all',
+            load_events=False, load_waveforms=False)
+        lena = len(block.segments[0].analogsignals[0])
+
+        block = b.read_block(
+            n_starts=301 * ns5_unit, n_stops=401 * ns5_unit,
+            channels=range(1, 9), nsx_to_load=5, units='all',
+            load_events=False, load_waveforms=False)
+        lenb = len(block.segments[0].analogsignals[0])
+
+        # Same length?
+        self.assertEqual(lena, lenb)
+        # Length should be 100 samples exactly
+        self.assertEqual(lena, 100)
+
+        # Load partial data types and check if this is selection is made
+        block = b.read_block(
+            n_starts=None, n_stops=None, channels=range(1, 9),
+            nsx_to_load=5, units='none', load_events=False,
+            load_waveforms=True)
+
+        self.assertEqual(len(block.segments), 1)
+        self.assertEqual(len(block.segments[0].analogsignals), 8)
+        self.assertEqual(len(block.recordingchannelgroups), 1)
+        self.assertEqual(len(block.recordingchannelgroups[0].units), 0)
+        self.assertEqual(len(block.segments[0].events), 0)
+        self.assertEqual(len(block.segments[0].spiketrains), 0)
+
+        # NOTE: channel 6 does not contain any unit
+        block = b.read_block(
+            n_starts=[None, 3000 * pq.ms], n_stops=[1000 * pq.ms, None],
+            channels=range(1, 9), nsx_to_load='none',
+            units={1: 0, 5: 0, 6: 0}, load_events=True,
+            load_waveforms=True)
+
+        self.assertEqual(len(block.segments), 2)
+        self.assertEqual(len(block.segments[0].analogsignals), 0)
+        self.assertEqual(len(block.recordingchannelgroups), 1)
+        self.assertEqual(len(block.recordingchannelgroups[0].units), 2)
+        self.assertEqual(len(block.segments[0].events), 0)
+        self.assertEqual(len(block.segments[0].spiketrains), 2)
+
+    @unittest.skipUnless(HAVE_SCIPY, "requires scipy")
+    def test_compare_blackrockio_with_matlabloader(self):
+        """
+        This test compares the output of ReachGraspIO.read_block() with the
+        output generated by a Matlab implementation of a Blackrock file reader
+        provided by the company. The output for comparison is provided in a
+        .mat file created by the script create_data_matlab_blackrock.m.
+        The function tests LFPs, spike times, and digital events on channels
+        80-83 and spike waveforms on channel 82, unit 1.
+        For details on the file contents, refer to FileSpec2.3.txt
+        """
+
+        # Load data from Matlab generated files
+        ml = scipy.io.loadmat(
+            get_test_file_full_path(
+                ioclass=BlackrockIO,
+                filename='FileSpec2.3001.mat',
+                directory=self.local_test_dir, clean=False))
+        lfp_ml = ml['lfp']  # (channel x time) LFP matrix
+        ts_ml = ml['ts']  # spike time stamps
+        elec_ml = ml['el']  # spike electrodes
+        unit_ml = ml['un']  # spike unit IDs
+        wf_ml = ml['wf']  # waveform unit 1 channel 1
+        mts_ml = ml['mts']  # marker time stamps
+        mid_ml = ml['mid']  # marker IDs
+
+        # Load data in channels 1-3 from original data files using the neo
+        # framework
+        session = BlackrockIO(
+            get_test_file_full_path(
+                ioclass=BlackrockIO,
+                filename='FileSpec2.3001',
+                directory=self.local_test_dir, clean=False),
+            verbose=False)
+        block = session.read_block(load_waveforms=True)
+
+        # Check if analog data on channels 1-8 are equal
+        for rcg_i in block.recordingchannelgroups:
+            # Should only have one recording channel per group
+            self.assertEqual(len(rcg_i.recordingchannels), 1)
+
+            rc = rcg_i.recordingchannels[0]
+            idx = rc.index
+            if idx in range(1, 9):
+                assert_equal(rc.analogsignals[0].base, lfp_ml[idx - 1, :])
+
+        # Should only have one segment
+        self.assertEqual(len(block.segments), 1)
+
+        # Check if spikes in channels 1,3,5,7 are equal
+        for st_i in block.segments[0].spiketrains:
+            channelid = st_i.annotations['channel_id']
+            if channelid in range(1, 7, 2):
+                unitid = st_i.annotations['unit_id']
+                matlab_spikes = ts_ml[np.nonzero(
+                    np.logical_and(elec_ml == channelid, unit_ml == unitid))]
+                assert_equal(st_i.base, matlab_spikes)
+
+                # Check waveforms of channel 1, unit 0
+                if channelid == 1 and unitid == 0:
+                    assert_equal(st_i.waveforms, wf_ml)
+
+        # Check if digital marker events are equal
+        for ea_i in block.segments[0].events:
+            if ('digital_marker' in ea_i.annotations.keys()) and (
+                    ea_i.annotations['digital_marker'] is True):
+                markerid = ea_i.annotations['marker_id']
+                matlab_digievents = mts_ml[np.nonzero(mid_ml == markerid)]
+                assert_equal(ea_i.times.base, matlab_digievents)
+
+        # Check if analog marker events are equal
+        # Currently not implemented by the Matlab loader
+        for ea_i in block.segments[0].events:
+            if ('analog_marker' in ea_i.annotations.keys()) and (
+                    ea_i.annotations['analog_marker'] is True):
+                markerid = ea_i.annotations['marker_id']
+                matlab_anaevents = mts_ml[np.nonzero(mid_ml == markerid)]
+                assert_equal(ea_i.times.base, matlab_anaevents)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request contains a fourth iteration of the BlackrockIO module to read files stored in the Blackrock file format.

The module is a combination from the previous two iterations combining the optimized, efficient, and more Neo compliant code of iteration 3 by @samuelgarcia with the important extended functionality of iteration 2. In addition, this IO adds several new features, in particular support for files of specification 2.1 and 2.3 and recording pauses (in 2.2 and 2.3). 

Also the code has been restructured to make it easier to add upcoming file specifications of Blackrock, by grouping read operations common to multiple file specifications (termed 'variants', e.g. 'variant_a').

Two new specific unit tests complement the generic IO unit tests and check the content of the read data objects, in part based on the Matlab implementation of the loading routine provided by the manufacturer. 