### PR TITLE
Bug fix for Event data generation

### DIFF
--- a/neo/test/generate_datasets.py
+++ b/neo/test/generate_datasets.py
@@ -107,6 +107,7 @@ def generate_one_simple_segment(seg_name='segment 0',
         for name, labels in iteritems(event_types):
             evt_size = rand()*np.diff(event_size_range)
             evt_size += event_size_range[0]
+            evt_size = int(evt_size)
             labels = np.array(labels, dtype='S')
             labels = labels[(rand(evt_size)*len(labels)).astype('i')]
             evt = Event(times=rand(evt_size)*duration, labels=labels)


### PR DESCRIPTION
Fixes #281.

The call to `rand()` with anything other than an integer argument fails with an error in recent numpy versions. This PR converts `evt_size` to an integer before it is used.