### PR TITLE
NIX IO small fixes

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -117,6 +117,12 @@ class NixIO(BaseIO):
         self._object_hashes = dict()
         self._block_read_counter = 0
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     def read_all_blocks(self, cascade=True, lazy=False):
         blocks = list()
         for blk in self.nix_file.blocks:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -22,7 +22,6 @@ import time
 from datetime import datetime
 from collections import Iterable
 import itertools
-from six import string_types
 from hashlib import md5
 
 import quantities as pq
@@ -38,6 +37,11 @@ try:
     HAVE_NIX = True
 except ImportError:
     HAVE_NIX = False
+
+try:
+    string_types = basestring
+except NameError:
+    string_types = str
 
 
 def stringify(value):

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -78,7 +78,10 @@ else:
 
 
 def calculate_timestamp(dt):
-    return int(time.mktime(dt.timetuple()))
+    try:
+        return int(dt)
+    except ValueError:
+        return int(time.mktime(dt.timetuple()))
 
 
 class NixIO(BaseIO):

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -53,10 +53,9 @@ def stringify(value):
 
 
 def calculate_timestamp(dt):
-    try:
-        return int(dt)
-    except ValueError:
+    if isinstance(dt, datetime):
         return int(time.mktime(dt.timetuple()))
+    return int(dt)
 
 
 class NixIO(BaseIO):

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -48,35 +48,6 @@ def stringify(value):
     return str(value)
 
 
-def nix_type_dict():
-    pycore = nixio.pycore
-
-    typedict = {
-        "Block": (pycore.Block,),
-        "Group": (pycore.Group,),
-        "SampledDimension": (pycore.SampledDimension,),
-        "RangeDimension": (pycore.RangeDimension,),
-        "SetDimension": (pycore.SetDimension,)
-    }
-
-    try:
-        ccore = nixio.core
-        typedict["Block"] += (ccore.Block,)
-        typedict["Group"] += (ccore.Group,)
-        typedict["SampledDimension"] += (ccore.SampledDimension,)
-        typedict["RangeDimension"] += (ccore.RangeDimension,)
-        typedict["SetDimension"] += (ccore.SetDimension,)
-    except AttributeError:
-        pass
-
-    return typedict
-
-if HAVE_NIX:
-    nixtypes = nix_type_dict()
-else:
-    nixtypes = {}
-
-
 def calculate_timestamp(dt):
     try:
         return int(dt)
@@ -316,7 +287,7 @@ class NixIO(BaseIO):
             lazy_shape = None
         timedim = self._get_time_dimension(nix_da_group[0])
         if (neo_type == "neo.analogsignal" or
-                isinstance(timedim, nixtypes["SampledDimension"])):
+                isinstance(timedim, nixio.pycore.SampledDimension)):
             if lazy:
                 sampling_period = pq.Quantity(1, timedim.unit)
                 t_start = pq.Quantity(0, timedim.unit)
@@ -337,7 +308,7 @@ class NixIO(BaseIO):
                 t_start=t_start, **neo_attrs
             )
         elif neo_type == "neo.irregularlysampledsignal"\
-                or isinstance(timedim, nixtypes["RangeDimension"]):
+                or isinstance(timedim, nixio.pycore.RangeDimension):
             if lazy:
                 times = pq.Quantity(np.empty(0), timedim.unit)
             else:
@@ -1191,7 +1162,7 @@ class NixIO(BaseIO):
                 else:
                     neo_attrs[prop.name] = values
 
-        if isinstance(nix_obj, (nixtypes["Block"], nixtypes["Group"])):
+        if isinstance(nix_obj, (nixio.pycore.Block, nixio.pycore.Group)):
             if "rec_datetime" not in neo_attrs:
                 neo_attrs["rec_datetime"] = None
 

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -110,8 +110,8 @@ class NixIO(BaseIO):
             filemode = nix.FileMode.Overwrite
         else:
             raise ValueError("Invalid mode specified '{}'. "
-                             "Valid modes: 'ro' (ReadOnly)', 'rw' (ReadWrite), "
-                             "'ow' (Overwrite).".format(mode))
+                             "Valid modes: 'ro' (ReadOnly)', 'rw' (ReadWrite),"
+                             " 'ow' (Overwrite).".format(mode))
         self.nix_file = nix.File.open(self.filename, filemode, backend="h5py")
         self._object_map = dict()
         self._lazy_loaded = list()
@@ -344,7 +344,8 @@ class NixIO(BaseIO):
                 durations = pq.Quantity(np.empty(0), nix_mtag.extents.unit)
                 labels = np.empty(0, dtype='S')
             else:
-                durations = pq.Quantity(nix_mtag.extents, nix_mtag.extents.unit)
+                durations = pq.Quantity(nix_mtag.extents,
+                                        nix_mtag.extents.unit)
                 labels = np.array(nix_mtag.positions.dimensions[0].labels,
                                   dtype="S")
             eest = Epoch(times=times, durations=durations, labels=labels,
@@ -393,7 +394,8 @@ class NixIO(BaseIO):
                 wfda = nix_mtag.features[0].data
                 wftime = self._get_time_dimension(wfda)
                 if lazy:
-                    eest.waveforms = pq.Quantity(np.empty((0, 0, 0)), wfda.unit)
+                    eest.waveforms = pq.Quantity(np.empty((0, 0, 0)),
+                                                 wfda.unit)
                     eest.sampling_period = pq.Quantity(1, wftime.unit)
                     eest.left_sweep = pq.Quantity(0, wftime.unit)
                 else:
@@ -481,8 +483,8 @@ class NixIO(BaseIO):
 
     def load_lazy_cascade(self, path, lazy):
         """
-        Loads the object at the location specified by the path and all children.
-        Data is loaded if lazy is False.
+        Loads the object at the location specified by the path and all
+        children. Data is loaded if lazy is False.
 
         :param path: Location of object in file
         :param lazy: Do not load data if True
@@ -547,7 +549,7 @@ class NixIO(BaseIO):
             nixobj = parentobj.create_group(attr["name"], "neo.segment")
         elif attr["type"] == "channelindex":
             nixobj = parentobj.create_source(attr["name"],
-                                               "neo.channelindex")
+                                             "neo.channelindex")
         elif attr["type"] in ("analogsignal", "irregularlysampledsignal"):
             blockpath = "/" + loc.split("/")[1]
             parentblock = self._get_object_at(blockpath)
@@ -590,8 +592,8 @@ class NixIO(BaseIO):
 
     def write_channelindex(self, chx, loc=""):
         """
-        Convert the provided ``chx`` (ChannelIndex) to a NIX Source and write it
-        to the NIX file at the location defined by ``loc``.
+        Convert the provided ``chx`` (ChannelIndex) to a NIX Source and write
+        it to the NIX file at the location defined by ``loc``.
 
         :param chx: The Neo ChannelIndex to be written
         :param loc: Path to the parent of the new CHX
@@ -647,8 +649,8 @@ class NixIO(BaseIO):
     def write_analogsignal(self, anasig, loc=""):
         """
         Convert the provided ``anasig`` (AnalogSignal) to a list of NIX
-        DataArray objects and write them to the NIX file at the location defined
-        by ``loc``. All DataArray objects created from the same
+        DataArray objects and write them to the NIX file at the location
+        defined by ``loc``. All DataArray objects created from the same
         AnalogSignal have their metadata section point to the same object.
 
         :param anasig: The Neo AnalogSignal to be written
@@ -925,7 +927,8 @@ class NixIO(BaseIO):
                 wftime = wfda.append_sampled_dimension(
                     attr["sampling_interval"]
                 )
-                metadata["sampling_interval.units"] = attr["sampling_interval.units"]
+                metadata["sampling_interval.units"] =\
+                    attr["sampling_interval.units"]
                 wftime.unit = attr["times.units"]
                 wftime.label = "time"
                 if wfname in metadata.sections:
@@ -964,9 +967,9 @@ class NixIO(BaseIO):
     @classmethod
     def resolve_name_conflicts(cls, objects):
         """
-        Given a list of neo objects, change their names such that no two objects
-        share the same name. Objects with no name are renamed based on their
-        type.
+        Given a list of neo objects, change their names such that no two
+        objects share the same name. Objects with no name are renamed based on
+        their type.
         If a container object is supplied (Block, Segment, or RCG), conflicts
         are resolved for the child objects.
 
@@ -1094,11 +1097,11 @@ class NixIO(BaseIO):
                 section[name] = nix.Value(v.magnitude.item())
             section.props[name].unit = str(v.dimensionality)
         elif isinstance(v, datetime):
-            section[name] = [nix.Value(calculate_timestamp(v))]
+            section[name] = nix.Value(calculate_timestamp(v))
         elif isinstance(v, string_types):
-            section[name] = [nix.Value(v)]
+            section[name] = nix.Value(v)
         elif isinstance(v, bytes):
-            section[name] = [nix.Value(v.decode())]
+            section[name] = nix.Value(v.decode())
         elif isinstance(v, Iterable):
             values = []
             unit = None
@@ -1119,9 +1122,9 @@ class NixIO(BaseIO):
             section[name] = values
             section.props[name].unit = unit
         elif type(v).__module__ == "numpy":
-            section[name] = [nix.Value(v.item())]
+            section[name] = nix.Value(v.item())
         else:
-            section[name] = [nix.Value(v)]
+            section[name] = nix.Value(v)
         return section.props[name]
 
     @staticmethod
@@ -1184,9 +1187,9 @@ class NixIO(BaseIO):
         """
         Groups data arrays that were generated by the same Neo Signal object.
 
-        :param paths: A list of paths (strings) of all the signals to be grouped
-        :return: A list of paths (strings) of signal groups. The last part of
-        each path is the common name of the signals in the group.
+        :param paths: A list of paths (strings) of all the signals to be
+        grouped :return: A list of paths (strings) of signal groups. The last
+        part of each path is the common name of the signals in the group.
         """
         grouppaths = list(".".join(p.split(".")[:-1])
                           for p in paths)

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -88,7 +88,7 @@ class NixIO(BaseIO):
         "units": "sources"
     }
 
-    def __init__(self, filename, mode="ro"):
+    def __init__(self, filename, mode="rw"):
         """
         Initialise IO instance and NIX file.
 

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -16,7 +16,7 @@ This IO supports both writing and reading of NIX files. Reading is supported
 only if the NIX file was created using this IO.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
 import time
 from datetime import datetime
@@ -1289,3 +1289,19 @@ class NixIO(BaseIO):
         strupdate(type(obj).__name__)
 
         return objhash.hexdigest()
+
+    def close(self):
+        """
+        Closes the open nix file and resets maps.
+        """
+        if (hasattr(self, "nix_file") and
+                self.nix_file and self.nix_file.is_open()):
+            self.nix_file.close()
+            self.nix_file = None
+            self._object_map = None
+            self._lazy_loaded = None
+            self._object_hashes = None
+            self._block_read_counter = None
+
+    def __del__(self):
+        self.close()

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -867,10 +867,15 @@ class NixIO(BaseIO):
             nixobj.force_created_at(calculate_timestamp(attr["created_at"]))
         if "file_datetime" in attr:
             metadata = self._get_or_init_metadata(nixobj, path)
-            metadata["file_datetime"] = attr["file_datetime"]
+            self._write_property(metadata,
+                                 "file_datetime", attr["file_datetime"])
+            # metadata["file_datetime"] = attr["file_datetime"]
         if "rec_datetime" in attr and attr["rec_datetime"]:
             metadata = self._get_or_init_metadata(nixobj, path)
-            metadata["rec_datetime"] = attr["rec_datetime"]
+            # metadata["rec_datetime"] = attr["rec_datetime"]
+            self._write_property(metadata,
+                                 "rec_datetime", attr["rec_datetime"])
+
         if "annotations" in attr:
             metadata = self._get_or_init_metadata(nixobj, path)
             for k, v in attr["annotations"].items():
@@ -1177,9 +1182,9 @@ class NixIO(BaseIO):
         if isinstance(nix_obj, (nix.pycore.Block, nix.pycore.Group)):
             if "rec_datetime" not in neo_attrs:
                 neo_attrs["rec_datetime"] = None
-
-        #     neo_attrs["rec_datetime"] = datetime.fromtimestamp(
-        #         nix_obj.created_at)
+            neo_attrs["rec_datetime"] = datetime.fromtimestamp(
+                nix_obj.created_at
+            )
         if "file_datetime" in neo_attrs:
             neo_attrs["file_datetime"] = datetime.fromtimestamp(
                 neo_attrs["file_datetime"]

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -296,7 +296,8 @@ class NixIOTest(unittest.TestCase):
 
     @classmethod
     def create_full_nix_file(cls, filename):
-        nixfile = nix.File.open(filename, nix.FileMode.Overwrite)
+        nixfile = nix.File.open(filename, nix.FileMode.Overwrite,
+                                backend="h5py")
 
         nix_block_a = nixfile.create_block(cls.rword(10), "neo.block")
         nix_block_a.definition = cls.rsentence(5, 10)
@@ -612,7 +613,8 @@ class NixIOWriteTest(NixIOTest):
         self.writer = NixIO(self.filename, "ow")
         self.io = self.writer
         self.reader = nix.File.open(self.filename,
-                                    nix.FileMode.ReadOnly)
+                                    nix.FileMode.ReadOnly,
+                                    backend="h5py")
 
     def tearDown(self):
         self.writer.close()

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -78,7 +78,7 @@ class NixIOTest(unittest.TestCase):
             if len(neochx.channel_names):
                 neochanname = neochx.channel_names[neochanpos]
                 if ((not isinstance(neochanname, str)) and
-                         isinstance(neochanname, bytes)):
+                        isinstance(neochanname, bytes)):
                     neochanname = neochanname.decode()
                 nixchanname = nixchan.name
                 self.assertEqual(neochanname, nixchanname)
@@ -111,10 +111,13 @@ class NixIOTest(unittest.TestCase):
             self.assertEqual(len(neoasigs), len(nixasigs))
 
             # IrregularlySampledSignals referencing CHX
-            neoisigs = list(sig.name for sig in neochx.irregularlysampledsignals)
-            nixisigs = list(set(da.metadata.name for da in nixblock.data_arrays
-                                if da.type == "neo.irregularlysampledsignal" and
-                                nixchx in da.sources))
+            neoisigs = list(sig.name for sig in
+                            neochx.irregularlysampledsignals)
+            nixisigs = list(
+                set(da.metadata.name for da in nixblock.data_arrays
+                    if da.type == "neo.irregularlysampledsignal" and
+                    nixchx in da.sources)
+            )
             self.assertEqual(len(neoisigs), len(nixisigs))
             # SpikeTrains referencing CHX and Units
             for sidx, neounit in enumerate(neochx.units):
@@ -472,7 +475,6 @@ class NixIOTest(unittest.TestCase):
             for siggroup in allsignalgroups:
                 mtag_ev.references.extend(siggroup)
 
-
         # CHX
         nixchx = blk.create_source(cls.rword(10),
                                    "neo.channelindex")
@@ -610,7 +612,7 @@ class NixIOWriteTest(NixIOTest):
         self.writer = NixIO(self.filename, "ow")
         self.io = self.writer
         self.reader = nix.File.open(self.filename,
-                                      nix.FileMode.ReadOnly)
+                                    nix.FileMode.ReadOnly)
 
     def tearDown(self):
         del self.writer
@@ -808,7 +810,8 @@ class NixIOWriteTest(NixIOTest):
         self.compare_blocks(blocks, self.reader.blocks)
 
     def test_to_value(self):
-        section = self.io.nix_file.create_section("Metadata value test", "Test")
+        section = self.io.nix_file.create_section("Metadata value test",
+                                                  "Test")
         writeprop = self.io._write_property
 
         # quantity
@@ -850,14 +853,6 @@ class NixIOWriteTest(NixIOTest):
         val = 42
         writeprop(section, "val", val)
         self.assertEqual(val, section["val"])
-
-        # multi-dimensional data -- UNSUPORTED
-        # mdlist = [[1, 2, 3], [4, 5, 6]]
-        # writeprop(section, "mdlist", mdlist)
-
-        # mdarray = np.random.random((10, 3))
-        # writeprop(section, "mdarray", mdarray)
-
 
 
 class NixIOReadTest(NixIOTest):
@@ -1160,4 +1155,3 @@ class NixIOPartialWriteTest(NixIOTest):
 class CommonTests(BaseTestIO, unittest.TestCase):
 
     ioclass = NixIO
-

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -25,7 +25,6 @@ except ImportError:
     import mock
 import string
 import itertools
-from six import string_types
 
 import numpy as np
 import quantities as pq
@@ -41,6 +40,7 @@ except ImportError:
     HAVE_NIX = False
 
 from neo.io.nixio import NixIO
+from neo.io.nixio import string_types
 
 
 @unittest.skipUnless(HAVE_NIX, "Requires NIX")

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -1157,3 +1157,4 @@ class NixIOPartialWriteTest(NixIOTest):
 class CommonTests(BaseTestIO, unittest.TestCase):
 
     ioclass = NixIO
+    read_and_write_is_bijective = False

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -615,7 +615,7 @@ class NixIOWriteTest(NixIOTest):
                                     nix.FileMode.ReadOnly)
 
     def tearDown(self):
-        del self.writer
+        self.writer.close()
         self.reader.close()
         os.remove(self.filename)
 
@@ -878,7 +878,7 @@ class NixIOReadTest(NixIOTest):
             cls.nixfile.close()
 
     def tearDown(self):
-        del self.io
+        self.io.close()
 
     def test_all_read(self):
         neo_blocks = self.io.read_all_blocks(cascade=True, lazy=False)
@@ -1085,7 +1085,7 @@ class NixIOPartialWriteTest(NixIOTest):
 
     def tearDown(self):
         self.restore_methods()
-        del self.io
+        self.io.close()
 
     def restore_methods(self):
         for name, method in self.original_methods.items():

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -727,7 +727,7 @@ class NixIOWriteTest(NixIOTest):
         seg.spiketrains.append(spiketrain)
         self.write_and_compare([block])
 
-        waveforms = self.rquant((20, 5, 10), pq.mV)
+        waveforms = self.rquant((3, 5, 10), pq.mV)
         spiketrain = SpikeTrain(times=[1, 1.1, 1.2]*pq.ms, t_stop=1.5*pq.s,
                                 name="spikes with wf",
                                 description="spikes for waveform test",

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -35,7 +35,7 @@ from neo.core import (Block, Segment, ChannelIndex, AnalogSignal,
 from neo.test.iotest.common_io_test import BaseTestIO
 
 try:
-    import nixio
+    import nixio as nix
     HAVE_NIX = True
 except ImportError:
     HAVE_NIX = False
@@ -186,7 +186,7 @@ class NixIOTest(unittest.TestCase):
             self.assertEqual(neounit, da.unit)
             timedim = da.dimensions[0]
             if isinstance(neosig, AnalogSignal):
-                self.assertIsInstance(timedim, nixio.pycore.SampledDimension)
+                self.assertIsInstance(timedim, nix.pycore.SampledDimension)
                 self.assertEqual(
                     pq.Quantity(timedim.sampling_interval, timedim.unit),
                     neosig.sampling_period
@@ -196,7 +196,7 @@ class NixIOTest(unittest.TestCase):
                     self.assertEqual(da.metadata["t_start.units"],
                                      str(neosig.t_start.dimensionality))
             elif isinstance(neosig, IrregularlySampledSignal):
-                self.assertIsInstance(timedim, nixio.pycore.RangeDimension)
+                self.assertIsInstance(timedim, nix.pycore.RangeDimension)
                 np.testing.assert_almost_equal(neosig.times.magnitude,
                                                timedim.ticks)
                 self.assertEqual(timedim.unit,
@@ -260,10 +260,10 @@ class NixIOTest(unittest.TestCase):
             self.assertEqual(np.shape(neowf), np.shape(nixwf))
             self.assertEqual(nixwf.unit, str(neowf.units.dimensionality))
             np.testing.assert_almost_equal(neowf.magnitude, nixwf)
-            self.assertIsInstance(nixwf.dimensions[0], nixio.pycore.SetDimension)
-            self.assertIsInstance(nixwf.dimensions[1], nixio.pycore.SetDimension)
+            self.assertIsInstance(nixwf.dimensions[0], nix.pycore.SetDimension)
+            self.assertIsInstance(nixwf.dimensions[1], nix.pycore.SetDimension)
             self.assertIsInstance(nixwf.dimensions[2],
-                                  nixio.pycore.SampledDimension)
+                                  nix.pycore.SampledDimension)
 
     def compare_attr(self, neoobj, nixobj):
         if neoobj.name:
@@ -293,7 +293,7 @@ class NixIOTest(unittest.TestCase):
 
     @classmethod
     def create_full_nix_file(cls, filename):
-        nixfile = nixio.File.open(filename, nixio.FileMode.Overwrite)
+        nixfile = nix.File.open(filename, nix.FileMode.Overwrite)
 
         nix_block_a = nixfile.create_block(cls.rword(10), "neo.block")
         nix_block_a.definition = cls.rsentence(5, 10)
@@ -398,7 +398,7 @@ class NixIOTest(unittest.TestCase):
             )
             mtag_st.metadata = mtag_st_md
             mtag_st_md.create_property(
-                "t_stop", nixio.Value(max(times_da).item()+1)
+                "t_stop", nix.Value(max(times_da).item()+1)
             )
 
             waveforms = cls.rquant((10, 8, 5), 1)
@@ -406,7 +406,7 @@ class NixIOTest(unittest.TestCase):
             wfda = blk.create_data_array(wfname, "neo.waveforms",
                                          data=waveforms)
             wfda.unit = "mV"
-            mtag_st.create_feature(wfda, nixio.LinkType.Indexed)
+            mtag_st.create_feature(wfda, nix.LinkType.Indexed)
             wfda.append_set_dimension()  # spike dimension
             wfda.append_set_dimension()  # channel dimension
             wftimedim = wfda.append_sampled_dimension(0.1)
@@ -416,7 +416,7 @@ class NixIOTest(unittest.TestCase):
                 wfname, "neo.waveforms.metadata"
             )
             wfda.metadata.create_property("left_sweep",
-                                          [nixio.Value(20)]*5)
+                                          [nix.Value(20)]*5)
             allspiketrains.append(mtag_st)
 
         # Epochs
@@ -488,11 +488,11 @@ class NixIOTest(unittest.TestCase):
             nixrc.metadata = nixchx.metadata.create_section(
                 nixrc.name, "neo.channelindex.metadata"
             )
-            nixrc.metadata.create_property("index", nixio.Value(idx))
-            dims = tuple(map(nixio.Value, cls.rquant(3, 1)))
+            nixrc.metadata.create_property("index", nix.Value(idx))
+            dims = tuple(map(nix.Value, cls.rquant(3, 1)))
             nixrc.metadata.create_property("coordinates", dims)
             nixrc.metadata.create_property("coordinates.units",
-                                           nixio.Value("um"))
+                                           nix.Value("um"))
 
         nunits = 1
         stsperunit = np.array_split(allspiketrains, nunits)
@@ -609,8 +609,8 @@ class NixIOWriteTest(NixIOTest):
         self.filename = "nixio_testfile_write.h5"
         self.writer = NixIO(self.filename, "ow")
         self.io = self.writer
-        self.reader = nixio.File.open(self.filename,
-                                      nixio.FileMode.ReadOnly)
+        self.reader = nix.File.open(self.filename,
+                                      nix.FileMode.ReadOnly)
 
     def tearDown(self):
         del self.writer

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -41,7 +41,6 @@ except ImportError:
     HAVE_NIX = False
 
 from neo.io.nixio import NixIO
-from neo.io.nixio import nixtypes
 
 
 @unittest.skipUnless(HAVE_NIX, "Requires NIX")
@@ -187,7 +186,7 @@ class NixIOTest(unittest.TestCase):
             self.assertEqual(neounit, da.unit)
             timedim = da.dimensions[0]
             if isinstance(neosig, AnalogSignal):
-                self.assertIsInstance(timedim, nixtypes["SampledDimension"])
+                self.assertIsInstance(timedim, nixio.pycore.SampledDimension)
                 self.assertEqual(
                     pq.Quantity(timedim.sampling_interval, timedim.unit),
                     neosig.sampling_period
@@ -197,7 +196,7 @@ class NixIOTest(unittest.TestCase):
                     self.assertEqual(da.metadata["t_start.units"],
                                      str(neosig.t_start.dimensionality))
             elif isinstance(neosig, IrregularlySampledSignal):
-                self.assertIsInstance(timedim, nixtypes["RangeDimension"])
+                self.assertIsInstance(timedim, nixio.pycore.RangeDimension)
                 np.testing.assert_almost_equal(neosig.times.magnitude,
                                                timedim.ticks)
                 self.assertEqual(timedim.unit,
@@ -261,10 +260,10 @@ class NixIOTest(unittest.TestCase):
             self.assertEqual(np.shape(neowf), np.shape(nixwf))
             self.assertEqual(nixwf.unit, str(neowf.units.dimensionality))
             np.testing.assert_almost_equal(neowf.magnitude, nixwf)
-            self.assertIsInstance(nixwf.dimensions[0], nixtypes["SetDimension"])
-            self.assertIsInstance(nixwf.dimensions[1], nixtypes["SetDimension"])
+            self.assertIsInstance(nixwf.dimensions[0], nixio.pycore.SetDimension)
+            self.assertIsInstance(nixwf.dimensions[1], nixio.pycore.SetDimension)
             self.assertIsInstance(nixwf.dimensions[2],
-                                  nixtypes["SampledDimension"])
+                                  nixio.pycore.SampledDimension)
 
     def compare_attr(self, neoobj, nixobj):
         if neoobj.name:


### PR DESCRIPTION
Some fixes and maintenance for the NIX IO:
- Remove support for C++ backend
The NIX IO was meant to rely on the pure Python backend of NIX. There was some code in the IO which made it compatible with the C++ backend before the Python backend was fully complete and polished, but now it's unnecessary and has been removed.
- Alias `nixio` import to `nix`
By convention, we `import nixio as nix`. This has the added benefit that it avoids any confusion that might arise from using the `nixio` package in the Neo-NIXIO.
- Remove dependency on `six`
It was used just for checking `string_types` so now the variable is set in the same way `six` sets it and the dependency is removed.
- Default file mode set to `rw`
Was read-only. Change is compatible with NIX and Neo tests.