### PR TITLE
axonio: decode byte array to string when reading protocol units for python-quantities

### DIFF
--- a/doc/source/authors.rst
+++ b/doc/source/authors.rst
@@ -21,6 +21,7 @@ and may not be the current affiliation of a contributor.
 * Robert Pröpper [8]
 * Domenico Guarino [2]
 * Achilleas Koutsou [5]
+* Erik Li [9]
 
 1. Centre de Recherche en Neuroscience de Lyon, CNRS UMR5292 - INSERM U1028 - Universite Claude Bernard Lyon 1
 2. Unité de Neuroscience, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France 
@@ -30,5 +31,6 @@ and may not be the current affiliation of a contributor.
 6. Institut de Neurosciences de la Timone, CNRS UMR 7289 - Université d'Aix-Marseille, Marseille, France
 7. Centre de Neurosciences Integratives et Cignitives, UMR 5228 - CNRS - Université Bordeaux I - Université Bordeaux II
 8. Neural Information Processing Group, TU Berlin, Germany
+9. Department of Neurobiology & Anatomy, Drexel University College of Medicine, Philadelphia, PA, USA
 
 If we've somehow missed you off the list we're very sorry - please let us know.

--- a/neo/io/axonio.py
+++ b/neo/io/axonio.py
@@ -560,7 +560,7 @@ class AxonIO(BaseIO):
                 t_start = 0 * pq.s  # TODO: Possibly check with episode array
                 name = header['listDACInfo'][DACNum]['DACChNames']
                 unit = header['listDACInfo'][DACNum]['DACChUnits'].\
-                    replace(b'\xb5', b'u')  # \xb5 is µ
+                    replace(b'\xb5', b'u').decode('utf-8')  # \xb5 is µ
                 signal = np.ones(nSam) *\
                     header['listDACInfo'][DACNum]['fDACHoldingLevel'] *\
                     pq.Quantity(1, unit)


### PR DESCRIPTION
Decode `unit` byte array to string so that python3-quantities can deal with the unit and not fail when reading protocol waveforms from abf2 format files.