### PR TITLE
Added `extras_require` field to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,14 @@ import os
 long_description = open("README.rst").read()
 install_requires = ['numpy>=1.7.1',
                     'quantities>=0.9.0']
+extras_require = {
+    'hdf5io': ['h5py'],
+    'igorproio': ['igor'],
+    'kwikio': ['scipy', 'klusta'],
+    'neomatlabio': ['scipy>=0.12.0'],
+    'nixio': ['nixio'],
+    'stimfitio': ['stfio'],
+}
 
 if os.environ.get('TRAVIS') == 'true' and \
     os.environ.get('TRAVIS_PYTHON_VERSION').startswith('2.6'):
@@ -17,6 +25,7 @@ setup(
     version = '0.5.1dev',
     packages = ['neo', 'neo.core', 'neo.io', 'neo.test', 'neo.test.iotest'],
     install_requires=install_requires,
+    extras_require=extras_require,
     author = "Neo authors and contributors",
     author_email = "samuel.garcia@cnrs.fr",
     description = "Neo is a package for representing electrophysiology data in Python, together with support for reading a wide range of neurophysiology file formats",


### PR DESCRIPTION
to clearly document the requirements for different io modules.

For example, this allows you to run:
```pip install neo[neomatlabio]```
and have the extra dependency needed for the `neomatlabio` module (scipy in this case) be automatically installed.