### PR TITLE
Fix for #320

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -300,6 +300,8 @@ class AnalogSignal(BaseNeo, pq.Quantity):
                     raise TypeError("%s not supported" % type(j))
                 if isinstance(k, int):
                     obj = obj.reshape(-1, 1)
+                if self.channel_index:
+                    obj.channel_index = self.channel_index.__getitem__(k)
         elif isinstance(i, slice):
             if i.start:
                 obj.t_start = self.t_start + i.start * self.sampling_period

--- a/neo/core/channelindex.py
+++ b/neo/core/channelindex.py
@@ -145,7 +145,26 @@ class ChannelIndex(Container):
             channel_ids = np.array([], dtype='i')
 
         # Store recommended attributes
-        self.channel_names = channel_names
-        self.channel_ids = channel_ids
-        self.index = index
+        self.channel_names = np.array(channel_names)
+        self.channel_ids = np.array(channel_ids)
+        self.index = np.array(index)
         self.coordinates = coordinates
+
+    def __getitem__(self, i):
+        '''
+        Get the item or slice :attr:`i`.
+        '''
+        index = self.index.__getitem__(i)
+        if self.channel_names.size > 0:
+            channel_names = self.channel_names[index]
+        else:
+            channel_names = None
+        if self.channel_ids.size > 0:
+            channel_ids = self.channel_ids[index]
+        else:
+            channel_ids = None
+        obj = ChannelIndex(index=np.arange(index.size),
+                           channel_names=channel_names,
+                           channel_ids=channel_ids)
+        obj.block = self.block
+        return obj

--- a/neo/core/channelindex.py
+++ b/neo/core/channelindex.py
@@ -157,10 +157,14 @@ class ChannelIndex(Container):
         index = self.index.__getitem__(i)
         if self.channel_names.size > 0:
             channel_names = self.channel_names[index]
+            if not channel_names.shape:
+                channel_names = [channel_names]
         else:
             channel_names = None
         if self.channel_ids.size > 0:
             channel_ids = self.channel_ids[index]
+            if not channel_ids.shape:
+                channel_ids = [channel_ids]
         else:
             channel_ids = None
         obj = ChannelIndex(index=np.arange(index.size),

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -384,11 +384,12 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
                               units="mV")
         self.assertEqual(signal.shape, (100, n))
         signal.channel_index = ChannelIndex(index=np.arange(n, dtype=int),
-                                            channel_names=["channel{}".format(i) for i in range(n)])
+                                            channel_names=["channel{0}".format(i) for i in range(n)])
         odd_channels = signal[:, 1::2]
         self.assertEqual(odd_channels.shape, (100, n//2))
         assert_array_equal(odd_channels.channel_index.index, np.arange(n//2, dtype=int))
-        assert_array_equal(odd_channels.channel_index.channel_names, ["channel{}".format(i) for i in range(1, n, 2)])
+        assert_array_equal(odd_channels.channel_index.channel_names, ["channel{0}".format(i) for i in range(1, n, 2)])
+        assert_array_equal(signal.channel_index.channel_names, ["channel{0}".format(i) for i in range(n)])
 
     def test__copy_should_let_access_to_parents_objects(self):
         ##copy

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -26,6 +26,7 @@ else:
 
 from numpy.testing import assert_array_equal
 from neo.core.analogsignal import AnalogSignal, _get_sampling_rate
+from neo.core.channelindex import ChannelIndex
 from neo.core import Segment
 from neo.test.tools import (assert_arrays_almost_equal,
                             assert_neo_object_is_compliant,
@@ -305,7 +306,7 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
                                          name='spam', description='eggs',
                                          file_origin='testfile.txt', arg1='test')
         self.signal1.segment = 1
-        self.signal1.channel_index = 5
+        self.signal1.channel_index = ChannelIndex(index=[0])
 
     def test__compliant(self):
         assert_neo_object_is_compliant(self.signal1)
@@ -375,6 +376,19 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         assert_array_equal(result1.magnitude, self.data1[:2].reshape(-1, 1))
         assert_array_equal(result2.magnitude, self.data1[::2].reshape(-1, 1))
         assert_array_equal(result3.magnitude, self.data1[1:7:2].reshape(-1, 1))
+
+    def test__slice_should_modify_linked_channelindex(self):
+        n = 8  # number of channels
+        signal = AnalogSignal(np.arange(n * 100.0).reshape(100, n),
+                              sampling_rate=1*pq.kHz,
+                              units="mV")
+        self.assertEqual(signal.shape, (100, n))
+        signal.channel_index = ChannelIndex(index=np.arange(n, dtype=int),
+                                            channel_names=["channel{}".format(i) for i in range(n)])
+        odd_channels = signal[:, 1::2]
+        self.assertEqual(odd_channels.shape, (100, n//2))
+        assert_array_equal(odd_channels.channel_index.index, np.arange(n//2, dtype=int))
+        assert_array_equal(odd_channels.channel_index.channel_names, ["channel{}".format(i) for i in range(1, n, 2)])
 
     def test__copy_should_let_access_to_parents_objects(self):
         ##copy


### PR DESCRIPTION
Adds a `__getitem__()` method to `ChannelIndex` and ensures the `channel_index` attribute of an `AnalogSignal` is updated when extracting a subset of channels from it.