### PR TITLE
Fix nixio infinite reading.

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -308,7 +308,7 @@ class NixIO(BaseIO):
             signaldata = pq.Quantity(np.empty(0), unit)
             lazy_shape = (len(nix_da_group[0]), len(nix_da_group))
         else:
-            signaldata = pq.Quantity(np.transpose(nix_da_group), unit)
+            signaldata = pq.Quantity(np.transpose(nix_da_group[0]), unit)
             lazy_shape = None
         timedim = self._get_time_dimension(nix_da_group[0])
         if (neo_type == "neo.analogsignal" or

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -308,7 +308,8 @@ class NixIO(BaseIO):
             signaldata = pq.Quantity(np.empty(0), unit)
             lazy_shape = (len(nix_da_group[0]), len(nix_da_group))
         else:
-            signaldata = pq.Quantity(np.transpose(nix_da_group[0]), unit)
+            signaldata = np.array([d[:] for d in nix_da_group]).transpose()
+            signaldata = pq.Quantity(signaldata, unit)
             lazy_shape = None
         timedim = self._get_time_dimension(nix_da_group[0])
         if (neo_type == "neo.analogsignal" or


### PR DESCRIPTION
Currently it transposes the list of elements, which leads to infinite processing by numpy. The first element of the list should be used instead, as is done in the surrounding code, since all the list elements are supposed to represent the same data.

The symptom is that that line causes cpu to get stuck at 100% and never stops.