### PR TITLE
NIX IO and tests

### DIFF
--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -66,6 +66,8 @@ Classes:
 
 .. autoclass:: neo.io.WinWcpIO
 
+.. autoclass:: neo.io.NixIO
+
 """
 
 import os.path
@@ -117,6 +119,7 @@ from neo.io.kwikio import KwikIO
 from neo.io.tdtio import TdtIO
 from neo.io.winedrio import WinEdrIO
 from neo.io.winwcpio import WinWcpIO
+from neo.io.nixio import NixIO
 
 
 iolist = [
@@ -149,7 +152,8 @@ iolist = [
           TdtIO,
           KwikIO,
           WinEdrIO,
-          WinWcpIO
+          WinWcpIO,
+          NixIO
 ]
 
 

--- a/neo/io/igorproio.py
+++ b/neo/io/igorproio.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""
+Class for reading data created by IGOR Pro (WaveMetrics, Inc., Portland, OR, USA)
+
+Depends on: igor (https://pypi.python.org/pypi/igor/)
+
+Supported: Read
+
+Author: Andrew Davison
+
+"""
+
+from __future__ import absolute_import
+from datetime import datetime
+from warnings import warn
+import numpy as np
+import quantities as pq
+from neo.io.baseio import BaseIO
+from neo.core import Block, Segment, AnalogSignal
+import igor.binarywave as bw
+
+
+class IgorIO(BaseIO):
+    """
+    Class for reading Igor Binary Waves (.ibw) written by WaveMetrics’ IGOR Pro software.
+
+    Support for Packed Experiment (.pxp) files is planned.
+
+    It requires the `igor` Python package by W. Trevor King.
+
+    Usage:
+        >>> from neo import io
+        >>> r = io.IgorIO(filename='...ibw')
+
+
+
+    """
+
+    is_readable = True   # This class can only read data
+    is_writable = False  # write is not supported
+    supported_objects = [Block, Segment, AnalogSignal]
+    readable_objects = [Block, Segment , AnalogSignal]
+    writeable_objects = []
+    has_header = False
+    is_streameable = False
+    name = 'igorpro'
+    extensions = ['ibw'] #, 'pxp']
+    mode = 'file'
+
+    def __init__(self, filename=None, parse_notes=None) :
+        """
+
+
+        Arguments:
+            filename: the filename
+
+            parse_notes: (optional) A function which will parse the 'notes'
+            field in the file header and return a dictionary which will be
+            added to the object annotations.
+
+        """
+        BaseIO.__init__(self)
+        self.filename = filename
+        self.parse_notes = parse_notes
+
+    def read_block(self, lazy=False, cascade=True):
+        block = Block(file_origin=self.filename)
+        block.segments.append(self.read_segment(lazy=lazy, cascade=cascade))
+        return block
+
+    def read_segment(self, lazy=False, cascade=True):
+        segment = Segment(file_origin=self.filename)
+        segment.analogsignals.append(self.read_analogsignal(lazy=lazy, cascade=cascade))
+        return segment
+
+    def read_analogsignal(self, lazy=False, cascade=True):
+        content = bw.load(self.filename)['wave']
+        assert content['padding'].size == 0, "Cannot handle non-empty padding"
+        signal = content['wData']
+        note = content['note']
+        header = content['wave_header']
+        name = header['bname']
+        assert header['botFullScale'] == 0
+        assert header['topFullScale'] == 0
+        units = "".join(header['dataUnits'])
+        time_units = "".join(header['xUnits']) or "s"
+        t_start = pq.Quantity(header['hsB'], time_units)
+        sampling_period = pq.Quantity(header['hsA'], time_units)
+        if self.parse_notes:
+            try:
+                annotations = self.parse_notes(note)
+            except ValueError:
+                warn("Couldn't parse notes field.")
+                annotations = {'note': note}
+        else:
+            annotations = {'note': note}
+
+        return AnalogSignal(signal, units=units, copy=False, t_start=t_start,
+                            sampling_period=sampling_period, name=name,
+                            file_origin=self.filename, **annotations)
+
+
+def key_value_string_parser(itemsep=";", kvsep=":"):
+    """
+    Parses a string into a dict.
+
+    Arguments:
+        itemsep - character which separates items
+        kvsep - character which separates the key and value within an item
+
+    Returns:
+        a function which takes the string to be parses as the sole argument and returns a dict.
+
+    Example:
+
+        >>> parse = key_value_string_parser(itemsep=";", kvsep=":")
+        >>> parse("a:2;b:3")
+        {'a': 2, 'b': 3}
+    """
+    def parser(s):
+        items = s.split(itemsep)
+        return dict(item.split(kvsep, 1) for item in items if item)
+    return parser

--- a/neo/io/igorproio.py
+++ b/neo/io/igorproio.py
@@ -11,13 +11,16 @@ Author: Andrew Davison
 """
 
 from __future__ import absolute_import
-from datetime import datetime
 from warnings import warn
 import numpy as np
 import quantities as pq
 from neo.io.baseio import BaseIO
 from neo.core import Block, Segment, AnalogSignal
-import igor.binarywave as bw
+try:
+    import igor.binarywave as bw
+    HAVE_IGOR = True
+except ImportError:
+    HAVE_IGOR = False
 
 
 class IgorIO(BaseIO):
@@ -78,6 +81,8 @@ class IgorIO(BaseIO):
         return segment
 
     def read_analogsignal(self, lazy=False, cascade=True):
+        if not HAVE_IGOR:
+            raise Exception("igor package not installed. Try `pip install igor`")
         data = bw.load(self.filename)
         version = data['version']
         if version > 3:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -1,0 +1,1303 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016, German Neuroinformatics Node (G-Node)
+#                     Achilleas Koutsou <achilleas.k@gmail.com>
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted under the terms of the BSD License. See
+# LICENSE file in the root of the Project.
+"""
+Module for reading data from files in the NIX format.
+
+Author: Achilleas Koutsou
+
+This IO supports both writina and reading of NIX files. Reading is supported
+only if the NIX file was created using this IO.
+"""
+
+from __future__ import absolute_import, print_function
+
+import time
+from datetime import datetime
+from collections import Iterable
+import itertools
+from six import string_types
+from hashlib import md5
+
+import quantities as pq
+import numpy as np
+
+from neo.io.baseio import BaseIO
+from neo.core import (Block, Segment, ChannelIndex, AnalogSignal,
+                      IrregularlySampledSignal, Epoch, Event, SpikeTrain, Unit)
+from neo.io.tools import LazyList
+
+try:
+    import nixio
+except ImportError:
+    raise ImportError("Failed to import NIX. "
+                      "The NixIO requires the Python bindings for NIX "
+                      "(nixio on PyPi).")
+
+
+def stringify(value):
+    if value is None:
+        return value
+    if isinstance(value, bytes):
+        value = value.decode()
+    return str(value)
+
+
+def nix_type_dict():
+    pycore = nixio.pycore
+
+    typedict = {
+        "Block": (pycore.Block,),
+        "Group": (pycore.Group,),
+        "SampledDimension": (pycore.SampledDimension,),
+        "RangeDimension": (pycore.RangeDimension,),
+        "SetDimension": (pycore.SetDimension,)
+    }
+
+    try:
+        ccore = nixio.core
+        typedict["Block"] += (ccore.Block,)
+        typedict["Group"] += (ccore.Group,)
+        typedict["SampledDimension"] += (ccore.SampledDimension,)
+        typedict["RangeDimension"] += (ccore.RangeDimension,)
+        typedict["SetDimension"] += (ccore.SetDimension,)
+    except AttributeError:
+        pass
+
+    return typedict
+
+nixtypes = nix_type_dict()
+
+
+def calculate_timestamp(dt):
+    return int(time.mktime(dt.timetuple()))
+
+
+class NixIO(BaseIO):
+    """
+    Class for reading and writing NIX files.
+    """
+
+    is_readable = True
+    is_writable = True
+
+    supported_objects = [Block, Segment, ChannelIndex,
+                         AnalogSignal, IrregularlySampledSignal,
+                         Epoch, Event, SpikeTrain, Unit]
+    readable_objects = [Block]
+    writeable_objects = [Block]
+
+    name = "NIX"
+    extensions = ["h5"]
+    mode = "file"
+
+    _container_map = {
+        "segments": "groups",
+        "analogsignals": "data_arrays",
+        "irregularlysampledsignals": "data_arrays",
+        "events": "multi_tags",
+        "epochs": "multi_tags",
+        "spiketrains": "multi_tags",
+        "channel_indexes": "sources",
+        "units": "sources"
+    }
+
+    def __init__(self, filename, mode="ro"):
+        """
+        Initialise IO instance and NIX file.
+
+        :param filename: Full path to the file
+        """
+        BaseIO.__init__(self, filename)
+        self.filename = filename
+        if mode == "ro":
+            filemode = nixio.FileMode.ReadOnly
+        elif mode == "rw":
+            filemode = nixio.FileMode.ReadWrite
+        elif mode == "ow":
+            filemode = nixio.FileMode.Overwrite
+        else:
+            raise ValueError("Invalid mode specified '{}'. "
+                             "Valid modes: 'ro' (ReadOnly)', 'rw' (ReadWrite), "
+                             "'ow' (Overwrite).".format(mode))
+        self.nix_file = nixio.File.open(self.filename, filemode, backend="h5py")
+        self._object_map = dict()
+        self._lazy_loaded = list()
+        self._object_hashes = dict()
+        self._block_read_counter = 0
+
+    def read_all_blocks(self, cascade=True, lazy=False):
+        blocks = list()
+        for blk in self.nix_file.blocks:
+            blocks.append(self.read_block("/" + blk.name, cascade, lazy))
+        return blocks
+
+    def read_block(self, path="/", cascade=True, lazy=False):
+        if path == "/":
+            try:
+                # Use yield?
+                nix_block = self.nix_file.blocks[self._block_read_counter]
+                path += nix_block.name
+                self._block_read_counter += 1
+            except KeyError:
+                return None
+        else:
+            nix_block = self._get_object_at(path)
+        neo_block = self._block_to_neo(nix_block)
+        neo_block.path = path
+        if cascade:
+            self._read_cascade(nix_block, path, cascade, lazy)
+        self._update_maps(neo_block, lazy)
+        return neo_block
+
+    def read_segment(self, path, cascade=True, lazy=False):
+        nix_group = self._get_object_at(path)
+        neo_segment = self._group_to_neo(nix_group)
+        neo_segment.path = path
+        if cascade:
+            self._read_cascade(nix_group, path, cascade, lazy)
+        self._update_maps(neo_segment, lazy)
+        nix_parent = self._get_parent(path)
+        neo_parent = self._get_mapped_object(nix_parent)
+        if neo_parent:
+            neo_segment.block = neo_parent
+        return neo_segment
+
+    def read_channelindex(self, path, cascade=True, lazy=False):
+        nix_source = self._get_object_at(path)
+        neo_rcg = self._source_chx_to_neo(nix_source)
+        neo_rcg.path = path
+        if cascade:
+            self._read_cascade(nix_source, path, cascade, lazy)
+        self._update_maps(neo_rcg, lazy)
+        nix_parent = self._get_parent(path)
+        neo_parent = self._get_mapped_object(nix_parent)
+        neo_rcg.block = neo_parent
+        return neo_rcg
+
+    def read_signal(self, path, lazy=False):
+        nix_data_arrays = list()
+        parent_group = self._get_parent(path)
+        parent_container = parent_group.data_arrays
+        signal_group_name = path.split("/")[-1]
+        for idx in itertools.count():
+            signal_name = "{}.{}".format(signal_group_name, idx)
+            if signal_name in parent_container:
+                nix_data_arrays.append(parent_container[signal_name])
+            else:
+                break
+        # check metadata segment
+        group_section = nix_data_arrays[0].metadata
+        for da in nix_data_arrays:
+            assert da.metadata == group_section,\
+                "DataArray {} is not a member of signal group {}".format(
+                    da.name, group_section.name
+                )
+        neo_signal = self._signal_da_to_neo(nix_data_arrays, lazy)
+        neo_signal.path = path
+        if self._find_lazy_loaded(neo_signal) is None:
+            self._update_maps(neo_signal, lazy)
+            nix_parent = self._get_parent(path)
+            neo_parent = self._get_mapped_object(nix_parent)
+            neo_signal.segment = neo_parent
+        return neo_signal
+
+    def read_analogsignal(self, path, cascade=True, lazy=False):
+        return self.read_signal(path, lazy)
+
+    def read_irregularlysampledsignal(self, path, cascade=True, lazy=False):
+        return self.read_signal(path, lazy)
+
+    def read_eest(self, path, lazy=False):
+        nix_mtag = self._get_object_at(path)
+        neo_eest = self._mtag_eest_to_neo(nix_mtag, lazy)
+        neo_eest.path = path
+        self._update_maps(neo_eest, lazy)
+        nix_parent = self._get_parent(path)
+        neo_parent = self._get_mapped_object(nix_parent)
+        neo_eest.segment = neo_parent
+        return neo_eest
+
+    def read_epoch(self, path, cascade=True, lazy=False):
+        return self.read_eest(path, lazy)
+
+    def read_event(self, path, cascade=True, lazy=False):
+        return self.read_eest(path, lazy)
+
+    def read_spiketrain(self, path, cascade=True, lazy=False):
+        return self.read_eest(path, lazy)
+
+    def read_unit(self, path, cascade=True, lazy=False):
+        nix_source = self._get_object_at(path)
+        neo_unit = self._source_unit_to_neo(nix_source)
+        neo_unit.path = path
+        if cascade:
+            self._read_cascade(nix_source, path, cascade, lazy)
+        self._update_maps(neo_unit, lazy)
+        nix_parent = self._get_parent(path)
+        neo_parent = self._get_mapped_object(nix_parent)
+        neo_unit.channel_index = neo_parent
+        return neo_unit
+
+    def _block_to_neo(self, nix_block):
+        neo_attrs = self._nix_attr_to_neo(nix_block)
+        neo_block = Block(**neo_attrs)
+        self._object_map[nix_block.id] = neo_block
+        return neo_block
+
+    def _group_to_neo(self, nix_group):
+        neo_attrs = self._nix_attr_to_neo(nix_group)
+        neo_segment = Segment(**neo_attrs)
+        self._object_map[nix_group.id] = neo_segment
+        return neo_segment
+
+    def _source_chx_to_neo(self, nix_source):
+        neo_attrs = self._nix_attr_to_neo(nix_source)
+        chx = list(self._nix_attr_to_neo(c)
+                   for c in nix_source.sources
+                   if c.type == "neo.channelindex")
+        neo_attrs["channel_names"] = np.array([c["name"] for c in chx],
+                                              dtype="S")
+        neo_attrs["index"] = np.array([c["index"] for c in chx])
+        if "coordinates" in chx[0]:
+            coord_units = chx[0]["coordinates.units"]
+            coord_values = list(c["coordinates"] for c in chx)
+            neo_attrs["coordinates"] = pq.Quantity(coord_values, coord_units)
+        rcg = ChannelIndex(**neo_attrs)
+        self._object_map[nix_source.id] = rcg
+        return rcg
+
+    def _source_unit_to_neo(self, nix_unit):
+        neo_attrs = self._nix_attr_to_neo(nix_unit)
+        neo_unit = Unit(**neo_attrs)
+        self._object_map[nix_unit.id] = neo_unit
+        return neo_unit
+
+    def _signal_da_to_neo(self, nix_da_group, lazy):
+        """
+        Convert a group of NIX DataArrays to a Neo signal. This method expects
+        a list of data arrays that all represent the same, multidimensional
+        Neo Signal object.
+        This returns either an AnalogSignal or IrregularlySampledSignal.
+
+        :param nix_da_group: a list of NIX DataArray objects
+        :return: a Neo Signal object
+        """
+        nix_da_group = sorted(nix_da_group, key=lambda d: d.name)
+        neo_attrs = self._nix_attr_to_neo(nix_da_group[0])
+        metadata = nix_da_group[0].metadata
+        neo_attrs["name"] = stringify(metadata.name)
+        neo_type = nix_da_group[0].type
+
+        unit = nix_da_group[0].unit
+        if lazy:
+            signaldata = pq.Quantity(np.empty(0), unit)
+            lazy_shape = (len(nix_da_group[0]), len(nix_da_group))
+        else:
+            signaldata = pq.Quantity(np.transpose(nix_da_group), unit)
+            lazy_shape = None
+        timedim = self._get_time_dimension(nix_da_group[0])
+        if (neo_type == "neo.analogsignal" or
+                isinstance(timedim, nixtypes["SampledDimension"])):
+            if lazy:
+                sampling_period = pq.Quantity(1, timedim.unit)
+                t_start = pq.Quantity(0, timedim.unit)
+            else:
+                if "sampling_interval.units" in metadata.props:
+                    sample_units = metadata["sampling_interval.units"]
+                else:
+                    sample_units = timedim.unit
+                sampling_period = pq.Quantity(timedim.sampling_interval,
+                                              sample_units)
+                if "t_start.units" in metadata.props:
+                    tsunits = metadata["t_start.units"]
+                else:
+                    tsunits = timedim.unit
+                t_start = pq.Quantity(timedim.offset, tsunits)
+            neo_signal = AnalogSignal(
+                signal=signaldata, sampling_period=sampling_period,
+                t_start=t_start, **neo_attrs
+            )
+        elif neo_type == "neo.irregularlysampledsignal"\
+                or isinstance(timedim, nixtypes["RangeDimension"]):
+            if lazy:
+                times = pq.Quantity(np.empty(0), timedim.unit)
+            else:
+                times = pq.Quantity(timedim.ticks, timedim.unit)
+            neo_signal = IrregularlySampledSignal(
+                signal=signaldata, times=times, **neo_attrs
+            )
+        else:
+            return None
+        for da in nix_da_group:
+            self._object_map[da.id] = neo_signal
+        if lazy_shape:
+            neo_signal.lazy_shape = lazy_shape
+        return neo_signal
+
+    def _mtag_eest_to_neo(self, nix_mtag, lazy):
+        neo_attrs = self._nix_attr_to_neo(nix_mtag)
+        neo_type = nix_mtag.type
+
+        time_unit = nix_mtag.positions.unit
+        if lazy:
+            times = pq.Quantity(np.empty(0), time_unit)
+            lazy_shape = np.shape(nix_mtag.positions)
+        else:
+            times = pq.Quantity(nix_mtag.positions, time_unit)
+            lazy_shape = None
+        if neo_type == "neo.epoch":
+            if lazy:
+                durations = pq.Quantity(np.empty(0), nix_mtag.extents.unit)
+                labels = np.empty(0, dtype='S')
+            else:
+                durations = pq.Quantity(nix_mtag.extents, nix_mtag.extents.unit)
+                labels = np.array(nix_mtag.positions.dimensions[0].labels,
+                                  dtype="S")
+            eest = Epoch(times=times, durations=durations, labels=labels,
+                         **neo_attrs)
+        elif neo_type == "neo.event":
+            if lazy:
+                labels = np.empty(0, dtype='S')
+            else:
+                labels = np.array(nix_mtag.positions.dimensions[0].labels,
+                                  dtype="S")
+            eest = Event(times=times, labels=labels, **neo_attrs)
+        elif neo_type == "neo.spiketrain":
+            if "t_start" in neo_attrs:
+                if "t_start.units" in neo_attrs:
+                    t_start_units = neo_attrs["t_start.units"]
+                    del neo_attrs["t_start.units"]
+                else:
+                    t_start_units = time_unit
+                t_start = pq.Quantity(neo_attrs["t_start"], t_start_units)
+                del neo_attrs["t_start"]
+            else:
+                t_start = None
+            if "t_stop" in neo_attrs:
+                if "t_stop.units" in neo_attrs:
+                    t_stop_units = neo_attrs["t_stop.units"]
+                    del neo_attrs["t_stop.units"]
+                else:
+                    t_stop_units = time_unit
+                t_stop = pq.Quantity(neo_attrs["t_stop"], t_stop_units)
+                del neo_attrs["t_stop"]
+            else:
+                t_stop = None
+            if "sampling_interval.units" in neo_attrs:
+                interval_units = neo_attrs["sampling_interval.units"]
+                del neo_attrs["sampling_interval.units"]
+            else:
+                interval_units = None
+            if "left_sweep.units" in neo_attrs:
+                left_sweep_units = neo_attrs["left_sweep.units"]
+                del neo_attrs["left_sweep.units"]
+            else:
+                left_sweep_units = None
+            eest = SpikeTrain(times=times, t_start=t_start,
+                              t_stop=t_stop, **neo_attrs)
+            if len(nix_mtag.features):
+                wfda = nix_mtag.features[0].data
+                wftime = self._get_time_dimension(wfda)
+                if lazy:
+                    eest.waveforms = pq.Quantity(np.empty((0, 0, 0)), wfda.unit)
+                    eest.sampling_period = pq.Quantity(1, wftime.unit)
+                    eest.left_sweep = pq.Quantity(0, wftime.unit)
+                else:
+                    eest.waveforms = pq.Quantity(wfda, wfda.unit)
+                    if interval_units is None:
+                        interval_units = wftime.unit
+                    eest.sampling_period = pq.Quantity(
+                        wftime.sampling_interval, interval_units
+                    )
+                    if left_sweep_units is None:
+                        left_sweep_units = wftime.unit
+                    if "left_sweep" in wfda.metadata:
+                        eest.left_sweep = pq.Quantity(
+                            wfda.metadata["left_sweep"], left_sweep_units
+                        )
+        else:
+            return None
+        self._object_map[nix_mtag.id] = eest
+        if lazy_shape:
+            eest.lazy_shape = lazy_shape
+        return eest
+
+    def _read_cascade(self, nix_obj, path, cascade, lazy):
+        neo_obj = self._object_map[nix_obj.id]
+        for neocontainer in getattr(neo_obj, "_child_containers", []):
+            nixcontainer = self._container_map[neocontainer]
+            if not hasattr(nix_obj, nixcontainer):
+                continue
+            if neocontainer == "channel_indexes":
+                neotype = "channelindex"
+            else:
+                neotype = neocontainer[:-1]
+            chpaths = list(path + "/" + neocontainer + "/" + c.name
+                           for c in getattr(nix_obj, nixcontainer)
+                           if c.type == "neo." + neotype)
+            if neocontainer in ("analogsignals",
+                                "irregularlysampledsignals"):
+                chpaths = self._group_signals(chpaths)
+            if cascade != "lazy":
+                read_func = getattr(self, "read_" + neotype)
+                children = list(read_func(cp, cascade, lazy)
+                                for cp in chpaths)
+            else:
+                children = LazyList(self, lazy, chpaths)
+            setattr(neo_obj, neocontainer, children)
+
+        if isinstance(neo_obj, ChannelIndex):
+            # set references to signals
+            parent_block_path = "/" + path.split("/")[1]
+            parent_block = self._get_object_at(parent_block_path)
+            ref_das = self._get_referers(nix_obj, parent_block.data_arrays)
+            ref_signals = self._get_mapped_objects(ref_das)
+            # deduplicate by name
+            ref_signals = list(dict((s.name, s) for s in ref_signals).values())
+            for sig in ref_signals:
+                if isinstance(sig, AnalogSignal):
+                    neo_obj.analogsignals.append(sig)
+                elif isinstance(sig, IrregularlySampledSignal):
+                    neo_obj.irregularlysampledsignals.append(sig)
+                sig.channel_index = neo_obj
+
+        elif isinstance(neo_obj, Unit):
+            # set references to spiketrains
+            parent_block_path = "/" + path.split("/")[1]
+            parent_block = self._get_object_at(parent_block_path)
+            ref_mtags = self._get_referers(nix_obj, parent_block.multi_tags)
+            ref_sts = self._get_mapped_objects(ref_mtags)
+            for st in ref_sts:
+                neo_obj.spiketrains.append(st)
+                st.unit = neo_obj
+
+    def get(self, path, cascade, lazy):
+        parts = path.split("/")
+        if len(parts) > 2:
+            neotype = parts[-2][:-1]
+        else:
+            neotype = "block"
+        if neotype == "channel_indexe":
+            neotype = "channelindex"
+        read_func = getattr(self, "read_" + neotype)
+        return read_func(path, cascade, lazy)
+
+    def load_lazy_object(self, obj):
+        return self.get(obj.path, cascade=False, lazy=False)
+
+    def load_lazy_cascade(self, path, lazy):
+        """
+        Loads the object at the location specified by the path and all children.
+        Data is loaded if lazy is False.
+
+        :param path: Location of object in file
+        :param lazy: Do not load data if True
+        :return: The loaded object
+        """
+        neoobj = self.get(path, cascade=True, lazy=lazy)
+        return neoobj
+
+    def write_all_blocks(self, neo_blocks):
+        """
+        Convert all ``neo_blocks`` to the NIX equivalent and write them to the
+        file.
+
+        :param neo_blocks: List (or iterable) containing Neo blocks
+        :return: A list containing the new NIX Blocks
+        """
+        self.resolve_name_conflicts(neo_blocks)
+        for bl in neo_blocks:
+            self.write_block(bl)
+
+    def _write_object(self, obj, loc=""):
+        if isinstance(obj, Block):
+            containerstr = "/"
+        else:
+            objtype = type(obj).__name__.lower()
+            if objtype == "channelindex":
+                containerstr = "/channel_indexes/"
+            else:
+                containerstr = "/" + type(obj).__name__.lower() + "s/"
+        self.resolve_name_conflicts(obj)
+        objpath = loc + containerstr + obj.name
+        oldhash = self._object_hashes.get(objpath)
+        if oldhash is None:
+            try:
+                oldobj = self.get(objpath, cascade=False, lazy=False)
+                oldhash = self._hash_object(oldobj)
+            except (KeyError, IndexError):
+                oldhash = None
+        newhash = self._hash_object(obj)
+        if oldhash != newhash:
+            attr = self._neo_attr_to_nix(obj)
+            if isinstance(obj, pq.Quantity):
+                attr.update(self._neo_data_to_nix(obj))
+            if oldhash is None:
+                nixobj = self._create_nix_obj(loc, attr)
+            else:
+                nixobj = self._get_object_at(objpath)
+            self._write_attr_annotations(nixobj, attr, objpath)
+            if isinstance(obj, pq.Quantity):
+                self._write_data(nixobj, attr, objpath)
+        else:
+            nixobj = self._get_object_at(objpath)
+        self._object_map[id(obj)] = nixobj
+        self._object_hashes[objpath] = newhash
+        self._write_cascade(obj, objpath)
+
+    def _create_nix_obj(self, loc, attr):
+        parentobj = self._get_object_at(loc)
+        if attr["type"] == "block":
+            nixobj = parentobj.create_block(attr["name"], "neo.block")
+        elif attr["type"] == "segment":
+            nixobj = parentobj.create_group(attr["name"], "neo.segment")
+        elif attr["type"] == "channelindex":
+            nixobj = parentobj.create_source(attr["name"],
+                                               "neo.channelindex")
+        elif attr["type"] in ("analogsignal", "irregularlysampledsignal"):
+            blockpath = "/" + loc.split("/")[1]
+            parentblock = self._get_object_at(blockpath)
+            nixobj = list()
+            typestr = "neo." + attr["type"]
+            parentmd = self._get_or_init_metadata(parentobj, loc)
+            sigmd = parentmd.create_section(attr["name"], typestr+".metadata")
+            for idx, datarow in enumerate(attr["data"]):
+                name = "{}.{}".format(attr["name"], idx)
+                da = parentblock.create_data_array(name, typestr, data=datarow)
+                da.metadata = sigmd
+                nixobj.append(da)
+            parentobj.data_arrays.extend(nixobj)
+        elif attr["type"] in ("epoch", "event", "spiketrain"):
+            blockpath = "/" + loc.split("/")[1]
+            parentblock = self._get_object_at(blockpath)
+            timesda = parentblock.create_data_array(
+                attr["name"]+".times", "neo."+attr["type"]+".times",
+                data=attr["data"]
+            )
+            nixobj = parentblock.create_multi_tag(
+                attr["name"], "neo."+attr["type"], timesda
+            )
+            parentobj.multi_tags.append(nixobj)
+        elif attr["type"] == "unit":
+            nixobj = parentobj.create_source(attr["name"], "neo.unit")
+        else:
+            raise ValueError("Unable to create NIX object. Invalid type.")
+        return nixobj
+
+    def write_block(self, bl, loc=""):
+        """
+        Convert ``bl`` to the NIX equivalent and write it to the file.
+
+        :param bl: Neo block to be written
+        :param loc: Unused for blocks
+        """
+        self._write_object(bl, loc)
+        self._create_references(bl)
+
+    def write_channelindex(self, chx, loc=""):
+        """
+        Convert the provided ``chx`` (ChannelIndex) to a NIX Source and write it
+        to the NIX file at the location defined by ``loc``.
+
+        :param chx: The Neo ChannelIndex to be written
+        :param loc: Path to the parent of the new CHX
+        """
+        self._write_object(chx, loc)
+
+    def write_segment(self, seg, loc=""):
+        """
+        Convert the provided ``seg`` to a NIX Group and write it to the NIX
+        file at the location defined by ``loc``.
+
+        :param seg: Neo seg to be written
+        :param loc: Path to the parent of the new Segment
+        """
+        self._write_object(seg, loc)
+
+    def write_indices(self, chx, loc=""):
+        """
+        Create NIX Source objects to represent individual indices based on the
+        provided ``chx`` (ChannelIndex) write them to the NIX file at
+        the parent ChannelIndex object.
+
+        :param chx: The Neo ChannelIndex
+        :param loc: Path to the CHX
+        """
+        nixsource = self._get_mapped_object(chx)
+        for idx, channel in enumerate(chx.index):
+            if len(chx.channel_names):
+                channame = stringify(chx.channel_names[idx])
+            else:
+                channame = "{}.ChannelIndex{}".format(chx.name, idx)
+            if channame in nixsource.sources:
+                nixchan = nixsource.sources[channame]
+            else:
+                nixchan = nixsource.create_source(channame,
+                                                  "neo.channelindex")
+            nixchan.definition = nixsource.definition
+            chanpath = loc + "/channelindex/" + channame
+            chanmd = self._get_or_init_metadata(nixchan, chanpath)
+            chanmd["index"] = self._to_value(int(channel))
+            if chx.coordinates is not None:
+                coords = chx.coordinates[idx]
+                coordunits = stringify(coords[0].dimensionality)
+                nixcoordunits = self._to_value(coordunits)
+                nixcoords = tuple(
+                    self._to_value(c.rescale(coordunits).magnitude.item())
+                    for c in coords
+                )
+                if "coordinates" in chanmd:
+                    del chanmd["coordinates"]
+                chanmd.create_property("coordinates", nixcoords)
+                chanmd["coordinates.units"] = nixcoordunits
+
+    def write_analogsignal(self, anasig, loc=""):
+        """
+        Convert the provided ``anasig`` (AnalogSignal) to a list of NIX
+        DataArray objects and write them to the NIX file at the location defined
+        by ``loc``. All DataArray objects created from the same
+        AnalogSignal have their metadata section point to the same object.
+
+        :param anasig: The Neo AnalogSignal to be written
+        :param loc: Path to the parent of the new AnalogSignal
+        """
+        self._write_object(anasig, loc)
+
+    def write_irregularlysampledsignal(self, irsig, loc=""):
+        """
+        Convert the provided ``irsig`` (IrregularlySampledSignal) to a list of
+        NIX DataArray objects and write them to the NIX file at the location
+        defined by ``loc``. All DataArray objects created from the same
+        IrregularlySampledSignal have their metadata section point to the same
+        object.
+
+        :param irsig: The Neo IrregularlySampledSignal to be written
+        :param loc: Path to the parent of the new
+        :return: The newly created NIX DataArray
+        """
+        self._write_object(irsig, loc)
+
+    def write_epoch(self, ep, loc=""):
+        """
+        Convert the provided ``ep`` (Epoch) to a NIX MultiTag and write it to
+        the NIX file at the location defined by ``loc``.
+
+        :param ep: The Neo Epoch to be written
+        :param loc: Path to the parent of the new MultiTag
+        """
+        self._write_object(ep, loc)
+
+    def write_event(self, ev, loc=""):
+        """
+        Convert the provided ``ev`` (Event) to a NIX MultiTag and write it to
+        the NIX file at the location defined by ``loc``.
+
+        :param ev: The Neo Event to be written
+        :param loc: Path to the parent of the new MultiTag
+        """
+        self._write_object(ev, loc)
+
+    def write_spiketrain(self, sptr, loc=""):
+        """
+        Convert the provided ``sptr`` (SpikeTrain) to a NIX MultiTag and write
+        it to the NIX file at the location defined by ``loc``.
+
+        :param sptr: The Neo SpikeTrain to be written
+        :param loc: Path to the parent of the new MultiTag
+        """
+        self._write_object(sptr, loc)
+
+    def write_unit(self, ut, loc=""):
+        """
+        Convert the provided ``ut`` (Unit) to a NIX Source and write it to the
+        NIX file at the parent RCG.
+
+        :param ut: The Neo Unit to be written
+        :param loc: Path to the parent of the new Source
+        """
+        self._write_object(ut, loc)
+
+    def _write_cascade(self, neoobj, path=""):
+        if isinstance(neoobj, ChannelIndex):
+            containers = ["units"]
+            self.write_indices(neoobj, path)
+        elif isinstance(neoobj, Unit):
+            containers = []
+        else:
+            containers = getattr(neoobj, "_child_containers", [])
+        for neocontainer in containers:
+            if neocontainer == "channel_indexes":
+                neotype = "channelindex"
+            else:
+                neotype = neocontainer[:-1]
+            children = getattr(neoobj, neocontainer)
+            write_func = getattr(self, "write_" + neotype)
+            for ch in children:
+                write_func(ch, path)
+
+    def _create_references(self, block):
+        """
+        Create references between NIX objects according to the supplied Neo
+        Block.
+        MultiTags reference DataArrays of the same Group.
+        DataArrays reference ChannelIndexs as sources, based on Neo
+         RCG -> Signal relationships.
+        MultiTags (SpikeTrains) reference ChannelIndexs and Units as
+         sources, based on Neo RCG -> Unit -> SpikeTrain relationships.
+
+        :param block: A Neo Block that has already been converted and mapped to
+         NIX objects.
+        """
+        for seg in block.segments:
+            group = self._get_mapped_object(seg)
+            group_signals = self._get_contained_signals(group)
+            for mtag in group.multi_tags:
+                if mtag.type in ("neo.epoch", "neo.event"):
+                    mtag.references.extend([sig for sig in group_signals
+                                            if sig not in mtag.references])
+        for rcg in block.channel_indexes:
+            rcgsource = self._get_mapped_object(rcg)
+            das = self._get_mapped_objects(rcg.analogsignals +
+                                           rcg.irregularlysampledsignals)
+            # flatten nested lists
+            das = [da for dalist in das for da in dalist]
+            for da in das:
+                if rcgsource not in da.sources:
+                    da.sources.append(rcgsource)
+            for unit in rcg.units:
+                unitsource = self._get_mapped_object(unit)
+                for st in unit.spiketrains:
+                    stmtag = self._get_mapped_object(st)
+                    if rcgsource not in stmtag.sources:
+                        stmtag.sources.append(rcgsource)
+                    if unitsource not in stmtag.sources:
+                        stmtag.sources.append(unitsource)
+
+    def _get_or_init_metadata(self, nix_obj, path):
+        """
+        Creates a metadata Section for the provided NIX object if it doesn't
+        have one already. Returns the new or existing metadata section.
+
+        :param nix_obj: The object to which the Section is attached
+        :param path: Path to nix_obj
+        :return: The metadata section of the provided object
+        """
+        parent_parts = path.split("/")[:-2]
+        parent_path = "/".join(parent_parts)
+        if nix_obj.metadata is None:
+            if len(parent_parts) == 0:  # nix_obj is root block
+                parent_metadata = self.nix_file
+            else:
+                obj_parent = self._get_object_at(parent_path)
+                parent_metadata = self._get_or_init_metadata(obj_parent,
+                                                             parent_path)
+            nix_obj.metadata = parent_metadata.create_section(
+                    nix_obj.name, nix_obj.type+".metadata"
+            )
+        return nix_obj.metadata
+
+    def _get_object_at(self, path):
+        """
+        Returns the object at the location defined by the path.
+        ``path`` is a '/' delimited string. Each part of the string alternates
+        between an object name and a container.
+
+        If the requested object is an AnalogSignal or IrregularlySampledSignal,
+        identified by the second-to-last part of the path string, a list of
+        (DataArray) objects is returned.
+
+        Example path: /block_1/segments/segment_a/events/event_a1
+
+        :param path: Path string
+        :return: The object at the location defined by the path
+        """
+        if path in ("", "/"):
+            return self.nix_file
+        parts = path.split("/")
+        if parts[0]:
+            ValueError("Invalid object path: {}".format(path))
+        if len(parts) == 2:  # root block
+            return self.nix_file.blocks[parts[1]]
+        parent_obj = self._get_parent(path)
+        container_name = self._container_map[parts[-2]]
+        parent_container = getattr(parent_obj, container_name)
+        objname = parts[-1]
+        if parts[-2] in ["analogsignals", "irregularlysampledsignals"]:
+            obj = list()
+            for idx in itertools.count():
+                name = "{}.{}".format(objname, idx)
+                if name in parent_container:
+                    obj.append(parent_container[name])
+                else:
+                    break
+        else:
+            obj = parent_container[objname]
+        return obj
+
+    def _get_parent(self, path):
+        parts = path.split("/")
+        parent_path = "/".join(parts[:-2])
+        parent_obj = self._get_object_at(parent_path)
+        return parent_obj
+
+    def _get_mapped_objects(self, object_list):
+        return list(map(self._get_mapped_object, object_list))
+
+    def _get_mapped_object(self, obj):
+        # We could use paths here instead
+        try:
+            if hasattr(obj, "id"):
+                return self._object_map[obj.id]
+            else:
+                return self._object_map[id(obj)]
+        except KeyError:
+            # raise KeyError("Failed to find mapped object for {}. "
+            #                "Object not yet converted.".format(obj))
+            return None
+
+    def _write_attr_annotations(self, nixobj, attr, path):
+        if isinstance(nixobj, list):
+            for obj in nixobj:
+                obj.definition = attr["definition"]
+            self._write_attr_annotations(nixobj[0], attr, path)
+            return
+        else:
+            nixobj.definition = attr["definition"]
+        if "created_at" in attr:
+            nixobj.force_created_at(calculate_timestamp(attr["created_at"]))
+        if "file_datetime" in attr:
+            metadata = self._get_or_init_metadata(nixobj, path)
+            metadata["file_datetime"] = self._to_value(attr["file_datetime"])
+        if "rec_datetime" in attr and attr["rec_datetime"]:
+            metadata = self._get_or_init_metadata(nixobj, path)
+            metadata["rec_datetime"] = self._to_value(attr["rec_datetime"])
+        if "annotations" in attr:
+            metadata = self._get_or_init_metadata(nixobj, path)
+            self._add_annotations(attr["annotations"], metadata)
+
+    def _write_data(self, nixobj, attr, path):
+        if isinstance(nixobj, list):
+            metadata = self._get_or_init_metadata(nixobj[0], path)
+            metadata["t_start.units"] = self._to_value(attr["t_start.units"])
+            for obj in nixobj:
+                obj.unit = attr["data.units"]
+                if attr["type"] == "analogsignal":
+                    timedim = obj.append_sampled_dimension(
+                        attr["sampling_interval"]
+                    )
+                    timedim.unit = attr["sampling_interval.units"]
+                elif attr["type"] == "irregularlysampledsignal":
+                    timedim = obj.append_range_dimension(attr["times"])
+                    timedim.unit = attr["times.units"]
+                timedim.label = "time"
+                timedim.offset = attr["t_start"]
+                obj.append_set_dimension()
+        else:
+            nixobj.positions.unit = attr["data.units"]
+            blockpath = "/" + path.split("/")[1]
+            parentblock = self._get_object_at(blockpath)
+            if "extents" in attr:
+                extname = nixobj.name + ".durations"
+                exttype = nixobj.type + ".durations"
+                if extname in parentblock.data_arrays:
+                    del parentblock.data_arrays[extname]
+                extents = parentblock.create_data_array(
+                    extname,
+                    exttype,
+                    data=attr["extents"]
+                )
+                extents.unit = attr["extents.units"]
+                nixobj.extents = extents
+            if "labels" in attr:
+                labeldim = nixobj.positions.append_set_dimension()
+                labeldim.labels = attr["labels"]
+            metadata = self._get_or_init_metadata(nixobj, path)
+            if "t_start" in attr:
+                metadata["t_start"] = self._to_value(attr["t_start"])
+                metadata["t_start.units"] = self._to_value(attr["t_start.units"])
+            if "t_stop" in attr:
+                metadata["t_stop"] = self._to_value(attr["t_stop"])
+                metadata["t_stop.units"] = self._to_value(attr["t_stop.units"])
+            if "waveforms" in attr:
+                wfname = nixobj.name + ".waveforms"
+                if wfname in parentblock.data_arrays:
+                    del parentblock.data_arrays[wfname]
+                    del nixobj.features[0]
+                wfda = parentblock.create_data_array(
+                    wfname, "neo.waveforms",
+                    data=attr["waveforms"]
+                )
+                wfda.unit = attr["waveforms.units"]
+                nixobj.create_feature(wfda, nixio.LinkType.Indexed)
+                wfda.append_set_dimension()
+                wfda.append_set_dimension()
+                wftime = wfda.append_sampled_dimension(
+                    attr["sampling_interval"]
+                )
+                metadata["sampling_interval.units"] = self._to_value(
+                    attr["sampling_interval.units"]
+                )
+                wftime.unit = attr["times.units"]
+                wftime.label = "time"
+                if wfname in metadata.sections:
+                    wfda.metadata = metadata.sections[wfname]
+                else:
+                    wfpath = path + "/waveforms/" + wfname
+                    wfda.metadata = self._get_or_init_metadata(wfda, wfpath)
+                if "left_sweep" in attr:
+                    wfda.metadata["left_sweep"] = self._to_value(
+                        attr["left_sweep"]
+                    )
+
+    def _update_maps(self, obj, lazy):
+        objidx = self._find_lazy_loaded(obj)
+        if lazy and objidx is None:
+            self._lazy_loaded.append(obj)
+        elif not lazy and objidx is not None:
+            self._lazy_loaded.pop(objidx)
+        if not lazy:
+            self._object_hashes[obj.path] = self._hash_object(obj)
+
+    def _find_lazy_loaded(self, obj):
+        """
+        Finds the index of an object in the _lazy_loaded list by comparing the
+        path attribute. Returns None if the object is not in the list.
+
+        :param obj: The object to find
+        :return: The index of the object in the _lazy_loaded list or None if it
+        was not added
+        """
+        for idx, llobj in enumerate(self._lazy_loaded):
+            if llobj.path == obj.path:
+                return idx
+        else:
+            return None
+
+    @classmethod
+    def resolve_name_conflicts(cls, objects):
+        """
+        Given a list of neo objects, change their names such that no two objects
+        share the same name. Objects with no name are renamed based on their
+        type.
+        If a container object is supplied (Block, Segment, or RCG), conflicts
+        are resolved for the child objects.
+
+        :param objects: List of Neo objects or Neo container object
+        """
+        if isinstance(objects, list):
+            if not len(objects):
+                return
+            names = [obj.name for obj in objects]
+            for idx, cn in enumerate(names):
+                if not cn:
+                    cn = cls._generate_name(objects[idx])
+                else:
+                    names[idx] = ""
+                if cn not in names:
+                    newname = cn
+                else:
+                    suffix = 1
+                    newname = "{}-{}".format(cn, suffix)
+                    while newname in names:
+                        suffix += 1
+                        newname = "{}-{}".format(cn, suffix)
+                names[idx] = newname
+            for obj, n in zip(objects, names):
+                obj.name = n
+            return
+        if not objects.name:
+            objects.name = cls._generate_name(objects)
+        if isinstance(objects, Block):
+            block = objects
+            allchildren = block.segments + block.channel_indexes
+            cls.resolve_name_conflicts(allchildren)
+            allchildren = list()
+            for seg in block.segments:
+                allchildren.extend(seg.analogsignals +
+                                   seg.irregularlysampledsignals +
+                                   seg.events +
+                                   seg.epochs +
+                                   seg.spiketrains)
+            cls.resolve_name_conflicts(allchildren)
+        elif isinstance(objects, Segment):
+            seg = objects
+            cls.resolve_name_conflicts(seg.analogsignals +
+                                       seg.irregularlysampledsignals +
+                                       seg.events +
+                                       seg.epochs +
+                                       seg.spiketrains)
+        elif isinstance(objects, ChannelIndex):
+            rcg = objects
+            cls.resolve_name_conflicts(rcg.units)
+
+    @staticmethod
+    def _generate_name(neoobj):
+        neotype = type(neoobj).__name__
+        return "neo.{}".format(neotype)
+
+    @staticmethod
+    def _neo_attr_to_nix(neoobj):
+        neotype = type(neoobj).__name__
+        attrs = dict()
+        attrs["name"] = neoobj.name
+        attrs["type"] = neotype.lower()
+        attrs["definition"] = neoobj.description
+        if isinstance(neoobj, (Block, Segment)):
+            attrs["rec_datetime"] = neoobj.rec_datetime
+            if neoobj.rec_datetime:
+                attrs["created_at"] = neoobj.rec_datetime
+            if neoobj.file_datetime:
+                attrs["file_datetime"] = neoobj.file_datetime
+        if neoobj.annotations:
+            attrs["annotations"] = neoobj.annotations
+        return attrs
+
+    @classmethod
+    def _neo_data_to_nix(cls, neoobj):
+        attr = dict()
+        attr["data"] = np.transpose(neoobj.magnitude)
+        attr["data.units"] = cls._get_units(neoobj)
+        if isinstance(neoobj, IrregularlySampledSignal):
+            attr["times"] = neoobj.times.magnitude
+            attr["times.units"] = cls._get_units(neoobj.times)
+        else:
+            attr["times.units"] = cls._get_units(neoobj.times, True)
+        if hasattr(neoobj, "t_start"):
+            attr["t_start"] = neoobj.t_start.magnitude.item()
+            attr["t_start.units"] = cls._get_units(neoobj.t_start)
+        if hasattr(neoobj, "t_stop"):
+            attr["t_stop"] = neoobj.t_stop.magnitude.item()
+            attr["t_stop.units"] = cls._get_units(neoobj.t_stop)
+        if hasattr(neoobj, "sampling_period"):
+            attr["sampling_interval"] = neoobj.sampling_period.magnitude.item()
+            attr["sampling_interval.units"] = cls._get_units(
+                neoobj.sampling_period
+            )
+        if hasattr(neoobj, "durations"):
+            attr["extents"] = neoobj.durations
+            attr["extents.units"] = cls._get_units(neoobj.durations)
+        if hasattr(neoobj, "labels"):
+            attr["labels"] = neoobj.labels.tolist()
+        if hasattr(neoobj, "waveforms") and neoobj.waveforms is not None:
+            attr["waveforms"] = list(wf.magnitude for wf in
+                                     list(wfgroup for wfgroup in
+                                          neoobj.waveforms))
+            attr["waveforms.units"] = cls._get_units(neoobj.waveforms)
+        if hasattr(neoobj, "left_sweep") and neoobj.left_sweep is not None:
+            attr["left_sweep"] = neoobj.left_sweep.magnitude
+            attr["left_sweep.units"] = cls._get_units(neoobj.left_sweep)
+        return attr
+
+    def _add_annotations(self, annotations, metadata):
+        for k, v in annotations.items():
+            v = self._to_value(v)
+            metadata[k] = v
+
+    def _to_value(self, v):
+        """
+        Helper function for converting arbitrary variables to types compatible
+        with nixio.Value().
+
+        :param v: The value to be converted
+        :return: a nixio.Value() object
+        """
+        if isinstance(v, pq.Quantity):
+            # v = nixio.Value((v.magnitude.item(), str(v.dimensionality)))
+            self.logger.warn("Quantities in annotations are not currently "
+                             "supported when writing to NIX. Units are dropped.")
+            v = nixio.Value(v.magnitude.item())
+        elif isinstance(v, datetime):
+            v = nixio.Value(calculate_timestamp(v))
+        elif isinstance(v, string_types):
+            v = nixio.Value(v)
+        elif isinstance(v, bytes):
+            v = nixio.Value(v.decode())
+        elif isinstance(v, Iterable):
+            vv = list()
+            for item in v:
+                if isinstance(item, Iterable):
+                    self.logger.warn("Multidimensional arrays and nested "
+                                     "containers are not currently supported "
+                                     "when writing to NIX.")
+                    return None
+                if type(item).__module__ == "numpy":
+                    item = nixio.Value(item.item())
+                else:
+                    item = nixio.Value(item)
+                vv.append(item)
+            if not len(vv):
+                vv = None
+            v = vv
+        elif type(v).__module__ == "numpy":
+            v = nixio.Value(v.item())
+        else:
+            v = nixio.Value(v)
+        return v
+
+    @staticmethod
+    def _get_contained_signals(obj):
+        return list(
+             da for da in obj.data_arrays
+             if da.type in ["neo.analogsignal", "neo.irregularlysampledsignal"]
+        )
+
+    @staticmethod
+    def _get_units(quantity, simplify=False):
+        """
+        Returns the units of a quantity value or array as a string, or None if
+        it is dimensionless.
+
+        :param quantity: Quantity scalar or array
+        :param simplify: True/False Simplify units
+        :return: Units of the quantity or None if dimensionless
+        """
+        units = quantity.units.dimensionality
+        if simplify:
+            units = units.simplified
+        units = stringify(units)
+        if units == "dimensionless":
+            units = None
+        return units
+
+    @staticmethod
+    def _nix_attr_to_neo(nix_obj):
+        neo_attrs = dict()
+        neo_attrs["name"] = stringify(nix_obj.name)
+
+        neo_attrs["description"] = stringify(nix_obj.definition)
+        if nix_obj.metadata:
+            for prop in nix_obj.metadata.props:
+                values = prop.values
+                if len(values) == 1:
+                    neo_attrs[prop.name] = values[0].value
+                else:
+                    neo_attrs[prop.name] = list(v.value for v in values)
+
+        if isinstance(nix_obj, (nixtypes["Block"], nixtypes["Group"])):
+            if "rec_datetime" not in neo_attrs:
+                neo_attrs["rec_datetime"] = None
+
+        #     neo_attrs["rec_datetime"] = datetime.fromtimestamp(
+        #         nix_obj.created_at)
+        if "file_datetime" in neo_attrs:
+            neo_attrs["file_datetime"] = datetime.fromtimestamp(
+                neo_attrs["file_datetime"]
+            )
+        # neo_attrs["file_origin"] = os.path.basename(self.filename)
+        return neo_attrs
+
+    @staticmethod
+    def _group_signals(paths):
+        """
+        Groups data arrays that were generated by the same Neo Signal object.
+
+        :param paths: A list of paths (strings) of all the signals to be grouped
+        :return: A list of paths (strings) of signal groups. The last part of
+        each path is the common name of the signals in the group.
+        """
+        grouppaths = list(".".join(p.split(".")[:-1])
+                          for p in paths)
+        # deduplicating paths
+        uniquepaths = []
+        for path in grouppaths:
+            if path not in uniquepaths:
+                uniquepaths.append(path)
+        return uniquepaths
+
+    @staticmethod
+    def _get_referers(nix_obj, obj_list):
+        ref_list = list()
+        for ref in obj_list:
+            if nix_obj.name in list(src.name for src in ref.sources):
+                ref_list.append(ref)
+        return ref_list
+
+    @staticmethod
+    def _get_time_dimension(obj):
+        for dim in obj.dimensions:
+            if hasattr(dim, "label") and dim.label == "time":
+                return dim
+        return None
+
+    @staticmethod
+    def _hash_object(obj):
+        """
+        Computes an MD5 hash of a Neo object based on its attribute values and
+        data objects. Child objects are not counted.
+
+        :param obj: A Neo object
+        :return: MD5 sum
+        """
+        objhash = md5()
+
+        def strupdate(a):
+            objhash.update(str(a).encode())
+
+        def dupdate(d):
+            if isinstance(d, np.ndarray) and not d.flags["C_CONTIGUOUS"]:
+                d = d.copy(order="C")
+            objhash.update(d)
+
+        # attributes
+        strupdate(obj.name)
+        strupdate(obj.description)
+
+        # annotations
+        for k, v in sorted(obj.annotations.items()):
+            strupdate(k)
+            strupdate(v)
+
+        # data objects and type-specific attributes
+        if isinstance(obj, (Block, Segment)):
+            strupdate(obj.rec_datetime)
+            strupdate(obj.file_datetime)
+        elif isinstance(obj, ChannelIndex):
+            for idx in obj.index:
+                strupdate(idx)
+            for n in obj.channel_names:
+                strupdate(n)
+            if obj.coordinates is not None:
+                for coord in obj.coordinates:
+                    for c in coord:
+                        strupdate(c)
+        elif isinstance(obj, AnalogSignal):
+            dupdate(obj)
+            dupdate(obj.units)
+            dupdate(obj.t_start)
+            dupdate(obj.sampling_rate)
+            dupdate(obj.t_stop)
+        elif isinstance(obj, IrregularlySampledSignal):
+            dupdate(obj)
+            dupdate(obj.times)
+            dupdate(obj.units)
+        elif isinstance(obj, Event):
+            dupdate(obj.times)
+            for l in obj.labels:
+                strupdate(l)
+        elif isinstance(obj, Epoch):
+            dupdate(obj.times)
+            dupdate(obj.durations)
+            for l in obj.labels:
+                strupdate(l)
+        elif isinstance(obj, SpikeTrain):
+            dupdate(obj.times)
+            dupdate(obj.units)
+            dupdate(obj.t_stop)
+            dupdate(obj.t_start)
+            if obj.waveforms is not None:
+                dupdate(obj.waveforms)
+            dupdate(obj.sampling_rate)
+            if obj.left_sweep is not None:
+                strupdate(obj.left_sweep)
+
+        # type
+        strupdate(type(obj).__name__)
+
+        return objhash.hexdigest()

--- a/neo/test/iotest/test_igorio.py
+++ b/neo/test/iotest/test_igorio.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+Tests of neo.io.igorproio
+"""
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+try:
+    import igor
+    HAVE_IGOR = True
+except ImportError:
+    HAVE_IGOR = False
+from neo.io.igorproio import IgorIO
+from neo.test.iotest.common_io_test import BaseTestIO
+
+
+@unittest.skipUnless(HAVE_IGOR, "requires igor")
+class TestIgorIO(BaseTestIO, unittest.TestCase):
+    ioclass = IgorIO
+    files_to_test = ['mac-version2.ibw',
+                     'win-version2.ibw']
+    files_to_download = files_to_test
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -1,0 +1,1139 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016, German Neuroinformatics Node (G-Node)
+#                     Achilleas Koutsou <achilleas.k@gmail.com>
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted under the terms of the BSD License. See
+# LICENSE file in the root of the Project.
+"""
+Tests for neo.io.nixio
+"""
+
+import os
+from datetime import datetime
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+import string
+import itertools
+from six import string_types
+
+import numpy as np
+import quantities as pq
+
+import nixio
+from neo.core import (Block, Segment, ChannelIndex, AnalogSignal,
+                      IrregularlySampledSignal, Unit, SpikeTrain, Event, Epoch)
+from neo.test.iotest.common_io_test import BaseTestIO
+
+from neo.io.nixio import NixIO
+from neo.io.nixio import nixtypes
+
+
+class NixIOTest(unittest.TestCase):
+
+    filename = None
+    io = None
+
+    def compare_blocks(self, neoblocks, nixblocks):
+        for neoblock, nixblock in zip(neoblocks, nixblocks):
+            self.compare_attr(neoblock, nixblock)
+            self.assertEqual(len(neoblock.segments), len(nixblock.groups))
+            for idx, neoseg in enumerate(neoblock.segments):
+                nixgrp = nixblock.groups[neoseg.name]
+                self.compare_segment_group(neoseg, nixgrp)
+            for idx, neochx in enumerate(neoblock.channel_indexes):
+                if neochx.name:
+                    nixsrc = nixblock.sources[neochx.name]
+                else:
+                    nixsrc = nixblock.sources[idx]
+                self.compare_chx_source(neochx, nixsrc)
+            self.check_refs(neoblock, nixblock)
+
+    def compare_chx_source(self, neochx, nixsrc):
+        self.compare_attr(neochx, nixsrc)
+        nix_channels = list(src for src in nixsrc.sources
+                            if src.type == "neo.channelindex")
+        self.assertEqual(len(neochx.index), len(nix_channels))
+        for nixchan in nix_channels:
+            nixchanidx = nixchan.metadata["index"]
+            try:
+                neochanpos = list(neochx.index).index(nixchanidx)
+            except ValueError:
+                self.fail("Channel indexes do not match.")
+            if len(neochx.channel_names):
+                neochanname = neochx.channel_names[neochanpos]
+                if ((not isinstance(neochanname, str)) and
+                         isinstance(neochanname, bytes)):
+                    neochanname = neochanname.decode()
+                nixchanname = nixchan.name
+                self.assertEqual(neochanname, nixchanname)
+        nix_units = list(src for src in nixsrc.sources
+                         if src.type == "neo.unit")
+        self.assertEqual(len(neochx.units), len(nix_units))
+        for neounit in neochx.units:
+            nixunit = nixsrc.sources[neounit.name]
+            self.compare_attr(neounit, nixunit)
+
+    def check_refs(self, neoblock, nixblock):
+        """
+        Checks whether the references between objects that are not nested are
+        mapped correctly (e.g., SpikeTrains referenced by a Unit).
+
+        :param neoblock: A Neo block
+        :param nixblock: The corresponding NIX block
+        """
+        for idx, neochx in enumerate(neoblock.channel_indexes):
+            if neochx.name:
+                nixchx = nixblock.sources[neochx.name]
+            else:
+                nixchx = nixblock.sources[idx]
+            # AnalogSignals referencing CHX
+            neoasigs = list(sig.name for sig in neochx.analogsignals)
+            nixasigs = list(set(da.metadata.name for da in nixblock.data_arrays
+                                if da.type == "neo.analogsignal" and
+                                nixchx in da.sources))
+
+            self.assertEqual(len(neoasigs), len(nixasigs))
+
+            # IrregularlySampledSignals referencing CHX
+            neoisigs = list(sig.name for sig in neochx.irregularlysampledsignals)
+            nixisigs = list(set(da.metadata.name for da in nixblock.data_arrays
+                                if da.type == "neo.irregularlysampledsignal" and
+                                nixchx in da.sources))
+            self.assertEqual(len(neoisigs), len(nixisigs))
+            # SpikeTrains referencing CHX and Units
+            for sidx, neounit in enumerate(neochx.units):
+                if neounit.name:
+                    nixunit = nixchx.sources[neounit.name]
+                else:
+                    nixunit = nixchx.sources[sidx]
+                neosts = list(st.name for st in neounit.spiketrains)
+                nixsts = list(mt for mt in nixblock.multi_tags
+                              if mt.type == "neo.spiketrain" and
+                              nixunit.name in mt.sources)
+                # SpikeTrains must also reference CHX
+                for nixst in nixsts:
+                    self.assertIn(nixchx.name, nixst.sources)
+                nixsts = list(st.name for st in nixsts)
+                self.assertEqual(len(neosts), len(nixsts))
+                for neoname in neosts:
+                    if neoname:
+                        self.assertIn(neoname, nixsts)
+
+        # Events and Epochs must reference all Signals in the Group (NIX only)
+        for nixgroup in nixblock.groups:
+            nixevep = list(mt for mt in nixgroup.multi_tags
+                           if mt.type in ["neo.event", "neo.epoch"])
+            nixsigs = list(da.name for da in nixgroup.data_arrays
+                           if da.type in ["neo.analogsignal",
+                                          "neo.irregularlysampledsignal"])
+            for nee in nixevep:
+                for ns in nixsigs:
+                    self.assertIn(ns, nee.references)
+
+    def compare_segment_group(self, neoseg, nixgroup):
+        self.compare_attr(neoseg, nixgroup)
+        neo_signals = neoseg.analogsignals + neoseg.irregularlysampledsignals
+        self.compare_signals_das(neo_signals, nixgroup.data_arrays)
+        neo_eests = neoseg.epochs + neoseg.events + neoseg.spiketrains
+        self.compare_eests_mtags(neo_eests, nixgroup.multi_tags)
+
+    def compare_signals_das(self, neosignals, data_arrays):
+        for sig in neosignals:
+            if self.io._find_lazy_loaded(sig) is not None:
+                sig = self.io.load_lazy_object(sig)
+            dalist = list()
+            for idx in itertools.count():
+                nixname = "{}.{}".format(sig.name, idx)
+                if nixname in data_arrays:
+                    dalist.append(data_arrays[nixname])
+                else:
+                    break
+            _, nsig = np.shape(sig)
+            self.assertEqual(nsig, len(dalist))
+            self.compare_signal_dalist(sig, dalist)
+
+    def compare_signal_dalist(self, neosig, nixdalist):
+        """
+        Check if a Neo Analog or IrregularlySampledSignal matches a list of
+        NIX DataArrays.
+
+        :param neosig: Neo Analog or IrregularlySampledSignal
+        :param nixdalist: List of DataArrays
+        """
+        nixmd = nixdalist[0].metadata
+        self.assertTrue(all(nixmd == da.metadata for da in nixdalist))
+        neounit = str(neosig.dimensionality)
+        for sig, da in zip(np.transpose(neosig),
+                           sorted(nixdalist, key=lambda d: d.name)):
+            self.compare_attr(neosig, da)
+            np.testing.assert_almost_equal(sig.magnitude, da)
+            self.assertEqual(neounit, da.unit)
+            timedim = da.dimensions[0]
+            chandim = da.dimensions[1]
+            if isinstance(neosig, AnalogSignal):
+                self.assertIsInstance(timedim, nixtypes["SampledDimension"])
+                self.assertEqual(
+                    pq.Quantity(timedim.sampling_interval, timedim.unit),
+                    neosig.sampling_period
+                )
+                self.assertEqual(timedim.offset, neosig.t_start.magnitude)
+                if "t_start.units" in da.metadata.props:
+                    self.assertEqual(da.metadata["t_start.units"],
+                                     str(neosig.t_start.dimensionality))
+            elif isinstance(neosig, IrregularlySampledSignal):
+                self.assertIsInstance(timedim, nixtypes["RangeDimension"])
+                np.testing.assert_almost_equal(neosig.times.magnitude,
+                                               timedim.ticks)
+                self.assertEqual(timedim.unit,
+                                 str(neosig.times.dimensionality))
+            self.assertIsInstance(chandim, nixtypes["SetDimension"])
+
+    def compare_eests_mtags(self, eestlist, mtaglist):
+        self.assertEqual(len(eestlist), len(mtaglist))
+        for eest in eestlist:
+            if self.io._find_lazy_loaded(eest) is not None:
+                eest = self.io.load_lazy_object(eest)
+            mtag = mtaglist[eest.name]
+            if isinstance(eest, Epoch):
+                self.compare_epoch_mtag(eest, mtag)
+            elif isinstance(eest, Event):
+                self.compare_event_mtag(eest, mtag)
+            elif isinstance(eest, SpikeTrain):
+                self.compare_spiketrain_mtag(eest, mtag)
+
+    def compare_epoch_mtag(self, epoch, mtag):
+        self.assertEqual(mtag.type, "neo.epoch")
+        self.compare_attr(epoch, mtag)
+        np.testing.assert_almost_equal(epoch.times.magnitude, mtag.positions)
+
+        np.testing.assert_almost_equal(epoch.durations.magnitude, mtag.extents)
+        self.assertEqual(mtag.positions.unit,
+                         str(epoch.times.units.dimensionality))
+        self.assertEqual(mtag.extents.unit,
+                         str(epoch.durations.units.dimensionality))
+        for neol, nixl in zip(epoch.labels,
+                              mtag.positions.dimensions[0].labels):
+            # Dirty. Should find the root cause instead
+            if isinstance(neol, bytes):
+                neol = neol.decode()
+            if isinstance(nixl, bytes):
+                nixl = nixl.decode()
+            self.assertEqual(neol, nixl)
+
+    def compare_event_mtag(self, event, mtag):
+        self.assertEqual(mtag.type, "neo.event")
+        self.compare_attr(event, mtag)
+        np.testing.assert_almost_equal(event.times.magnitude, mtag.positions)
+        self.assertEqual(mtag.positions.unit, str(event.units.dimensionality))
+        for neol, nixl in zip(event.labels,
+                              mtag.positions.dimensions[0].labels):
+            # Dirty. Should find the root cause instead
+            # Only happens in 3.2
+            if isinstance(neol, bytes):
+                neol = neol.decode()
+            if isinstance(nixl, bytes):
+                nixl = nixl.decode()
+            self.assertEqual(neol, nixl)
+
+    def compare_spiketrain_mtag(self, spiketrain, mtag):
+        self.assertEqual(mtag.type, "neo.spiketrain")
+        self.compare_attr(spiketrain, mtag)
+        np.testing.assert_almost_equal(spiketrain.times.magnitude,
+                                       mtag.positions)
+        if len(mtag.features):
+            neowf = spiketrain.waveforms
+            nixwf = mtag.features[0].data
+            self.assertEqual(np.shape(neowf), np.shape(nixwf))
+            self.assertEqual(nixwf.unit, str(neowf.units.dimensionality))
+            np.testing.assert_almost_equal(neowf.magnitude, nixwf)
+            self.assertIsInstance(nixwf.dimensions[0], nixtypes["SetDimension"])
+            self.assertIsInstance(nixwf.dimensions[1], nixtypes["SetDimension"])
+            self.assertIsInstance(nixwf.dimensions[2],
+                                  nixtypes["SampledDimension"])
+
+    def compare_attr(self, neoobj, nixobj):
+        if neoobj.name:
+            if isinstance(neoobj, (AnalogSignal, IrregularlySampledSignal)):
+                nix_name = ".".join(nixobj.name.split(".")[:-1])
+            else:
+                nix_name = nixobj.name
+            self.assertEqual(neoobj.name, nix_name)
+        self.assertEqual(neoobj.description, nixobj.definition)
+        if hasattr(neoobj, "rec_datetime") and neoobj.rec_datetime:
+            self.assertEqual(neoobj.rec_datetime,
+                             datetime.fromtimestamp(nixobj.created_at))
+        if hasattr(neoobj, "file_datetime") and neoobj.file_datetime:
+            self.assertEqual(neoobj.file_datetime,
+                             datetime.fromtimestamp(
+                                 nixobj.metadata["file_datetime"]))
+        if neoobj.annotations:
+            nixmd = nixobj.metadata
+            for k, v, in neoobj.annotations.items():
+                self.assertEqual(nixmd[str(k)], v)
+
+    @classmethod
+    def create_full_nix_file(cls, filename):
+        nixfile = nixio.File.open(filename, nixio.FileMode.Overwrite)
+
+        nix_block_a = nixfile.create_block(cls.rword(10), "neo.block")
+        nix_block_a.definition = cls.rsentence(5, 10)
+        nix_block_b = nixfile.create_block(cls.rword(10), "neo.block")
+        nix_block_b.definition = cls.rsentence(3, 3)
+
+        nix_block_a.metadata = nixfile.create_section(
+            nix_block_a.name, nix_block_a.name+".metadata"
+        )
+
+        nix_block_b.metadata = nixfile.create_section(
+            nix_block_b.name, nix_block_b.name+".metadata"
+        )
+
+        nix_blocks = [nix_block_a, nix_block_b]
+
+        for blk in nix_blocks:
+            for ind in range(3):
+                group = blk.create_group(cls.rword(), "neo.segment")
+                group.definition = cls.rsentence(10, 15)
+
+                group_md = blk.metadata.create_section(group.name,
+                                                       group.name+".metadata")
+                group.metadata = group_md
+
+        blk = nix_blocks[0]
+        group = blk.groups[0]
+        allspiketrains = list()
+        allsignalgroups = list()
+
+        # analogsignals
+        for n in range(3):
+            siggroup = list()
+            asig_name = "{}_asig{}".format(cls.rword(10), n)
+            asig_definition = cls.rsentence(5, 5)
+            asig_md = group.metadata.create_section(asig_name,
+                                                    asig_name+".metadata")
+            for idx in range(3):
+                da_asig = blk.create_data_array(
+                    "{}.{}".format(asig_name, idx),
+                    "neo.analogsignal",
+                    data=cls.rquant(100, 1)
+                )
+                da_asig.definition = asig_definition
+                da_asig.unit = "mV"
+
+                da_asig.metadata = asig_md
+
+                timedim = da_asig.append_sampled_dimension(0.01)
+                timedim.unit = "ms"
+                timedim.label = "time"
+                timedim.offset = 10
+                da_asig.append_set_dimension()
+                group.data_arrays.append(da_asig)
+                siggroup.append(da_asig)
+            allsignalgroups.append(siggroup)
+
+        # irregularlysampledsignals
+        for n in range(2):
+            siggroup = list()
+            isig_name = "{}_isig{}".format(cls.rword(10), n)
+            isig_definition = cls.rsentence(12, 12)
+            isig_md = group.metadata.create_section(isig_name,
+                                                    isig_name+".metadata")
+            isig_times = cls.rquant(200, 1, True)
+            for idx in range(10):
+                da_isig = blk.create_data_array(
+                    "{}.{}".format(isig_name, idx),
+                    "neo.irregularlysampledsignal",
+                    data=cls.rquant(200, 1)
+                )
+                da_isig.definition = isig_definition
+                da_isig.unit = "mV"
+
+                da_isig.metadata = isig_md
+
+                timedim = da_isig.append_range_dimension(isig_times)
+                timedim.unit = "s"
+                timedim.label = "time"
+                da_isig.append_set_dimension()
+                group.data_arrays.append(da_isig)
+                siggroup.append(da_isig)
+            allsignalgroups.append(siggroup)
+
+        # SpikeTrains with Waveforms
+        for n in range(4):
+            stname = "{}-st{}".format(cls.rword(20), n)
+            times = cls.rquant(400, 1, True)
+            times_da = blk.create_data_array(
+                "{}.times".format(stname),
+                "neo.spiketrain.times",
+                data=times
+            )
+            times_da.unit = "ms"
+            mtag_st = blk.create_multi_tag(stname,
+                                           "neo.spiketrain",
+                                           times_da)
+            group.multi_tags.append(mtag_st)
+            mtag_st.definition = cls.rsentence(20, 30)
+            mtag_st_md = group.metadata.create_section(
+                mtag_st.name, mtag_st.name+".metadata"
+            )
+            mtag_st.metadata = mtag_st_md
+            mtag_st_md.create_property(
+                "t_stop", nixio.Value(max(times_da).item()+1)
+            )
+
+            waveforms = cls.rquant((10, 8, 5), 1)
+            wfname = "{}.waveforms".format(mtag_st.name)
+            wfda = blk.create_data_array(wfname, "neo.waveforms",
+                                         data=waveforms)
+            wfda.unit = "mV"
+            mtag_st.create_feature(wfda, nixio.LinkType.Indexed)
+            wfda.append_set_dimension()  # spike dimension
+            wfda.append_set_dimension()  # channel dimension
+            wftimedim = wfda.append_sampled_dimension(0.1)
+            wftimedim.unit = "ms"
+            wftimedim.label = "time"
+            wfda.metadata = mtag_st_md.create_section(
+                wfname, "neo.waveforms.metadata"
+            )
+            wfda.metadata.create_property("left_sweep",
+                                          [nixio.Value(20)]*5)
+            allspiketrains.append(mtag_st)
+
+        # Epochs
+        for n in range(3):
+            epname = "{}-ep{}".format(cls.rword(5), n)
+            times = cls.rquant(5, 1, True)
+            times_da = blk.create_data_array(
+                "{}.times".format(epname),
+                "neo.epoch.times",
+                data=times
+            )
+            times_da.unit = "s"
+
+            extents = cls.rquant(5, 1)
+            extents_da = blk.create_data_array(
+                "{}.durations".format(epname),
+                "neo.epoch.durations",
+                data=extents
+            )
+            extents_da.unit = "s"
+
+            mtag_ep = blk.create_multi_tag(
+                epname, "neo.epoch", times_da
+            )
+            group.multi_tags.append(mtag_ep)
+            mtag_ep.definition = cls.rsentence(2)
+            mtag_ep.extents = extents_da
+            label_dim = mtag_ep.positions.append_set_dimension()
+            label_dim.labels = cls.rsentence(5).split(" ")
+            # reference all signals in the group
+            for siggroup in allsignalgroups:
+                mtag_ep.references.extend(siggroup)
+
+        # Events
+        for n in range(2):
+            evname = "{}-ev{}".format(cls.rword(5), n)
+            times = cls.rquant(5, 1, True)
+            times_da = blk.create_data_array(
+                "{}.times".format(evname),
+                "neo.event.times",
+                data=times
+            )
+            times_da.unit = "s"
+
+            mtag_ev = blk.create_multi_tag(
+                evname, "neo.event", times_da
+            )
+            group.multi_tags.append(mtag_ev)
+            mtag_ev.definition = cls.rsentence(2)
+            label_dim = mtag_ev.positions.append_set_dimension()
+            label_dim.labels = cls.rsentence(5).split(" ")
+            # reference all signals in the group
+            for siggroup in allsignalgroups:
+                mtag_ev.references.extend(siggroup)
+
+
+        # CHX
+        nixchx = blk.create_source(cls.rword(10),
+                                   "neo.channelindex")
+        nixchx.metadata = nix_blocks[0].metadata.create_section(
+            nixchx.name, "neo.channelindex.metadata"
+        )
+        chantype = "neo.channelindex"
+        # 3 channels
+        for idx in [2, 5, 9]:
+            channame = cls.rword(20)
+            nixrc = nixchx.create_source(channame, chantype)
+            nixrc.definition = cls.rsentence(13)
+            nixrc.metadata = nixchx.metadata.create_section(
+                nixrc.name, "neo.channelindex.metadata"
+            )
+            nixrc.metadata.create_property("index", nixio.Value(idx))
+            dims = tuple(map(nixio.Value, cls.rquant(3, 1)))
+            nixrc.metadata.create_property("coordinates", dims)
+            nixrc.metadata.create_property("coordinates.units",
+                                           nixio.Value("um"))
+
+        nunits = 1
+        stsperunit = np.array_split(allspiketrains, nunits)
+        for idx in range(nunits):
+            unitname = "{}-unit{}".format(cls.rword(5), idx)
+            nixunit = nixchx.create_source(unitname, "neo.unit")
+            nixunit.definition = cls.rsentence(4, 10)
+            for st in stsperunit[idx]:
+                st.sources.append(nixchx)
+                st.sources.append(nixunit)
+
+        # pick a few signal groups to reference this CHX
+        randsiggroups = np.random.choice(allsignalgroups, 5, False)
+        for siggroup in randsiggroups:
+            for sig in siggroup:
+                sig.sources.append(nixchx)
+
+        return nixfile
+
+    @staticmethod
+    def rdate():
+        return datetime(year=np.random.randint(1980, 2020),
+                        month=np.random.randint(1, 13),
+                        day=np.random.randint(1, 29))
+
+    @classmethod
+    def populate_dates(cls, obj):
+        obj.file_datetime = cls.rdate()
+        obj.rec_datetime = cls.rdate()
+
+    @staticmethod
+    def rword(n=10):
+        return "".join(np.random.choice(list(string.ascii_letters), n))
+
+    @classmethod
+    def rsentence(cls, n=3, maxwl=10):
+        return " ".join(cls.rword(np.random.randint(1, maxwl))
+                        for _ in range(n))
+
+    @classmethod
+    def rdict(cls, nitems):
+        rd = dict()
+        for _ in range(nitems):
+            key = cls.rword()
+            value = cls.rword() if np.random.choice((0, 1)) \
+                else np.random.uniform()
+            rd[key] = value
+        return rd
+
+    @staticmethod
+    def rquant(shape, unit, incr=False):
+        try:
+            dim = len(shape)
+        except TypeError:
+            dim = 1
+        if incr and dim > 1:
+            raise TypeError("Shape of quantity array may only be "
+                            "one-dimensional when incremental values are "
+                            "requested.")
+        arr = np.random.random(shape)
+        if incr:
+            arr = np.array(np.cumsum(arr))
+        return arr*unit
+
+    @classmethod
+    def create_all_annotated(cls):
+        times = cls.rquant(1, pq.s)
+        signal = cls.rquant(1, pq.V)
+        blk = Block()
+        blk.annotate(**cls.rdict(3))
+
+        seg = Segment()
+        seg.annotate(**cls.rdict(4))
+        blk.segments.append(seg)
+
+        asig = AnalogSignal(signal=signal, sampling_rate=pq.Hz)
+        asig.annotate(**cls.rdict(2))
+        seg.analogsignals.append(asig)
+
+        isig = IrregularlySampledSignal(times=times, signal=signal,
+                                        time_units=pq.s)
+        isig.annotate(**cls.rdict(2))
+        seg.irregularlysampledsignals.append(isig)
+
+        epoch = Epoch(times=times, durations=times)
+        epoch.annotate(**cls.rdict(4))
+        seg.epochs.append(epoch)
+
+        event = Event(times=times)
+        event.annotate(**cls.rdict(4))
+        seg.events.append(event)
+
+        spiketrain = SpikeTrain(times=times, t_stop=pq.s, units=pq.s)
+        spiketrain.annotate(**cls.rdict(6))
+        seg.spiketrains.append(spiketrain)
+
+        chx = ChannelIndex(name="achx", index=[1, 2])
+        chx.annotate(**cls.rdict(5))
+        blk.channel_indexes.append(chx)
+
+        unit = Unit()
+        unit.annotate(**cls.rdict(2))
+        chx.units.append(unit)
+
+        return blk
+
+
+class NixIOWriteTest(NixIOTest):
+
+    def setUp(self):
+        self.filename = "nixio_testfile_write.h5"
+        self.writer = NixIO(self.filename, "ow")
+        self.io = self.writer
+        self.reader = nixio.File.open(self.filename,
+                                      nixio.FileMode.ReadOnly)
+
+    def tearDown(self):
+        del self.writer
+        self.reader.close()
+        os.remove(self.filename)
+
+    def write_and_compare(self, blocks):
+        self.writer.write_all_blocks(blocks)
+        self.compare_blocks(self.writer.read_all_blocks(), self.reader.blocks)
+
+    def test_block_write(self):
+        block = Block(name=self.rword(),
+                      description=self.rsentence())
+        self.write_and_compare([block])
+
+        block.annotate(**self.rdict(5))
+        self.write_and_compare([block])
+
+    def test_segment_write(self):
+        block = Block(name=self.rword())
+        segment = Segment(name=self.rword(), description=self.rword())
+        block.segments.append(segment)
+        self.write_and_compare([block])
+
+        segment.annotate(**self.rdict(2))
+        self.write_and_compare([block])
+
+    def test_channel_index_write(self):
+        block = Block(name=self.rword())
+        chx = ChannelIndex(name=self.rword(),
+                           description=self.rsentence(),
+                           index=[1, 2, 3, 5, 8, 13])
+        block.channel_indexes.append(chx)
+        self.write_and_compare([block])
+
+        chx.annotate(**self.rdict(3))
+        self.write_and_compare([block])
+
+    def test_signals_write(self):
+        block = Block()
+        seg = Segment()
+        block.segments.append(seg)
+
+        asig = AnalogSignal(signal=self.rquant((10, 3), pq.mV),
+                            sampling_rate=pq.Quantity(10, "Hz"))
+        seg.analogsignals.append(asig)
+        self.write_and_compare([block])
+
+        anotherblock = Block("ir signal block")
+        seg = Segment("ir signal seg")
+        anotherblock.segments.append(seg)
+        irsig = IrregularlySampledSignal(
+            signal=np.random.random((20, 3)),
+            times=self.rquant(20, pq.ms, True),
+            units=pq.A
+        )
+        seg.irregularlysampledsignals.append(irsig)
+        self.write_and_compare([anotherblock])
+
+        block.segments[0].analogsignals.append(
+            AnalogSignal(signal=[10.0, 1.0, 3.0], units=pq.S,
+                         sampling_period=pq.Quantity(3, "s"),
+                         dtype=np.double, name="signal42",
+                         description="this is an analogsignal",
+                         t_start=45 * pq.ms),
+        )
+        self.write_and_compare([block, anotherblock])
+
+        block.segments[0].irregularlysampledsignals.append(
+            IrregularlySampledSignal(times=np.random.random(10),
+                                     signal=np.random.random((10, 3)),
+                                     units="mV", time_units="s",
+                                     dtype=np.float,
+                                     name="some sort of signal",
+                                     description="the signal is described")
+        )
+        self.write_and_compare([block, anotherblock])
+
+    def test_epoch_write(self):
+        block = Block()
+        seg = Segment()
+        block.segments.append(seg)
+
+        epoch = Epoch(times=[1, 1, 10, 3]*pq.ms, durations=[3, 3, 3, 1]*pq.ms,
+                      labels=np.array(["one", "two", "three", "four"]),
+                      name="test epoch", description="an epoch for testing")
+
+        seg.epochs.append(epoch)
+        self.write_and_compare([block])
+
+    def test_event_write(self):
+        block = Block()
+        seg = Segment()
+        block.segments.append(seg)
+
+        event = Event(times=np.arange(0, 30, 10)*pq.s,
+                      labels=np.array(["0", "1", "2"]),
+                      name="event name",
+                      description="event description")
+        seg.events.append(event)
+        self.write_and_compare([block])
+
+    def test_spiketrain_write(self):
+        block = Block()
+        seg = Segment()
+        block.segments.append(seg)
+
+        spiketrain = SpikeTrain(times=[3, 4, 5]*pq.s, t_stop=10.0,
+                                name="spikes!", description="sssssspikes")
+        seg.spiketrains.append(spiketrain)
+        self.write_and_compare([block])
+
+        waveforms = self.rquant((20, 5, 10), pq.mV)
+        spiketrain = SpikeTrain(times=[1, 1.1, 1.2]*pq.ms, t_stop=1.5*pq.s,
+                                name="spikes with wf",
+                                description="spikes for waveform test",
+                                waveforms=waveforms)
+
+        seg.spiketrains.append(spiketrain)
+        self.write_and_compare([block])
+
+        spiketrain.left_sweep = np.random.random(10)*pq.ms
+        self.write_and_compare([block])
+
+    def test_metadata_structure_write(self):
+        neoblk = self.create_all_annotated()
+        self.io.write_block(neoblk)
+        blk = self.io.nix_file.blocks[0]
+
+        blkmd = blk.metadata
+        self.assertEqual(blk.name, blkmd.name)
+
+        grp = blk.groups[0]  # segment
+        self.assertIn(grp.name, blkmd.sections)
+
+        grpmd = blkmd.sections[grp.name]
+        for da in grp.data_arrays:  # signals
+            name = ".".join(da.name.split(".")[:-1])
+            self.assertIn(name, grpmd.sections)
+        for mtag in grp.multi_tags:  # spiketrains, events, and epochs
+            self.assertIn(mtag.name, grpmd.sections)
+
+        srcchx = blk.sources[0]  # chx
+        self.assertIn(srcchx.name, blkmd.sections)
+
+        for srcunit in blk.sources:  # units
+            self.assertIn(srcunit.name, blkmd.sections)
+
+    def test_anonymous_objects_write(self):
+        nblocks = 2
+        nsegs = 2
+        nanasig = 4
+        nirrseg = 2
+        nepochs = 3
+        nevents = 4
+        nspiketrains = 3
+        nchx = 5
+        nunits = 10
+
+        times = self.rquant(1, pq.s)
+        signal = self.rquant(1, pq.V)
+        blocks = []
+        for blkidx in range(nblocks):
+            blk = Block()
+            blocks.append(blk)
+            for segidx in range(nsegs):
+                seg = Segment()
+                blk.segments.append(seg)
+                for anaidx in range(nanasig):
+                    seg.analogsignals.append(AnalogSignal(signal=signal,
+                                                          sampling_rate=pq.Hz))
+                for irridx in range(nirrseg):
+                    seg.irregularlysampledsignals.append(
+                        IrregularlySampledSignal(times=times,
+                                                 signal=signal,
+                                                 time_units=pq.s)
+                    )
+                for epidx in range(nepochs):
+                    seg.epochs.append(Epoch(times=times, durations=times))
+                for evidx in range(nevents):
+                    seg.events.append(Event(times=times))
+                for stidx in range(nspiketrains):
+                    seg.spiketrains.append(SpikeTrain(times=times, t_stop=pq.s,
+                                                      units=pq.s))
+            for chidx in range(nchx):
+                chx = ChannelIndex(name="chx{}".format(chidx),
+                                   index=[1, 2])
+                blk.channel_indexes.append(chx)
+                for unidx in range(nunits):
+                    unit = Unit()
+                    chx.units.append(unit)
+        self.writer.write_all_blocks(blocks)
+        self.compare_blocks(blocks, self.reader.blocks)
+
+    def test_to_value(self):
+        section = self.io.nix_file.create_section("Metadata value test", "Test")
+        tovalue = self.io._to_value
+
+        # quantity
+        # qvalue = pq.Quantity(10, "mV")
+        # section["qvalue"] = tovalue(qvalue)
+        # self.assertEqual(section["qvalue"], 10)
+
+        # datetime
+        dt = self.rdate()
+        section["dt"] = tovalue(dt)
+        self.assertEqual(datetime.fromtimestamp(section["dt"]), dt)
+
+        # string
+        randstr = self.rsentence()
+        section["randstr"] = tovalue(randstr)
+        self.assertEqual(section["randstr"], randstr)
+
+        # bytes
+        bytestring = b"bytestring"
+        section["randbytes"] = tovalue(bytestring)
+        self.assertEqual(section["randbytes"], bytestring.decode())
+
+        # iterables
+        # mdlist = [[1, 2, 3], [4, 5, 6]]
+        # self.assertIs(tovalue(mdlist), None)
+        #
+        # mdarray = np.random.random((10, 3))
+        # self.assertIs(tovalue(mdarray), None)
+
+        randlist = np.random.random(10).tolist()
+        section["randlist"] = tovalue(randlist)
+        self.assertEqual(randlist, section["randlist"])
+
+        randarray = np.random.random(10)
+        section["randarray"] = tovalue(randarray)
+        np.testing.assert_almost_equal(randarray, section["randarray"])
+
+        empty = []
+        self.assertIs(tovalue(empty), None)
+
+        # numpy item
+        npval = np.float64(2398)
+        section["npval"] = tovalue(npval)
+        self.assertEqual(npval, section["npval"])
+
+        # number
+        val = 42
+        section["val"] = tovalue(val)
+        self.assertEqual(val, section["val"])
+
+
+class NixIOReadTest(NixIOTest):
+
+    filename = "testfile_readtest.h5"
+    nixfile = None
+    nix_blocks = None
+    original_methods = dict()
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nixfile = cls.create_full_nix_file(cls.filename)
+
+    def setUp(self):
+        self.io = NixIO(self.filename, "ro")
+        self.original_methods["_read_cascade"] = self.io._read_cascade
+        self.original_methods["_update_maps"] = self.io._update_maps
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.nixfile.close()
+
+    def tearDown(self):
+        del self.io
+
+    def test_all_read(self):
+        neo_blocks = self.io.read_all_blocks(cascade=True, lazy=False)
+        nix_blocks = self.io.nix_file.blocks
+        self.compare_blocks(neo_blocks, nix_blocks)
+
+    def test_lazyload_fullcascade_read(self):
+        neo_blocks = self.io.read_all_blocks(cascade=True, lazy=True)
+        nix_blocks = self.io.nix_file.blocks
+        # data objects should be empty
+        for block in neo_blocks:
+            for seg in block.segments:
+                for asig in seg.analogsignals:
+                    self.assertEqual(len(asig), 0)
+                for isig in seg.irregularlysampledsignals:
+                    self.assertEqual(len(isig), 0)
+                for epoch in seg.epochs:
+                    self.assertEqual(len(epoch), 0)
+                for event in seg.events:
+                    self.assertEqual(len(event), 0)
+                for st in seg.spiketrains:
+                    self.assertEqual(len(st), 0)
+        self.compare_blocks(neo_blocks, nix_blocks)
+
+    def test_lazyload_lazycascade_read(self):
+        neo_blocks = self.io.read_all_blocks(cascade="lazy", lazy=True)
+        nix_blocks = self.io.nix_file.blocks
+        self.compare_blocks(neo_blocks, nix_blocks)
+
+    def test_lazycascade_read(self):
+        def getitem(self, index):
+            return self._data.__getitem__(index)
+        from neo.io.nixio import LazyList
+        getitem_original = LazyList.__getitem__
+        LazyList.__getitem__ = getitem
+        neo_blocks = self.io.read_all_blocks(cascade="lazy", lazy=False)
+        for block in neo_blocks:
+            self.assertIsInstance(block.segments, LazyList)
+            self.assertIsInstance(block.channel_indexes, LazyList)
+            for seg in block.segments:
+                self.assertIsInstance(seg, string_types)
+            for chx in block.channel_indexes:
+                self.assertIsInstance(chx, string_types)
+        LazyList.__getitem__ = getitem_original
+
+    def test_load_lazy_cascade(self):
+        from neo.io.nixio import LazyList
+        neo_blocks = self.io.read_all_blocks(cascade="lazy", lazy=False)
+        for block in neo_blocks:
+            self.assertIsInstance(block.segments, LazyList)
+            self.assertIsInstance(block.channel_indexes, LazyList)
+            name = block.name
+            block = self.io.load_lazy_cascade("/" + name, lazy=False)
+            self.assertIsInstance(block.segments, list)
+            self.assertIsInstance(block.channel_indexes, list)
+            for seg in block.segments:
+                self.assertIsInstance(seg.analogsignals, list)
+                self.assertIsInstance(seg.irregularlysampledsignals, list)
+                self.assertIsInstance(seg.epochs, list)
+                self.assertIsInstance(seg.events, list)
+                self.assertIsInstance(seg.spiketrains, list)
+
+    def test_nocascade_read(self):
+        self.io._read_cascade = mock.Mock()
+        neo_blocks = self.io.read_all_blocks(cascade=False)
+        self.io._read_cascade.assert_not_called()
+        for block in neo_blocks:
+            self.assertEqual(len(block.segments), 0)
+            nix_block = self.io.nix_file.blocks[block.name]
+            self.compare_attr(block, nix_block)
+
+    def test_lazy_load_subschema(self):
+        blk = self.io.nix_file.blocks[0]
+        segpath = "/" + blk.name + "/segments/" + blk.groups[0].name
+        segment = self.io.load_lazy_cascade(segpath, lazy=True)
+        self.assertIsInstance(segment, Segment)
+        self.assertEqual(segment.name, blk.groups[0].name)
+        self.assertIs(segment.block, None)
+        self.assertEqual(len(segment.analogsignals[0]), 0)
+        segment = self.io.load_lazy_cascade(segpath, lazy=False)
+        self.assertEqual(np.shape(segment.analogsignals[0]), (100, 3))
+
+
+class NixIOHashTest(NixIOTest):
+
+    def setUp(self):
+        self.hash = NixIO._hash_object
+
+    def _hash_test(self, objtype, argfuncs):
+        attr = {}
+        for arg, func in argfuncs.items():
+            attr[arg] = func()
+
+        obj_one = objtype(**attr)
+        obj_two = objtype(**attr)
+        hash_one = self.hash(obj_one)
+        hash_two = self.hash(obj_two)
+        self.assertEqual(hash_one, hash_two)
+
+        for arg, func in argfuncs.items():
+            chattr = attr.copy()
+            chattr[arg] = func()
+            obj_two = objtype(**chattr)
+            hash_two = self.hash(obj_two)
+            self.assertNotEqual(
+                hash_one, hash_two,
+                "Hash test failed with different '{}'".format(arg)
+            )
+
+    def test_block_seg_hash(self):
+        argfuncs = {"name": self.rword,
+                    "description": self.rsentence,
+                    "rec_datetime": self.rdate,
+                    "file_datetime": self.rdate,
+                    # annotations
+                    self.rword(): self.rword,
+                    self.rword(): lambda: self.rquant((10, 10), pq.mV)}
+        self._hash_test(Block, argfuncs)
+        self._hash_test(Segment, argfuncs)
+        self._hash_test(Unit, argfuncs)
+
+    def test_chx_hash(self):
+        argfuncs = {"name": self.rword,
+                    "description": self.rsentence,
+                    "index": lambda: np.random.random(10).tolist(),
+                    "channel_names": lambda: self.rsentence(10).split(" "),
+                    "coordinates": lambda: [(np.random.random() * pq.cm,
+                                             np.random.random() * pq.cm,
+                                             np.random.random() * pq.cm)]*10,
+                    # annotations
+                    self.rword(): self.rword,
+                    self.rword(): lambda: self.rquant((10, 10), pq.mV)}
+        self._hash_test(ChannelIndex, argfuncs)
+
+    def test_analogsignal_hash(self):
+        argfuncs = {"name": self.rword,
+                    "description": self.rsentence,
+                    "signal": lambda: self.rquant((10, 10), pq.mV),
+                    "sampling_rate": lambda: np.random.random() * pq.Hz,
+                    "t_start": lambda: np.random.random() * pq.sec,
+                    "t_stop": lambda: np.random.random() * pq.sec,
+                    # annotations
+                    self.rword(): self.rword,
+                    self.rword(): lambda: self.rquant((10, 10), pq.mV)}
+        self._hash_test(AnalogSignal, argfuncs)
+
+    def test_irregularsignal_hash(self):
+        argfuncs = {"name": self.rword,
+                    "description": self.rsentence,
+                    "signal": lambda: self.rquant((10, 10), pq.mV),
+                    "times": lambda: self.rquant(10, pq.ms, True),
+                    # annotations
+                    self.rword(): self.rword,
+                    self.rword(): lambda: self.rquant((10, 10), pq.mV)}
+        self._hash_test(IrregularlySampledSignal, argfuncs)
+
+    def test_event_hash(self):
+        argfuncs = {"name": self.rword,
+                    "description": self.rsentence,
+                    "times": lambda: self.rquant(10, pq.ms),
+                    "durations": lambda: self.rquant(10, pq.ms),
+                    "labels": lambda: self.rsentence(10).split(" "),
+                    # annotations
+                    self.rword(): self.rword,
+                    self.rword(): lambda: self.rquant((10, 10), pq.mV)}
+        self._hash_test(Event, argfuncs)
+        self._hash_test(Epoch, argfuncs)
+
+    def test_spiketrain_hash(self):
+        argfuncs = {"name": self.rword,
+                    "description": self.rsentence,
+                    "times": lambda: self.rquant(10, pq.ms, True),
+                    "t_start": lambda: -np.random.random() * pq.sec,
+                    "t_stop": lambda: np.random.random() * 100 * pq.sec,
+                    "waveforms": lambda: self.rquant((10, 10, 20), pq.mV),
+                    # annotations
+                    self.rword(): self.rword,
+                    self.rword(): lambda: self.rquant((10, 10), pq.mV)}
+        self._hash_test(SpikeTrain, argfuncs)
+
+
+class NixIOPartialWriteTest(NixIOTest):
+
+    filename = "testfile_partialwrite.h5"
+    nixfile = None
+    neo_blocks = None
+    original_methods = dict()
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nixfile = cls.create_full_nix_file(cls.filename)
+
+    def setUp(self):
+        self.io = NixIO(self.filename, "rw")
+        self.neo_blocks = self.io.read_all_blocks()
+        self.original_methods["_write_attr_annotations"] =\
+            self.io._write_attr_annotations
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.nixfile.close()
+
+    def tearDown(self):
+        self.restore_methods()
+        del self.io
+
+    def restore_methods(self):
+        for name, method in self.original_methods.items():
+            setattr(self.io, name, self.original_methods[name])
+
+    def _mock_write_attr(self, objclass):
+        typestr = str(objclass.__name__).lower()
+        self.io._write_attr_annotations = mock.Mock(
+            wraps=self.io._write_attr_annotations,
+            side_effect=self.check_obj_type("neo.{}".format(typestr))
+        )
+        neo_blocks = self.neo_blocks
+        self.modify_objects(neo_blocks, excludes=[objclass])
+        self.io.write_all_blocks(neo_blocks)
+        self.restore_methods()
+
+    def check_obj_type(self, typestring):
+        neq = self.assertNotEqual
+
+        def side_effect_func(*args, **kwargs):
+            obj = kwargs.get("nixobj", args[0])
+            if isinstance(obj, list):
+                for sig in obj:
+                    neq(sig.type, typestring)
+            else:
+                neq(obj.type, typestring)
+        return side_effect_func
+
+    @classmethod
+    def modify_objects(cls, objs, excludes=()):
+        excludes = tuple(excludes)
+        for obj in objs:
+            if not (excludes and isinstance(obj, excludes)):
+                obj.description = cls.rsentence()
+            for container in getattr(obj, "_child_containers", []):
+                children = getattr(obj, container)
+                cls.modify_objects(children, excludes)
+
+    def test_partial(self):
+        for objclass in NixIO.supported_objects:
+            self._mock_write_attr(objclass)
+            self.compare_blocks(self.neo_blocks, self.io.nix_file.blocks)
+
+    def test_no_modifications(self):
+        self.io._write_attr_annotations = mock.Mock()
+
+        self.io.write_all_blocks(self.neo_blocks)
+        self.io._write_attr_annotations.assert_not_called()
+        self.compare_blocks(self.neo_blocks, self.io.nix_file.blocks)
+
+        # clearing hashes and checking again
+        for k in self.io._object_hashes.keys():
+            self.io._object_hashes[k] = None
+        self.io.write_all_blocks(self.neo_blocks)
+        self.io._write_attr_annotations.assert_not_called()
+
+        # changing hashes to force rewrite
+        for k in self.io._object_hashes.keys():
+            self.io._object_hashes[k] = "_"
+        self.io.write_all_blocks(self.neo_blocks)
+        callcount = self.io._write_attr_annotations.call_count
+        self.assertEqual(callcount, len(self.io._object_hashes))
+        self.compare_blocks(self.neo_blocks, self.io.nix_file.blocks)
+
+
+class CommonTests(BaseTestIO, unittest.TestCase):
+
+    ioclass = NixIO
+


### PR DESCRIPTION
This is a pull request to add an IO for [NIX](https://github.com/G-Node/nix). The IO uses the Python version of the library, [NIXPy](https://github.com/G-Node/nixpy) in pure Python mode (no compiled dependencies).

As of today, the version of NIXPy that is compatible with this IO should be on PyPI. The name of the package is `nixio` and the compatible version is `1.2.0`.

Note: NIX is a format based on HDF5 and uses the default file extension `.h5`. This may cause issues with file type detection if both the NIX IO and the HDF5 IO are used.