### PR TITLE
Read sProtocolPath for ABF2 as well as ABF1

### DIFF
--- a/neo/io/axonio.py
+++ b/neo/io/axonio.py
@@ -455,6 +455,7 @@ class AxonIO(BaseIO):
                 else:
                     protocol[key] = np.array(val)
             header['protocol'] = protocol
+            header['sProtocolPath'] = strings[header['uProtocolPathIndex']-1]
 
             # tags
             listTag = []


### PR DESCRIPTION
This commit reads the field for sProtocolPath for ABF2. AxonIO already handles this field for ABF1 files and stores it in header['sProtocolPath'], so I followed the same convention.