### PR TITLE
issue220 with tests

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -237,7 +237,7 @@ class AnalogSignal(BaseNeo, pq.Quantity):
         super(AnalogSignal, self).__array_finalize__(obj)
         self._t_start = getattr(obj, '_t_start', 0 * pq.s)
         self._sampling_rate = getattr(obj, '_sampling_rate', None)
-
+       
         # The additional arguments
         self.annotations = getattr(obj, 'annotations', None)
 
@@ -245,6 +245,10 @@ class AnalogSignal(BaseNeo, pq.Quantity):
         self.name = getattr(obj, 'name', None)
         self.file_origin = getattr(obj, 'file_origin', None)
         self.description = getattr(obj, 'description', None)
+
+        # Parents objects
+        self.segment = getattr(obj, 'segment', None)
+        self.channel_index = getattr(obj, 'channel_index', None)
 
     def __repr__(self):
         '''

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -304,6 +304,8 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.signal1 = AnalogSignal(self.data1quant, sampling_rate=1*pq.kHz,
                                          name='spam', description='eggs',
                                          file_origin='testfile.txt', arg1='test')
+        self.signal1.segment = 1
+        self.signal1.channel_index = 5
 
     def test__compliant(self):
         assert_neo_object_is_compliant(self.signal1)
@@ -332,6 +334,11 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.assertEqual(result.name, self.signal1.name)
         self.assertEqual(result.description, self.signal1.description)
         self.assertEqual(result.annotations, self.signal1.annotations)
+
+    def test__slice_should_let_access_to_parents_objects(self):
+        result =  self.signal1.time_slice(1*pq.ms,3*pq.ms)
+        self.assertEqual(result.segment, self.signal1.segment)
+        self.assertEqual(result.channel_index, self.signal1.channel_index)
 
     def test__slice_should_change_sampling_period(self):
         result1 = self.signal1[:2, 0]
@@ -368,6 +375,16 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         assert_array_equal(result1.magnitude, self.data1[:2].reshape(-1, 1))
         assert_array_equal(result2.magnitude, self.data1[::2].reshape(-1, 1))
         assert_array_equal(result3.magnitude, self.data1[1:7:2].reshape(-1, 1))
+
+    def test__copy_should_let_access_to_parents_objects(self):
+        ##copy
+        result =  self.signal1.copy()
+        self.assertEqual(result.segment, self.signal1.segment)
+        self.assertEqual(result.channel_index, self.signal1.channel_index)
+        ## deep copy (not fixed yet)
+        #result = copy.deepcopy(self.signal1)
+        #self.assertEqual(result.segment, self.signal1.segment)
+        #self.assertEqual(result.channel_index, self.signal1.channel_index)
 
     def test__getitem_should_return_single_quantity(self):
         result1 = self.signal1[0, 0]


### PR DESCRIPTION
the access to "parents" property is only fixed for time_slice and copy, not yet for deepcopy