### PR TITLE
Updating check for NoneType by using "is" instead of "=="

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -553,7 +553,7 @@ class AnalogSignal(BaseNeo, pq.Quantity):
         '''
 
         # checking start time and transforming to start index
-        if t_start == None:
+        if t_start is None:
             i = 0
         else:
             t_start = t_start.rescale(self.sampling_period.units)
@@ -561,7 +561,7 @@ class AnalogSignal(BaseNeo, pq.Quantity):
             i = int(np.rint(i.magnitude))
 
         # checking stop time and transforming to stop index
-        if t_stop == None:
+        if t_stop is None:
             j = len(self)
         else:
             t_stop = t_stop.rescale(self.sampling_period.units)


### PR DESCRIPTION
Minor fix by substituting "==" by "is" for comparison to None.
Using "== None" currently results in a warning: "FutureWarning: comparison to `None` will result in an elementwise object comparison in the future."