### PR TITLE
Issue166 In the __array_finalize__ method of AnalogSignal and SpikeTrain,

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -239,7 +239,7 @@ class AnalogSignal(BaseNeo, pq.Quantity):
         self._sampling_rate = getattr(obj, '_sampling_rate', None)
 
         # The additional arguments
-        self.annotations = getattr(obj, 'annotations', None)
+        self.annotations = getattr(obj, 'annotations', {})
 
         # Globally recommended attributes
         self.name = getattr(obj, 'name', None)

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -378,7 +378,7 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         self.unit = getattr(obj, 'unit', None)
 
         # The additional arguments
-        self.annotations = getattr(obj, 'annotations', None)
+        self.annotations = getattr(obj, 'annotations', {})
 
         # Globally recommended attributes
         self.name = getattr(obj, 'name', None)


### PR DESCRIPTION
the default value "None" is now a dict "{}"