### PR TITLE
[NIX IO] Dimension mismatch fix and quantities in metadata

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -652,13 +652,13 @@ class NixIO(BaseIO):
             nixchan.definition = nixsource.definition
             chanpath = loc + "/channelindex/" + channame
             chanmd = self._get_or_init_metadata(nixchan, chanpath)
-            chanmd["index"] = self._to_value(int(channel))
+            chanmd["index"] = self._to_property(int(channel))
             if chx.coordinates is not None:
                 coords = chx.coordinates[idx]
                 coordunits = stringify(coords[0].dimensionality)
-                nixcoordunits = self._to_value(coordunits)
+                nixcoordunits = self._to_property(coordunits)
                 nixcoords = tuple(
-                    self._to_value(c.rescale(coordunits).magnitude.item())
+                    self._to_property(c.rescale(coordunits).magnitude.item())
                     for c in coords
                 )
                 if "coordinates" in chanmd:
@@ -882,18 +882,21 @@ class NixIO(BaseIO):
             nixobj.force_created_at(calculate_timestamp(attr["created_at"]))
         if "file_datetime" in attr:
             metadata = self._get_or_init_metadata(nixobj, path)
-            metadata["file_datetime"] = self._to_value(attr["file_datetime"])
+            metadata["file_datetime"] = self._to_property(attr["file_datetime"])
         if "rec_datetime" in attr and attr["rec_datetime"]:
             metadata = self._get_or_init_metadata(nixobj, path)
-            metadata["rec_datetime"] = self._to_value(attr["rec_datetime"])
+            metadata["rec_datetime"] = self._to_property(attr["rec_datetime"])
         if "annotations" in attr:
             metadata = self._get_or_init_metadata(nixobj, path)
-            self._add_annotations(attr["annotations"], metadata)
+            for k, v in attr["annotations"].items():
+                prop = self._to_property(v)
+                metadata.create_property(k, prop["values"])
+                metadata.unit = prop["unit"]
 
     def _write_data(self, nixobj, attr, path):
         if isinstance(nixobj, list):
             metadata = self._get_or_init_metadata(nixobj[0], path)
-            metadata["t_start.units"] = self._to_value(attr["t_start.units"])
+            metadata["t_start.units"] = self._to_property(attr["t_start.units"])
             for obj in nixobj:
                 obj.unit = attr["data.units"]
                 if attr["type"] == "analogsignal":
@@ -927,11 +930,9 @@ class NixIO(BaseIO):
                 labeldim.labels = attr["labels"]
             metadata = self._get_or_init_metadata(nixobj, path)
             if "t_start" in attr:
-                metadata["t_start"] = self._to_value(attr["t_start"])
-                metadata["t_start.units"] = self._to_value(attr["t_start.units"])
+                metadata["t_start"] = self._to_property(attr["t_start"])
             if "t_stop" in attr:
-                metadata["t_stop"] = self._to_value(attr["t_stop"])
-                metadata["t_stop.units"] = self._to_value(attr["t_stop.units"])
+                metadata["t_stop"] = self._to_property(attr["t_stop"])
             if "waveforms" in attr:
                 wfname = nixobj.name + ".waveforms"
                 if wfname in parentblock.data_arrays:
@@ -948,7 +949,7 @@ class NixIO(BaseIO):
                 wftime = wfda.append_sampled_dimension(
                     attr["sampling_interval"]
                 )
-                metadata["sampling_interval.units"] = self._to_value(
+                metadata["sampling_interval.units"] = self._to_property(
                     attr["sampling_interval.units"]
                 )
                 wftime.unit = attr["times.units"]
@@ -959,7 +960,7 @@ class NixIO(BaseIO):
                     wfpath = path + "/waveforms/" + wfname
                     wfda.metadata = self._get_or_init_metadata(wfda, wfpath)
                 if "left_sweep" in attr:
-                    wfda.metadata["left_sweep"] = self._to_value(
+                    wfda.metadata["left_sweep"] = self._to_property(
                         attr["left_sweep"]
                     )
 
@@ -1102,32 +1103,29 @@ class NixIO(BaseIO):
             attr["left_sweep.units"] = cls._get_units(neoobj.left_sweep)
         return attr
 
-    def _add_annotations(self, annotations, metadata):
-        for k, v in annotations.items():
-            v = self._to_value(v)
-            metadata[k] = v
-
-    def _to_value(self, v):
+    def _to_property(self, v):
         """
-        Helper function for converting arbitrary variables to types compatible
-        with nixio.Value().
+        Helper function for converting arbitrary variables to nix metadata
+        properties. The function returns a dictionary with two keys:
+        values and unit, which are then used to create a nix.Property.
+
+
 
         :param v: The value to be converted
-        :return: a nixio.Value() object
+        :return: dictionary: {"values": [nix.Value()], "unit": str or None}
         """
+        ret = {"values": None, "unit": None}
         if isinstance(v, pq.Quantity):
-            # v = nixio.Value((v.magnitude.item(), str(v.dimensionality)))
-            self.logger.warn("Quantities in annotations are not currently "
-                             "supported when writing to NIX. Units are dropped.")
-            v = nixio.Value(v.magnitude.item())
+            ret["values"] = [nixio.Value(v.magnitude.item())]
+            ret["unit"] = str(v.dimensionality)
         elif isinstance(v, datetime):
-            v = nixio.Value(calculate_timestamp(v))
+            ret["values"] = [nixio.Value(calculate_timestamp(v))]
         elif isinstance(v, string_types):
-            v = nixio.Value(v)
+            ret["values"] = [nixio.Value(v)]
         elif isinstance(v, bytes):
-            v = nixio.Value(v.decode())
+            ret["values"] = [nixio.Value(v.decode())]
         elif isinstance(v, Iterable):
-            vv = list()
+            ret["values"] = []
             for item in v:
                 if isinstance(item, Iterable):
                     self.logger.warn("Multidimensional arrays and nested "
@@ -1138,15 +1136,12 @@ class NixIO(BaseIO):
                     item = nixio.Value(item.item())
                 else:
                     item = nixio.Value(item)
-                vv.append(item)
-            if not len(vv):
-                vv = None
-            v = vv
+                ret["values"].append(item)
         elif type(v).__module__ == "numpy":
-            v = nixio.Value(v.item())
+            ret["values"] = [nixio.Value(v.item())]
         else:
-            v = nixio.Value(v)
-        return v
+            ret["values"] = [nixio.Value(v)]
+        return ret
 
     @staticmethod
     def _get_contained_signals(obj):

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -906,7 +906,6 @@ class NixIO(BaseIO):
                     timedim.unit = attr["times.units"]
                 timedim.label = "time"
                 timedim.offset = attr["t_start"]
-                obj.append_set_dimension()
         else:
             nixobj.positions.unit = attr["data.units"]
             blockpath = "/" + path.split("/")[1]

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -186,7 +186,6 @@ class NixIOTest(unittest.TestCase):
             np.testing.assert_almost_equal(sig.magnitude, da)
             self.assertEqual(neounit, da.unit)
             timedim = da.dimensions[0]
-            chandim = da.dimensions[1]
             if isinstance(neosig, AnalogSignal):
                 self.assertIsInstance(timedim, nixtypes["SampledDimension"])
                 self.assertEqual(
@@ -203,7 +202,6 @@ class NixIOTest(unittest.TestCase):
                                                timedim.ticks)
                 self.assertEqual(timedim.unit,
                                  str(neosig.times.dimensionality))
-            self.assertIsInstance(chandim, nixtypes["SetDimension"])
 
     def compare_eests_mtags(self, eestlist, mtaglist):
         self.assertEqual(len(eestlist), len(mtaglist))
@@ -825,12 +823,6 @@ class NixIOWriteTest(NixIOTest):
         self.assertEqual(section["randbytes"], bytestring.decode())
 
         # iterables
-        # mdlist = [[1, 2, 3], [4, 5, 6]]
-        # self.assertIs(toprop(mdlist), None)
-        #
-        # mdarray = np.random.random((10, 3))
-        # self.assertIs(toprop(mdarray), None)
-
         randlist = np.random.random(10).tolist()
         writeprop(section, "randlist", randlist)
         self.assertEqual(randlist, section["randlist"])
@@ -848,6 +840,14 @@ class NixIOWriteTest(NixIOTest):
         val = 42
         writeprop(section, "val", val)
         self.assertEqual(val, section["val"])
+
+        # multi-dimensional data -- UNSUPORTED
+        # mdlist = [[1, 2, 3], [4, 5, 6]]
+        # writeprop(section, "mdlist", mdlist)
+
+        # mdarray = np.random.random((10, 3))
+        # writeprop(section, "mdarray", mdarray)
+
 
 
 class NixIOReadTest(NixIOTest):

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -801,54 +801,52 @@ class NixIOWriteTest(NixIOTest):
 
     def test_to_value(self):
         section = self.io.nix_file.create_section("Metadata value test", "Test")
-        tovalue = self.io._to_value
+        writeprop = self.io._write_property
 
         # quantity
-        # qvalue = pq.Quantity(10, "mV")
-        # section["qvalue"] = tovalue(qvalue)
-        # self.assertEqual(section["qvalue"], 10)
+        qvalue = pq.Quantity(10, "mV")
+        writeprop(section, "qvalue", qvalue)
+        self.assertEqual(section["qvalue"], 10)
+        self.assertEqual(section.props["qvalue"].unit, "mV")
 
         # datetime
         dt = self.rdate()
-        section["dt"] = tovalue(dt)
+        writeprop(section, "dt", dt)
         self.assertEqual(datetime.fromtimestamp(section["dt"]), dt)
 
         # string
         randstr = self.rsentence()
-        section["randstr"] = tovalue(randstr)
+        writeprop(section, "randstr", randstr)
         self.assertEqual(section["randstr"], randstr)
 
         # bytes
         bytestring = b"bytestring"
-        section["randbytes"] = tovalue(bytestring)
+        writeprop(section, "randbytes", bytestring)
         self.assertEqual(section["randbytes"], bytestring.decode())
 
         # iterables
         # mdlist = [[1, 2, 3], [4, 5, 6]]
-        # self.assertIs(tovalue(mdlist), None)
+        # self.assertIs(toprop(mdlist), None)
         #
         # mdarray = np.random.random((10, 3))
-        # self.assertIs(tovalue(mdarray), None)
+        # self.assertIs(toprop(mdarray), None)
 
         randlist = np.random.random(10).tolist()
-        section["randlist"] = tovalue(randlist)
+        writeprop(section, "randlist", randlist)
         self.assertEqual(randlist, section["randlist"])
 
         randarray = np.random.random(10)
-        section["randarray"] = tovalue(randarray)
+        writeprop(section, "randarray", randarray)
         np.testing.assert_almost_equal(randarray, section["randarray"])
-
-        empty = []
-        self.assertIs(tovalue(empty), None)
 
         # numpy item
         npval = np.float64(2398)
-        section["npval"] = tovalue(npval)
+        writeprop(section, "npval", npval)
         self.assertEqual(npval, section["npval"])
 
         # number
         val = 42
-        section["val"] = tovalue(val)
+        writeprop(section, "val", val)
         self.assertEqual(val, section["val"])
 
 


### PR DESCRIPTION
This PR fixes a dimensionality mismatch in DataArrays created from AnalogSignal and IrregularlySampledSignal objects and adds support for storing and loading quantities in annotations (metadata).