### PR TITLE
Add methods `as_array()` and `as_quantity()` to Neo data objects

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -646,3 +646,20 @@ class AnalogSignal(BaseNeo, pq.Quantity):
         if hasattr(self, "lazy_shape"):
             signal.lazy_shape = merged_lazy_shape
         return signal
+
+    def as_array(self, units=None):
+        """
+        Return the signal as a plain NumPy array.
+
+        If `units` is specified, first rescale to those units.
+        """
+        if units:
+            return self.rescale(units).magnitude
+        else:
+            return self.magnitude
+
+    def as_quantity(self):
+        """
+        Return the signal as a quantities array.
+        """
+        return self.view(pq.Quantity)

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -216,3 +216,20 @@ class Epoch(BaseNeo, pq.Quantity):
         new_epc.durations = self.durations[indices]
         new_epc.labels = self.labels[indices]
         return new_epc
+
+    def as_array(self, units=None):
+        """
+        Return the epoch start times as a plain NumPy array.
+
+        If `units` is specified, first rescale to those units.
+        """
+        if units:
+            return self.rescale(units).magnitude
+        else:
+            return self.magnitude
+
+    def as_quantity(self):
+        """
+        Return the epoch start times as a quantities array.
+        """
+        return self.view(pq.Quantity)

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -202,3 +202,20 @@ class Event(BaseNeo, pq.Quantity):
         new_evt = self[indices]
 
         return new_evt
+
+    def as_array(self, units=None):
+        """
+        Return the event times as a plain NumPy array.
+
+        If `units` is specified, first rescale to those units.
+        """
+        if units:
+            return self.rescale(units).magnitude
+        else:
+            return self.magnitude
+
+    def as_quantity(self):
+        """
+        Return the event times as a quantities array.
+        """
+        return self.view(pq.Quantity)

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -530,3 +530,20 @@ class IrregularlySampledSignal(BaseNeo, pq.Quantity):
         new_st = self[id_start:id_stop]
 
         return new_st
+
+    def as_array(self, units=None):
+        """
+        Return the signal as a plain NumPy array.
+
+        If `units` is specified, first rescale to those units.
+        """
+        if units:
+            return self.rescale(units).magnitude
+        else:
+            return self.magnitude
+
+    def as_quantity(self):
+        """
+        Return the signal as a quantities array.
+        """
+        return self.view(pq.Quantity)

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -613,3 +613,20 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         if self.left_sweep is None or dur is None:
             return None
         return self.left_sweep + dur
+
+    def as_array(self, units=None):
+        """
+        Return the spike times as a plain NumPy array.
+
+        If `units` is specified, first rescale to those units.
+        """
+        if units:
+            return self.rescale(units).magnitude
+        else:
+            return self.magnitude
+
+    def as_quantity(self):
+        """
+        Return the spike times as a quantities array.
+        """
+        return self.view(pq.Quantity)

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -456,6 +456,16 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
     def test__rescale_new_incompatible_ValueError(self):
         self.assertRaises(ValueError, self.signal1.rescale, pq.mV)
 
+    def test_as_array(self):
+        sig_as_arr = self.signal1.as_array()
+        self.assertIsInstance(sig_as_arr, np.ndarray)
+        assert_array_equal(self.data1, sig_as_arr.flat)
+
+    def test_as_quantity(self):
+        sig_as_q = self.signal1.as_quantity()
+        self.assertIsInstance(sig_as_q, pq.Quantity)
+        assert_array_equal(self.data1, sig_as_q.magnitude.flat)
+
 
 class TestAnalogSignalEquality(unittest.TestCase):
     def test__signals_with_different_data_complement_should_be_not_equal(self):

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -485,7 +485,21 @@ class TestEpoch(unittest.TestCase):
         self.assertEqual(result.annotations['test1'], targ.annotations['test1'])
         self.assertEqual(result.annotations['test2'], targ.annotations['test2'])
     
+    def test_as_array(self):
+        times = [2, 3, 4, 5]
+        durations = [0.1, 0.2, 0.3, 0.4]
+        epc = Epoch(times * pq.ms, durations=durations * pq.ms)
+        epc_as_arr = epc.as_array(units='ms')
+        self.assertIsInstance(epc_as_arr, np.ndarray)
+        assert_array_equal(times, epc_as_arr)
 
+    def test_as_quantity(self):
+        times = [2, 3, 4, 5]
+        durations = [0.1, 0.2, 0.3, 0.4]
+        epc = Epoch(times * pq.ms, durations=durations * pq.ms)
+        epc_as_q = epc.as_quantity()
+        self.assertIsInstance(epc_as_q, pq.Quantity)
+        assert_array_equal(times * pq.ms, epc_as_q)
 
 
 class TestDuplicateWithNewData(unittest.TestCase):

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -388,6 +388,21 @@ class TestEvent(unittest.TestCase):
         evt3 = evt.time_slice(2.2 * pq.ms, None)
         assert_arrays_equal(evt3.times, [3, 4, 5] * pq.ms)
 
+    def test_as_array(self):
+        data = [2, 3, 4, 5]
+        evt = Event(data * pq.ms)
+        evt_as_arr = evt.as_array()
+        self.assertIsInstance(evt_as_arr, np.ndarray)
+        assert_array_equal(data, evt_as_arr)
+
+    def test_as_quantity(self):
+        data = [2, 3, 4, 5]
+        evt = Event(data * pq.ms)
+        evt_as_q = evt.as_quantity()
+        self.assertIsInstance(evt_as_q, pq.Quantity)
+        assert_array_equal(data * pq.ms, evt_as_q)
+
+
 class TestDuplicateWithNewData(unittest.TestCase):
     def setUp(self):
         self.data = np.array([0.1, 0.5, 1.2, 3.3, 6.4, 7])

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -543,6 +543,17 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         self.assertEqual(result.file_origin, 'testfile.txt')
         self.assertEqual(result.annotations, {'arg1': 'test'})
 
+    def test_as_array(self):
+        sig_as_arr = self.signal1.as_array()
+        self.assertIsInstance(sig_as_arr, np.ndarray)
+        assert_array_equal(self.data1, sig_as_arr.flat)
+
+    def test_as_quantity(self):
+        sig_as_q = self.signal1.as_quantity()
+        self.assertIsInstance(sig_as_q, pq.Quantity)
+        assert_array_equal(self.data1, sig_as_q.magnitude.flat)
+
+
 class TestIrregularlySampledSignalCombination(unittest.TestCase):
     def setUp(self):
         self.data1 = np.arange(10.0)

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -14,6 +14,7 @@ except ImportError:
     import unittest
 
 import numpy as np
+from numpy.testing import assert_array_equal
 import quantities as pq
 
 try:
@@ -1758,6 +1759,20 @@ class TestMiscellaneous(unittest.TestCase):
                            t_start=t_start64, t_stop=t_stop64,
                            dtype=np.float64)
         assert_neo_object_is_compliant(train)
+
+    def test_as_array(self):
+        data = np.arange(10.0)
+        st = SpikeTrain(data, t_stop=10.0, units='ms')
+        st_as_arr = st.as_array()
+        self.assertIsInstance(st_as_arr, np.ndarray)
+        assert_array_equal(data, st_as_arr)
+
+    def test_as_quantity(self):
+        data = np.arange(10.0)
+        st = SpikeTrain(data, t_stop=10.0, units='ms')
+        st_as_q = st.as_quantity()
+        self.assertIsInstance(st_as_q, pq.Quantity)
+        assert_array_equal(data * pq.ms, st_as_q)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
to simplify the common tasks of turning a Neo data object back into a plain Numpy array (many people do not know about `object.magnitude`) or into a Quantity array.