### PR TITLE
NeuroExplorerIO: correct offset for continuous signal

### DIFF
--- a/neo/io/neuroexplorerio.py
+++ b/neo/io/neuroexplorerio.py
@@ -3,13 +3,13 @@
 Class for reading data from NeuroExplorer (.nex)
 
 Documentation for dev :
-http://www.neuroexplorer.com/code.html
+http://www.neuroexplorer.com/downloads/HowToReadAndWriteNexAndNex5FilesInMatlab.zip
 
 Depend on:
 
 Supported : Read
 
-Author: sgarcia,luc estebanez
+Author: sgarcia,luc estebanez, mark hollenbeck
 
 """
 

--- a/neo/io/neuroexplorerio.py
+++ b/neo/io/neuroexplorerio.py
@@ -206,9 +206,11 @@ class NeuroExplorerIO(BaseIO):
                                        shape=(entity_header['n']),
                                        offset=entity_header['offset'])
                 timestamps = timestamps.astype('f8') / global_header['freq']
+
+                fragment_starts_offset = entity_header['offset'] + entity_header['n']*4
                 fragment_starts = np.memmap(self.filename, np.dtype('i4'), 'r',
                                             shape=(entity_header['n']),
-                                            offset=entity_header['offset'])
+                                            offset=fragment_starts_offset)
                 fragment_starts = fragment_starts.astype('f8') / global_header[
                     'freq']
                 t_start = timestamps[0] - fragment_starts[0] / float(
@@ -218,9 +220,10 @@ class NeuroExplorerIO(BaseIO):
                 if lazy:
                     signal = [] * pq.mV
                 else:
+                    signal_offset = fragment_starts_offset + entity_header['n']*4
                     signal = np.memmap(self.filename, np.dtype('i2'), 'r',
                                        shape=(entity_header['NPointsWave']),
-                                       offset=entity_header['offset'])
+                                       offset=signal_offset)
                     signal = signal.astype('f')
                     signal *= entity_header['ADtoMV']
                     signal += entity_header['MVOffset']


### PR DESCRIPTION
When parsing continuous signal from a NeuroExplorer file, the same byte offset was being used for indices, fragment starts, and data signal (i.e. `entity_header['offset']`). However, these are positioned sequentially in the file. This corrects the offsets such that the correct fragment starts, and signal are returned with the IO object. 

Tested against a local continuous signal file of `.nex` format. 