### PR TITLE
Update axonio.py

### DIFF
--- a/neo/io/axonio.py
+++ b/neo/io/axonio.py
@@ -317,7 +317,7 @@ class AxonIO(BaseIO):
                 comments = []
                 for i, tag in enumerate(header['listTag']):
                     times.append(tag['lTagTime']/sampling_rate)
-                    labels.append(tag['nTagType'].decode("utf-8"))
+                    labels.append(str(tag['nTagType']))
                     comments.append(clean_string(tag['sComment']))
                 times = np.array(times)
                 labels = np.array(labels, dtype='S')


### PR DESCRIPTION
Original line 320 crashes in 64-bit python 3.5.2 on many ABFs that have tags (observed in ABF v 2.x).  
Error is:
  File "c:\program files\python35\lib\site-packages\neo\io\axonio.py", line 320, in read_block
    labels.append(tag['nTagType'].decode("utf-8"))
AttributeError: 'int' object has no attribute 'decode'

Proposed change avoids this crash.