### PR TITLE
fix some python 3 incompatibilities in axonio

### DIFF
--- a/neo/io/axonio.py
+++ b/neo/io/axonio.py
@@ -302,7 +302,7 @@ class AxonIO(BaseIO):
 
                     anaSig = AnalogSignal(signal, sampling_rate=sampling_rate,
                                           t_start=t_start,
-                                          name=str(name),
+                                          name=name.decode("utf-8"),
                                           channel_index=int(num))
                     if lazy:
                         anaSig.lazy_shape = length / nbchannel
@@ -317,7 +317,7 @@ class AxonIO(BaseIO):
                 comments = []
                 for i, tag in enumerate(header['listTag']):
                     times.append(tag['lTagTime']/sampling_rate)
-                    labels.append(str(tag['nTagType']))
+                    labels.append(tag['nTagType'].decode("utf-8"))
                     comments.append(clean_string(tag['sComment']))
                 times = np.array(times)
                 labels = np.array(labels, dtype='S')
@@ -544,8 +544,8 @@ class AxonIO(BaseIO):
             'llNumEntries']  # Number of ADC channels
         nDAC = header['sections']['DACSection'][
             'llNumEntries']  # Number of DAC channels
-        nSam = header['protocol'][
-            'lNumSamplesPerEpisode'] / nADC  # Number of samples per episode
+        nSam = int(header['protocol'][
+            'lNumSamplesPerEpisode'] / nADC)  # Number of samples per episode
         nEpi = header['lActualEpisodes']  # Actual number of episodes
         sampling_rate = 1.e6 / header['protocol'][
             'fADCSequenceInterval'] * pq.Hz
@@ -565,7 +565,7 @@ class AxonIO(BaseIO):
                     header['listDACInfo'][DACNum]['fDACHoldingLevel'] *\
                     pq.Quantity(1, unit)
                 ana_sig = AnalogSignal(signal, sampling_rate=sampling_rate,
-                                       t_start=t_start, name=str(name),
+                                       t_start=t_start, name=name.decode("utf-8"),
                                        channel_index=DACNum)
                 # If there are epoch infos for this DAC
                 if DACNum in header['dictEpochInfoPerDAC']:


### PR DESCRIPTION
Some values need to be converted to ints in order to work as indices

Some strings need to have .decode() called, not str(), or they have a spurious "b" at the start.