### PR TITLE
Fix tests and implementation of spiketrain 'duplicate with new data' feature

### DIFF
--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -79,7 +79,7 @@ def _check_waveform_dimensions(spiketrain):
 
     waveforms = spiketrain.waveforms
 
-    if not (waveforms and waveforms.size):
+    if (waveforms is None) or (not waveforms.size):
         return
 
     if waveforms.shape[0] != len(spiketrain):
@@ -477,8 +477,8 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         if waveforms is None:
             waveforms = self.waveforms
 
-        new_st = self.__class__(signal, t_stop,waveforms=waveforms,
-                                units=self.units)
+        new_st = self.__class__(signal,t_start=t_start, t_stop=t_stop,
+                                waveforms=waveforms, units=self.units)
         new_st._copy_data_complement(self)
 
         # overwriting t_start and t_stop with new values

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -1154,13 +1154,16 @@ class TestDuplicateWithNewData(unittest.TestCase):
         self.data = np.array([0.1, 0.5, 1.2, 3.3, 6.4, 7])
         self.dataquant = self.data*pq.ms
         self.train = SpikeTrain(self.dataquant, t_stop=10.0*pq.ms,
-                                 waveforms=self.waveforms)
+                                waveforms=self.waveforms)
 
     def test_duplicate_with_new_data(self):
         signal1 = self.train
-        new_data = np.sort(np.random.uniform(0, 100, (self.train))) * pq.ms
         new_t_start = -10*pq.s
         new_t_stop = 10*pq.s
+        new_data = np.sort(np.random.uniform(new_t_start.magnitude,
+                                             new_t_stop.magnitude,
+                                             len(self.train))) * pq.ms
+
         signal1b = signal1.duplicate_with_new_data(new_data,
                                                    t_start=new_t_start,
                                                    t_stop=new_t_stop)


### PR DESCRIPTION
Previously, testing was performed using an array of random numbers with length 0 (line 1161). Fixing the test also showed some bugs in the feature implementation, which are also fixed in this PR.
