### PR TITLE
Event epoch time slice

### DIFF
--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -196,6 +196,8 @@ class Epoch(BaseNeo, pq.Quantity):
 
         indices = (self.times >= _t_start) & (self.times <= _t_stop)
 
-        new_epc = self.duplicate_with_new_data(self.times[indices])
-        new_epc = self.__class__(times=self.times[indices],durations=self.durations[indices],labels=self.labels[indices],**self.annotations)
+        new_epc = self.__class__(times=self.times[indices],
+                                 durations=self.durations[indices],
+                                 labels=self.labels[indices],
+                                 **self.annotations)
         return new_epc

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -179,3 +179,23 @@ class Epoch(BaseNeo, pq.Quantity):
         new = self.__class__(times=signal)
         new._copy_data_complement(self)
         return new
+
+    def time_slice(self, t_start, t_stop):
+        '''
+        Creates a new :class:`Epoch` corresponding to the time slice of
+        the original :class:`Epoch` between (and including) times
+        :attr:`t_start` and :attr:`t_stop`. Either parameter can also be None
+        to use infinite endpoints for the time interval.
+        '''
+        _t_start = t_start
+        _t_stop = t_stop
+        if t_start is None:
+            _t_start = -np.inf
+        if t_stop is None:
+            _t_stop = np.inf
+
+        indices = (self.times >= _t_start) & (self.times <= _t_stop)
+
+        new_epc = self.duplicate_with_new_data(self.times[indices])
+        new_epc = self.__class__(times=self.times[indices],durations=self.durations[indices],labels=self.labels[indices],**self.annotations)
+        return new_epc

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -198,6 +198,6 @@ class Epoch(BaseNeo, pq.Quantity):
 
         new_epc = self.__class__(times=self.times[indices],
                                  durations=self.durations[indices],
-                                 labels=self.labels[indices],
+                                 labels=np.array(self.labels)[indices],
                                  **self.annotations)
         return new_epc

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -166,3 +166,22 @@ class Event(BaseNeo, pq.Quantity):
         new = self.__class__(times=signal)
         new._copy_data_complement(self)
         return new
+
+    def time_slice(self, t_start, t_stop):
+        '''
+        Creates a new :class:`Event` corresponding to the time slice of
+        the original :class:`Event` between (and including) times
+        :attr:`t_start` and :attr:`t_stop`. Either parameter can also be None
+        to use infinite endpoints for the time interval.
+        '''
+        _t_start = t_start
+        _t_stop = t_stop
+        if t_start is None:
+            _t_start = -np.inf
+        if t_stop is None:
+            _t_stop = np.inf
+
+        indices = (self >= _t_start) & (self <= _t_stop)
+        new_evt = self[indices]
+
+        return new_evt

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -236,7 +236,7 @@ class TestEpoch(unittest.TestCase):
         epc2 = epc.time_slice(10*pq.s,20*pq.s)
         assert_arrays_equal(epc2.times,[10, 20] * pq.s)
         assert_arrays_equal(epc2.durations,[10, 5] * pq.ms)
-        self.assertEqual(epc2.labels,['btn0','btn1'])
+        assert_arrays_equal(epc2.labels,['btn0','btn1'])
         self.assertEqual(epc.annotations, epc2.annotations)
 
 class TestDuplicateWithNewData(unittest.TestCase):

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -230,18 +230,14 @@ class TestEpoch(unittest.TestCase):
         self.assertEqual(prepr, targ)
 
     def test__time_slice(self):
-
         epc = Epoch(times=[10, 20, 30]*pq.s, durations=[10, 5, 7] * pq.ms,
                     labels=['btn0', 'btn1', 'btn2'], foo='bar')
 
         epc2 = epc.time_slice(10*pq.s,20*pq.s)
-        self.assertEqual(epc2.times,[10, 20] * pq.s)
-        self.assertEqual(epc2.durations,[10, 5] * pq.ms)
+        assert_arrays_equal(epc2.times,[10, 20] * pq.s)
+        assert_arrays_equal(epc2.durations,[10, 5] * pq.ms)
         self.assertEqual(epc2.labels,['btn0','btn1'])
         self.assertEqual(epc.annotations, epc2.annotations)
-
-        epc3 = epc.time_slice(None, None)
-        self.assertEqual(epc, epc3)
 
 class TestDuplicateWithNewData(unittest.TestCase):
     def setUp(self):

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -230,13 +230,14 @@ class TestEpoch(unittest.TestCase):
         self.assertEqual(prepr, targ)
 
     def test__time_slice(self):
-        epc = Epoch(times=[10, 20, 30]*pq.s, durations=[10, 5, 7] * pq.ms,
-                    labels=['btn0', 'btn1', 'btn2'], foo='bar')
+        epc = Epoch(times=[10, 20, 30] * pq.s, durations=[10, 5, 7] * pq.ms,
+                    labels=np.array(['btn0', 'btn1', 'btn2'], dtype='S'),
+                    foo='bar')
 
-        epc2 = epc.time_slice(10*pq.s,20*pq.s)
-        assert_arrays_equal(epc2.times,[10, 20] * pq.s)
-        assert_arrays_equal(epc2.durations,[10, 5] * pq.ms)
-        assert_arrays_equal(epc2.labels,['btn0','btn1'])
+        epc2 = epc.time_slice(10 * pq.s, 20 * pq.s)
+        assert_arrays_equal(epc2.times, [10, 20] * pq.s)
+        assert_arrays_equal(epc2.durations, [10, 5] * pq.ms)
+        assert_arrays_equal(epc2.labels, np.array(['btn0','btn1'], dtype='S'))
         self.assertEqual(epc.annotations, epc2.annotations)
 
 class TestDuplicateWithNewData(unittest.TestCase):

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -229,6 +229,20 @@ class TestEpoch(unittest.TestCase):
 
         self.assertEqual(prepr, targ)
 
+    def test__time_slice(self):
+
+        epc = Epoch(times=[10, 20, 30]*pq.s, durations=[10, 5, 7] * pq.ms,
+                    labels=['btn0', 'btn1', 'btn2'], foo='bar')
+
+        epc2 = epc.time_slice(10*pq.s,20*pq.s)
+        self.assertEqual(epc2.times,[10, 20] * pq.ms)
+        self.assertEqual(epc2.durations,[10, 5] * pq.ms)
+        self.assertEqual(epc2.labels,['btn0','btn1'])
+        self.assertEqual(epc.annotations, epc2.annotations)
+
+        epc3 = epc.time_slice(None, None)
+        self.assertEqual(epc, epc3)
+
 class TestDuplicateWithNewData(unittest.TestCase):
     def setUp(self):
         self.data = np.array([0.1, 0.5, 1.2, 3.3, 6.4, 7])

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -235,7 +235,7 @@ class TestEpoch(unittest.TestCase):
                     labels=['btn0', 'btn1', 'btn2'], foo='bar')
 
         epc2 = epc.time_slice(10*pq.s,20*pq.s)
-        self.assertEqual(epc2.times,[10, 20] * pq.ms)
+        self.assertEqual(epc2.times,[10, 20] * pq.s)
         self.assertEqual(epc2.durations,[10, 5] * pq.ms)
         self.assertEqual(epc2.labels,['btn0','btn1'])
         self.assertEqual(epc.annotations, epc2.annotations)

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -224,17 +224,14 @@ class TestEvent(unittest.TestCase):
         evt = Event(data, foo='bar')
 
         evt1 = evt.time_slice(2.2 * pq.ms, 4.2 * pq.ms)
-        self.assertEqual(evt1.times,[3, 4] * pq.ms)
+        assert_arrays_equal(evt1.times,[3, 4] * pq.ms)
         self.assertEqual(evt.annotations, evt1.annotations)
 
         evt2 = evt.time_slice(None, 4.2 * pq.ms)
-        self.assertEqual(evt2.times,[2, 3, 4] * pq.ms)
+        assert_arrays_equal(evt2.times,[2, 3, 4] * pq.ms)
 
         evt3 = evt.time_slice(2.2 * pq.ms, None)
-        self.assertEqual(evt3.times, [3, 4, 5] * pq.ms)
-
-        evt4 = evt.time_slice(None, None)
-        self.assertEqual(evt, evt4)
+        assert_arrays_equal(evt3.times, [3, 4, 5] * pq.ms)
 
 class TestDuplicateWithNewData(unittest.TestCase):
     def setUp(self):

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -234,7 +234,7 @@ class TestEvent(unittest.TestCase):
         self.assertEqual(evt3.times, [3, 4, 5] * pq.ms)
 
         evt4 = evt.time_slice(None, None)
-        self.assertEqual(evt1, evt4)
+        self.assertEqual(evt, evt4)
 
 class TestDuplicateWithNewData(unittest.TestCase):
     def setUp(self):

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -224,11 +224,11 @@ class TestEvent(unittest.TestCase):
         evt = Event(data, foo='bar')
 
         evt1 = evt.time_slice(2.2 * pq.ms, 4.2 * pq.ms)
-        assert_arrays_equal(evt1.times,[3, 4] * pq.ms)
+        assert_arrays_equal(evt1.times, [3, 4] * pq.ms)
         self.assertEqual(evt.annotations, evt1.annotations)
 
         evt2 = evt.time_slice(None, 4.2 * pq.ms)
-        assert_arrays_equal(evt2.times,[2, 3, 4] * pq.ms)
+        assert_arrays_equal(evt2.times, [2, 3, 4] * pq.ms)
 
         evt3 = evt.time_slice(2.2 * pq.ms, None)
         assert_arrays_equal(evt3.times, [3, 4, 5] * pq.ms)

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -219,6 +219,23 @@ class TestEvent(unittest.TestCase):
 
         self.assertEqual(prepr, targ)
 
+    def test__time_slice(self):
+        data = [2, 3, 4, 5] * pq.ms
+        evt = Event(data, foo='bar')
+
+        evt1 = evt.time_slice(2.2 * pq.ms, 4.2 * pq.ms)
+        self.assertEqual(evt1.times,[3, 4] * pq.ms)
+        self.assertEqual(evt.annotations, evt1.annotations)
+
+        evt2 = evt.time_slice(None, 4.2 * pq.ms)
+        self.assertEqual(evt2.times,[2, 3, 4] * pq.ms)
+
+        evt3 = evt.time_slice(2.2 * pq.ms, None)
+        self.assertEqual(evt3.times, [3, 4, 5] * pq.ms)
+
+        evt4 = evt.time_slice(None, None)
+        self.assertEqual(evt1, evt4)
+
 class TestDuplicateWithNewData(unittest.TestCase):
     def setUp(self):
         self.data = np.array([0.1, 0.5, 1.2, 3.3, 6.4, 7])


### PR DESCRIPTION
Implementing `time_slice` method for `Epoch` and `Event`
Issue #60

concerning the question I wrote in the thread of #60, it's now implemented that the individual epochs of an `Epoch` are only contained in the sliced `Epoch` if their start time falls within the slice time.

Hope it's done right this time ;)