### PR TITLE
reimplementing __add__ method for spiketrains

### DIFF
--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -427,6 +427,23 @@ class SpikeTrain(BaseNeo, pq.Quantity):
             obj.waveforms = obj.waveforms[i:j]
         return obj
 
+    def __add__(self,time):
+        '''
+        Shifts the time point of all spikes by the amount in :attr:`time`.
+
+        Raises an exception of new time points fall outside :attr:`t_start` or
+        :attr:`t_stop`
+        '''
+        spikes = self.view(pq.Quantity)
+        check_has_dimensions_time(time)
+        _check_time_in_range(spikes+time, self.t_start, self.t_stop)
+        return SpikeTrain(times=spikes+time, t_stop=self.t_stop, units=self.units,
+                          sampling_rate=self.sampling_rate,
+                          t_start=self.t_start, waveforms=self.waveforms,
+                          left_sweep=self.left_sweep, name=self.name,
+                          file_origin=self.file_origin,
+                          description=self.description, **self.annotations)
+
     def __getitem__(self, i):
         '''
         Get the item or slice :attr:`i`.

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -438,7 +438,7 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         spikes = self.view(pq.Quantity)
         check_has_dimensions_time(time)
         _check_time_in_range(spikes + time, self.t_start, self.t_stop)
-        return SpikeTrain(times=spikes+time, t_stop=self.t_stop, units=self.units,
+        return SpikeTrain(times=spikes + time, t_stop=self.t_stop, units=self.units,
                           sampling_rate=self.sampling_rate,
                           t_start=self.t_start, waveforms=self.waveforms,
                           left_sweep=self.left_sweep, name=self.name,
@@ -456,7 +456,7 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         spikes = self.view(pq.Quantity)
         check_has_dimensions_time(time)
         _check_time_in_range(spikes - time, self.t_start, self.t_stop)
-        return SpikeTrain(times=spikes+time, t_stop=self.t_stop, units=self.units,
+        return SpikeTrain(times=spikes - time, t_stop=self.t_stop, units=self.units,
                           sampling_rate=self.sampling_rate,
                           t_start=self.t_start, waveforms=self.waveforms,
                           left_sweep=self.left_sweep, name=self.name,

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -438,8 +438,8 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         spikes = self.view(pq.Quantity)
         check_has_dimensions_time(time)
         _check_time_in_range(spikes + time, self.t_start, self.t_stop)
-        return SpikeTrain(times=spikes + time, t_stop=self.t_stop, units=self.units,
-                          sampling_rate=self.sampling_rate,
+        return SpikeTrain(times=spikes + time, t_stop=self.t_stop,
+                          units=self.units, sampling_rate=self.sampling_rate,
                           t_start=self.t_start, waveforms=self.waveforms,
                           left_sweep=self.left_sweep, name=self.name,
                           file_origin=self.file_origin,
@@ -456,8 +456,8 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         spikes = self.view(pq.Quantity)
         check_has_dimensions_time(time)
         _check_time_in_range(spikes - time, self.t_start, self.t_stop)
-        return SpikeTrain(times=spikes - time, t_stop=self.t_stop, units=self.units,
-                          sampling_rate=self.sampling_rate,
+        return SpikeTrain(times=spikes - time, t_stop=self.t_stop,
+                          units=self.units, sampling_rate=self.sampling_rate,
                           t_start=self.t_start, waveforms=self.waveforms,
                           left_sweep=self.left_sweep, name=self.name,
                           file_origin=self.file_origin,

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -429,8 +429,8 @@ class SpikeTrain(BaseNeo, pq.Quantity):
 
     def __add__(self, time):
         '''
-        Shifts the time point of all spikes by the amount in :attr:`time`
-        (:class:`Quantity`)
+        Shifts the time point of all spikes by adding the amount in
+        :attr:`time` (:class:`Quantity`)
 
         Raises an exception if new time points fall outside :attr:`t_start` or
         :attr:`t_stop`
@@ -447,8 +447,8 @@ class SpikeTrain(BaseNeo, pq.Quantity):
 
     def __sub__(self, time):
         '''
-        Shifts the time point of all spikes by the amount in :attr:`time`
-        (:class:`Quantity`)
+        Shifts the time point of all spikes by subtracting the amount in
+        :attr:`time` (:class:`Quantity`)
 
         Raises an exception if new time points fall outside :attr:`t_start` or
         :attr:`t_stop`

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -445,6 +445,24 @@ class SpikeTrain(BaseNeo, pq.Quantity):
                           file_origin=self.file_origin,
                           description=self.description, **self.annotations)
 
+    def __sub__(self, time):
+        '''
+        Shifts the time point of all spikes by the amount in :attr:`time`
+        (:class:`Quantity`)
+
+        Raises an exception if new time points fall outside :attr:`t_start` or
+        :attr:`t_stop`
+        '''
+        spikes = self.view(pq.Quantity)
+        check_has_dimensions_time(time)
+        _check_time_in_range(spikes - time, self.t_start, self.t_stop)
+        return SpikeTrain(times=spikes+time, t_stop=self.t_stop, units=self.units,
+                          sampling_rate=self.sampling_rate,
+                          t_start=self.t_start, waveforms=self.waveforms,
+                          left_sweep=self.left_sweep, name=self.name,
+                          file_origin=self.file_origin,
+                          description=self.description, **self.annotations)
+
     def __getitem__(self, i):
         '''
         Get the item or slice :attr:`i`.

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -427,16 +427,17 @@ class SpikeTrain(BaseNeo, pq.Quantity):
             obj.waveforms = obj.waveforms[i:j]
         return obj
 
-    def __add__(self,time):
+    def __add__(self, time):
         '''
-        Shifts the time point of all spikes by the amount in :attr:`time`.
+        Shifts the time point of all spikes by the amount in :attr:`time`
+        (:class:`Quantity`)
 
-        Raises an exception of new time points fall outside :attr:`t_start` or
+        Raises an exception if new time points fall outside :attr:`t_start` or
         :attr:`t_stop`
         '''
         spikes = self.view(pq.Quantity)
         check_has_dimensions_time(time)
-        _check_time_in_range(spikes+time, self.t_start, self.t_stop)
+        _check_time_in_range(spikes + time, self.t_start, self.t_stop)
         return SpikeTrain(times=spikes+time, t_stop=self.t_stop, units=self.units,
                           sampling_rate=self.sampling_rate,
                           t_start=self.t_start, waveforms=self.waveforms,

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -1364,8 +1364,14 @@ class TestChanging(unittest.TestCase):
         train = SpikeTrain(data, copy=False, t_start=0.5, t_stop=10.0)
         assert_neo_object_is_compliant(train)
         self.assertRaises(ValueError, train.__add__(10 * pq.ms))
-        self.assertRaises(ValueError, train.__add__(-10 * pq.ms))
         assert_arrays_equal(train + 1 * pq.ms, data + 1 * pq.ms)
+
+    def test__subtracting_time(self):
+        data = [3, 4, 5] * pq.ms
+        train = SpikeTrain(data, copy=False, t_start=0.5, t_stop=10.0)
+        assert_neo_object_is_compliant(train)
+        self.assertRaises(ValueError, train.__sub__(10 * pq.ms))
+        assert_arrays_equal(train - 1 * pq.ms, data - 1 * pq.ms)
 
     def test__rescale(self):
         data = [3, 4, 5] * pq.ms

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -1363,14 +1363,14 @@ class TestChanging(unittest.TestCase):
         data = [3, 4, 5] * pq.ms
         train = SpikeTrain(data, copy=False, t_start=0.5, t_stop=10.0)
         assert_neo_object_is_compliant(train)
-        self.assertRaises(ValueError, train.__add__(10 * pq.ms))
+        self.assertRaises(ValueError, train.__add__, 10 * pq.ms)
         assert_arrays_equal(train + 1 * pq.ms, data + 1 * pq.ms)
 
     def test__subtracting_time(self):
         data = [3, 4, 5] * pq.ms
         train = SpikeTrain(data, copy=False, t_start=0.5, t_stop=10.0)
         assert_neo_object_is_compliant(train)
-        self.assertRaises(ValueError, train.__sub__(10 * pq.ms))
+        self.assertRaises(ValueError, train.__sub__, 10 * pq.ms)
         assert_arrays_equal(train - 1 * pq.ms, data - 1 * pq.ms)
 
     def test__rescale(self):

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -1359,6 +1359,14 @@ class TestChanging(unittest.TestCase):
             self.assertRaises(ValueError, train.__setslice__,
                               0, 3, [0, 4, 5] * pq.ms)
 
+    def test__adding_time(self):
+        data = [3, 4, 5] * pq.ms
+        train = SpikeTrain(data, copy=False, t_start=0.5, t_stop=10.0)
+        assert_neo_object_is_compliant(train)
+        self.assertRaises(ValueError, train.__add__(10 * pq.ms))
+        self.assertRaises(ValueError, train.__add__(-10 * pq.ms))
+        assert_arrays_equal(train + 1 * pq.ms, data + 1 * pq.ms)
+
     def test__rescale(self):
         data = [3, 4, 5] * pq.ms
         train = SpikeTrain(data, t_start=0.5, t_stop=10.0)


### PR DESCRIPTION
for shifting all spikes in a spiketrain by a constant amount of time. Currently, when adding a time quantity to a spike train, several properties like `t_start`, `t_stop`, and most importantly, `annotations` are lost.

Hope I am doing everything right here, first pull request. Apologies if something is off normal procedure.