### PR TITLE
Simplify and fix array shape

### DIFF
--- a/neo/io/axonio.py
+++ b/neo/io/axonio.py
@@ -580,7 +580,7 @@ class AxonIO(BaseIO):
                         i_end = i_last + epoch['lEpochInitDuration'] +\
                             epoch['lEpochDurationInc'] * epiNum
                         dif = i_end-i_begin
-                        ana_sig[i_begin:i_end] = np.ones(len(range(dif))) *\
+                        ana_sig[i_begin:i_end] = np.ones((dif, 1)) *\
                             pq.Quantity(1, unit) * (epoch['fEpochInitLevel'] +
                                                     epoch['fEpochLevelInc'] *
                                                     epiNum)


### PR DESCRIPTION
* len(range(dif)) == dif
* ana_sig[i_begin:i_end] has shape (X, 1), whereas np.ones() has (X)
  resulting in: ValueError: could not broadcast input array from shape.