### PR TITLE
Use new API for PyTables

### DIFF
--- a/neo/io/hdf5io.py
+++ b/neo/io/hdf5io.py
@@ -305,8 +305,8 @@ class NeoHdf5IO(BaseIO):
         """
         if not self.connected:
             try:
-                if tb.isHDF5File(filename):
-                    self._data = tb.openFile(filename, mode='a',
+                if tb.is_hdf5_file(filename):
+                    self._data = tb.open_file(filename, mode='a',
                                              title=filename)
                     self.connected = True
                 else:
@@ -314,7 +314,7 @@ class NeoHdf5IO(BaseIO):
                                     filename)
             except IOError:
                 # create a new file if specified file not found
-                self._data = tb.openFile(filename, mode='w', title=filename)
+                self._data = tb.open_file(filename, mode='w', title=filename)
                 self.connected = True
             except:
                 raise NameError("Incorrect file path, couldn't find or "


### PR DESCRIPTION
Use `open_file` instead of `openFile` and `is_hdf5_file` instead of `isHDF5File`.
The previous version was completely deprecated in PyTables 3.3.