### PR TITLE
TdtIO: Improved python 3 compatability and small bug fixes

### DIFF
--- a/neo/io/tdtio.py
+++ b/neo/io/tdtio.py
@@ -24,7 +24,11 @@ import sys
 
 import numpy as np
 import quantities as pq
-import itertools
+
+try:
+    from itertools import izip as zip
+except ImportError:  # zip already exists without import in python 3.x
+    pass
 
 from neo.io.baseio import BaseIO
 from neo.core import Block, Segment, AnalogSignal, SpikeTrain, Event
@@ -38,7 +42,7 @@ def get_chunks(sizes, offsets, big_array):
     # sizes are not!!
     # so need this (I really do not knwo why...):
     sizes = (sizes -10)  * 4 #
-    all = np.concatenate([ big_array[o:o+s] for s, o in itertools.izip(sizes, offsets) ])
+    all = np.concatenate([ big_array[o:o+s] for s, o in zip(sizes, offsets) ])
     return all
 
 class TdtIO(BaseIO):

--- a/neo/io/tdtio.py
+++ b/neo/io/tdtio.py
@@ -248,10 +248,9 @@ class TdtIO(BaseIO):
                             signal = get_chunks(tsq[mask3]['size'],tsq[mask3]['eventoffset'],  sig_array).view(dt)
 
                         anasig = AnalogSignal(signal        = signal* pq.V,
-                                              name          = '{0} {1}'.format(code, channel),
+                                              name          = '{0} {1}'.format(signame, channel),
                                               sampling_rate = sr * pq.Hz,
-                                              t_start       = (tsq[mask3]['timestamp'][0] - global_t_start) * pq.s,
-                                              channel_index = int(channel)
+                                              t_start       = (tsq[mask3]['timestamp'][0] - global_t_start) * pq.s
                                               )
                         if lazy:
                             anasig.lazy_shape = shape


### PR DESCRIPTION
Fixes #328: Python 3 compatibility of `TdtIO.get_chunks()`