### PR TITLE
[NixIO] New object naming scheme

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -285,8 +285,8 @@ class NixIO(BaseIO):
         nix_da_group = sorted(nix_da_group, key=lambda d: d.name)
         neo_attrs = self._nix_attr_to_neo(nix_da_group[0])
         metadata = nix_da_group[0].metadata
-        neo_attrs["name"] = stringify(metadata.name)
         neo_type = nix_da_group[0].type
+        neo_attrs["nix_name"] = metadata.name  # use the common base name
 
         unit = nix_da_group[0].unit
         if lazy:
@@ -456,7 +456,8 @@ class NixIO(BaseIO):
             ref_das = self._get_referers(nix_obj, parent_block.data_arrays)
             ref_signals = self._get_mapped_objects(ref_das)
             # deduplicate by name
-            ref_signals = list(dict((s.name, s) for s in ref_signals).values())
+            ref_signals = list(dict((s.annotations["nix_name"], s)
+                                    for s in ref_signals).values())
             for sig in ref_signals:
                 if isinstance(sig, AnalogSignal):
                     neo_obj.analogsignals.append(sig)

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -924,9 +924,11 @@ class NixIO(BaseIO):
                 labeldim = nixobj.positions.append_set_dimension()
                 labeldim.labels = attr["labels"]
             if "t_start" in attr:
-                self._write_property(metadata, "t_start", attr["t_start"])
+                metadata["t_start"] = nix.Value(attr["t_start"])
+                metadata["t_start.units"] = nix.Value(attr["t_start.units"])
             if "t_stop" in attr:
-                self._write_property(metadata, "t_stop", attr["t_stop"])
+                metadata["t_stop"] = nix.Value(attr["t_stop"])
+                metadata["t_stop.units"] = nix.Value(attr["t_stop.units"])
             if "waveforms" in attr:
                 wfname = nixobj.name + ".waveforms"
                 if wfname in parentblock.data_arrays:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -1115,7 +1115,10 @@ class NixIO(BaseIO):
     @staticmethod
     def _nix_attr_to_neo(nix_obj):
         neo_attrs = dict()
-        neo_attrs["name"] = stringify(nix_obj.name)
+        # neo_attrs["name"] = stringify(nix_obj.name)
+        neo_name = nix_obj.metadata["neo_name"]\
+            if "neo_name" in nix_obj.metadata else None
+        neo_attrs["name"] = neo_name
 
         neo_attrs["description"] = stringify(nix_obj.definition)
         if nix_obj.metadata:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -520,8 +520,11 @@ class NixIO(BaseIO):
                 containerstr = "/channel_indexes/"
             else:
                 containerstr = "/" + type(obj).__name__.lower() + "s/"
-        nix_name = "neo.{}.{}".format(objtype, self._generate_nix_name())
-        obj.annotate(nix_name=nix_name)
+        if "nix_name" in obj.annotations:
+            nix_name = obj.annotations["nix_name"]
+        else:
+            nix_name = "neo.{}.{}".format(objtype, self._generate_nix_name())
+            obj.annotate(nix_name=nix_name)
         objpath = loc + containerstr + nix_name
         oldhash = self._object_hashes.get(objpath)
         if oldhash is None:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -240,12 +240,18 @@ class NixIO(BaseIO):
     def _block_to_neo(self, nix_block):
         neo_attrs = self._nix_attr_to_neo(nix_block)
         neo_block = Block(**neo_attrs)
+        neo_block.rec_datetime = datetime.fromtimestamp(
+            nix_block.created_at
+        )
         self._object_map[nix_block.id] = neo_block
         return neo_block
 
     def _group_to_neo(self, nix_group):
         neo_attrs = self._nix_attr_to_neo(nix_group)
         neo_segment = Segment(**neo_attrs)
+        neo_segment.rec_datetime = datetime.fromtimestamp(
+            nix_group.created_at
+        )
         self._object_map[nix_group.id] = neo_segment
         return neo_segment
 
@@ -879,7 +885,7 @@ class NixIO(BaseIO):
         if "file_datetime" in attr:
             self._write_property(metadata,
                                  "file_datetime", attr["file_datetime"])
-        if "rec_datetime" in attr and attr["rec_datetime"]:
+        if attr.get("rec_datetime"):
             self._write_property(metadata,
                                  "rec_datetime", attr["rec_datetime"])
 
@@ -1131,12 +1137,6 @@ class NixIO(BaseIO):
                     neo_attrs[prop.name] = values
         neo_attrs["name"] = neo_attrs.get("neo_name")
 
-        if isinstance(nix_obj, (nix.pycore.Block, nix.pycore.Group)):
-            if "rec_datetime" not in neo_attrs:
-                neo_attrs["rec_datetime"] = None
-            neo_attrs["rec_datetime"] = datetime.fromtimestamp(
-                nix_obj.created_at
-            )
         if "file_datetime" in neo_attrs:
             neo_attrs["file_datetime"] = datetime.fromtimestamp(
                 neo_attrs["file_datetime"]

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -117,6 +117,7 @@ class NixIO(BaseIO):
         self._lazy_loaded = list()
         self._object_hashes = dict()
         self._block_read_counter = 0
+        self._path_map = dict()
 
     def __enter__(self):
         return self
@@ -819,6 +820,8 @@ class NixIO(BaseIO):
         :param path: Path string
         :return: The object at the location defined by the path
         """
+        if path in self._path_map:
+            return self._path_map[path]
         if path in ("", "/"):
             return self.nix_file
         parts = path.split("/")
@@ -840,6 +843,7 @@ class NixIO(BaseIO):
                     break
         else:
             obj = parent_container[objname]
+        self._path_map[path] = obj
         return obj
 
     def _get_parent(self, path):

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -298,7 +298,7 @@ class NixIO(BaseIO):
             lazy_shape = None
         timedim = self._get_time_dimension(nix_da_group[0])
         if (neo_type == "neo.analogsignal" or
-                isinstance(timedim, nix.pycore.SampledDimension)):
+                timedim.dimension_type == nix.DimensionType.Sample):
             if lazy:
                 sampling_period = pq.Quantity(1, timedim.unit)
                 t_start = pq.Quantity(0, timedim.unit)
@@ -318,8 +318,8 @@ class NixIO(BaseIO):
                 signal=signaldata, sampling_period=sampling_period,
                 t_start=t_start, **neo_attrs
             )
-        elif neo_type == "neo.irregularlysampledsignal"\
-                or isinstance(timedim, nix.pycore.RangeDimension):
+        elif (neo_type == "neo.irregularlysampledsignal"
+              or timedim.dimension_type == nix.DimensionType.Range):
             if lazy:
                 times = pq.Quantity(np.empty(0), timedim.unit)
             else:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -1117,11 +1117,7 @@ class NixIO(BaseIO):
     @staticmethod
     def _nix_attr_to_neo(nix_obj):
         neo_attrs = dict()
-        # neo_attrs["name"] = stringify(nix_obj.name)
-        neo_name = nix_obj.metadata["neo_name"]\
-            if "neo_name" in nix_obj.metadata else None
-        neo_attrs["name"] = neo_name
-
+        neo_attrs["nix_name"] = nix_obj.name
         neo_attrs["description"] = stringify(nix_obj.definition)
         if nix_obj.metadata:
             for prop in nix_obj.metadata.props:
@@ -1133,6 +1129,7 @@ class NixIO(BaseIO):
                     neo_attrs[prop.name] = values[0]
                 else:
                     neo_attrs[prop.name] = values
+        neo_attrs["name"] = neo_attrs.get("neo_name")
 
         if isinstance(nix_obj, (nix.pycore.Block, nix.pycore.Group)):
             if "rec_datetime" not in neo_attrs:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -987,7 +987,10 @@ class NixIO(BaseIO):
     def _neo_attr_to_nix(neoobj):
         neotype = type(neoobj).__name__
         attrs = dict()
-        attrs["neo_name"] = neoobj.name
+        # NIX metadata does not support None values
+        # The property will be excluded to signify 'name is None'
+        if neoobj.name is not None:
+            attrs["neo_name"] = neoobj.name
         attrs["type"] = neotype.lower()
         attrs["definition"] = neoobj.description
         if isinstance(neoobj, (Block, Segment)):

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -134,7 +134,6 @@ class NixIO(BaseIO):
     def read_block(self, path="/", cascade=True, lazy=False):
         if path == "/":
             try:
-                # Use yield?
                 nix_block = self.nix_file.blocks[self._block_read_counter]
                 path += nix_block.name
                 self._block_read_counter += 1
@@ -558,18 +557,28 @@ class NixIO(BaseIO):
         parentobj = self._get_object_at(loc)
         if attr["type"] == "block":
             nixobj = parentobj.create_block(attr["name"], "neo.block")
+            nixobj.metadata = self.nix_file.create_section(
+                attr["name"], "neo.block.metadata"
+            )
         elif attr["type"] == "segment":
             nixobj = parentobj.create_group(attr["name"], "neo.segment")
+            nixobj.metadata = parentobj.metadata.create_section(
+                attr["name"], "neo.segment.metadata"
+            )
         elif attr["type"] == "channelindex":
             nixobj = parentobj.create_source(attr["name"],
                                              "neo.channelindex")
+            nixobj.metadata = parentobj.metadata.create_section(
+                attr["name"], "neo.channelindex.metadata"
+            )
         elif attr["type"] in ("analogsignal", "irregularlysampledsignal"):
             blockpath = "/" + loc.split("/")[1]
             parentblock = self._get_object_at(blockpath)
             nixobj = list()
-            typestr = "neo." + attr["type"]
-            parentmd = self._get_or_init_metadata(parentobj, loc)
-            sigmd = parentmd.create_section(attr["name"], typestr+".metadata")
+            typestr = "neo.{}".format(attr["type"])
+            sigmd = parentobj.metadata.create_section(
+                attr["name"], "{}.metadata".format(typestr)
+            )
             for idx, datarow in enumerate(attr["data"]):
                 name = "{}.{}".format(attr["name"], idx)
                 da = parentblock.create_data_array(name, typestr, data=datarow)
@@ -579,16 +588,23 @@ class NixIO(BaseIO):
         elif attr["type"] in ("epoch", "event", "spiketrain"):
             blockpath = "/" + loc.split("/")[1]
             parentblock = self._get_object_at(blockpath)
+            typestr = "neo.{}".format(attr["type"])
             timesda = parentblock.create_data_array(
-                attr["name"]+".times", "neo."+attr["type"]+".times",
+                "{}.times".format(attr["name"]), "{}.times".format(typestr),
                 data=attr["data"]
             )
             nixobj = parentblock.create_multi_tag(
-                attr["name"], "neo."+attr["type"], timesda
+                attr["name"], typestr, timesda
+            )
+            nixobj.metadata = parentobj.metadata.create_section(
+                attr["name"], "{}.metadata".format(typestr)
             )
             parentobj.multi_tags.append(nixobj)
         elif attr["type"] == "unit":
             nixobj = parentobj.create_source(attr["name"], "neo.unit")
+            nixobj.metadata = parentobj.metadata.create_section(
+                attr["name"], "neo.unit.metadata"
+            )
         else:
             raise ValueError("Unable to create NIX object. Invalid type.")
         return nixobj
@@ -641,9 +657,11 @@ class NixIO(BaseIO):
             else:
                 nixchan = nixsource.create_source(channame,
                                                   "neo.channelindex")
+                nixchan.metadata = nixsource.metadata.create_section(
+                    nixchan.name, "neo.channelindex.metadata"
+                )
             nixchan.definition = nixsource.definition
-            chanpath = loc + "/channelindex/" + channame
-            chanmd = self._get_or_init_metadata(nixchan, chanpath)
+            chanmd = nixchan.metadata
             if len(chx.channel_names):
                 neochanname = stringify(chx.channel_names[idx])
                 chanmd["neo_name"] = nix.Value(neochanname)
@@ -782,29 +800,6 @@ class NixIO(BaseIO):
                     if unitsource not in stmtag.sources:
                         stmtag.sources.append(unitsource)
 
-    def _get_or_init_metadata(self, nix_obj, path):
-        """
-        Creates a metadata Section for the provided NIX object if it doesn't
-        have one already. Returns the new or existing metadata section.
-
-        :param nix_obj: The object to which the Section is attached
-        :param path: Path to nix_obj
-        :return: The metadata section of the provided object
-        """
-        parent_parts = path.split("/")[:-2]
-        parent_path = "/".join(parent_parts)
-        if nix_obj.metadata is None:
-            if len(parent_parts) == 0:  # nix_obj is root block
-                parent_metadata = self.nix_file
-            else:
-                obj_parent = self._get_object_at(parent_path)
-                parent_metadata = self._get_or_init_metadata(obj_parent,
-                                                             parent_path)
-            nix_obj.metadata = parent_metadata.create_section(
-                    nix_obj.name, nix_obj.type+".metadata"
-            )
-        return nix_obj.metadata
-
     def _get_object_at(self, path):
         """
         Returns the object at the location defined by the path.
@@ -869,36 +864,32 @@ class NixIO(BaseIO):
 
     def _write_attr_annotations(self, nixobj, attr, path):
         if isinstance(nixobj, list):
+            metadata = nixobj[0].metadata
             for obj in nixobj:
                 obj.definition = attr["definition"]
             self._write_attr_annotations(nixobj[0], attr, path)
             return
         else:
+            metadata = nixobj.metadata
             nixobj.definition = attr["definition"]
         if "neo_name" in attr:
-            metadata = self._get_or_init_metadata(nixobj, path)
             metadata["neo_name"] = attr["neo_name"]
         if "created_at" in attr:
             nixobj.force_created_at(calculate_timestamp(attr["created_at"]))
         if "file_datetime" in attr:
-            metadata = self._get_or_init_metadata(nixobj, path)
             self._write_property(metadata,
                                  "file_datetime", attr["file_datetime"])
-            # metadata["file_datetime"] = attr["file_datetime"]
         if "rec_datetime" in attr and attr["rec_datetime"]:
-            metadata = self._get_or_init_metadata(nixobj, path)
-            # metadata["rec_datetime"] = attr["rec_datetime"]
             self._write_property(metadata,
                                  "rec_datetime", attr["rec_datetime"])
 
         if "annotations" in attr:
-            metadata = self._get_or_init_metadata(nixobj, path)
             for k, v in attr["annotations"].items():
                 self._write_property(metadata, k, v)
 
     def _write_data(self, nixobj, attr, path):
         if isinstance(nixobj, list):
-            metadata = self._get_or_init_metadata(nixobj[0], path)
+            metadata = nixobj[0].metadata
             metadata["t_start.units"] = nix.Value(attr["t_start.units"])
             for obj in nixobj:
                 obj.unit = attr["data.units"]
@@ -913,6 +904,7 @@ class NixIO(BaseIO):
                 timedim.label = "time"
                 timedim.offset = attr["t_start"]
         else:
+            metadata = nixobj.metadata
             nixobj.positions.unit = attr["data.units"]
             blockpath = "/" + path.split("/")[1]
             parentblock = self._get_object_at(blockpath)
@@ -931,7 +923,6 @@ class NixIO(BaseIO):
             if "labels" in attr:
                 labeldim = nixobj.positions.append_set_dimension()
                 labeldim.labels = attr["labels"]
-            metadata = self._get_or_init_metadata(nixobj, path)
             if "t_start" in attr:
                 self._write_property(metadata, "t_start", attr["t_start"])
             if "t_stop" in attr:
@@ -939,11 +930,15 @@ class NixIO(BaseIO):
             if "waveforms" in attr:
                 wfname = nixobj.name + ".waveforms"
                 if wfname in parentblock.data_arrays:
+                    del metadata.sections[wfname]
                     del parentblock.data_arrays[wfname]
                     del nixobj.features[0]
                 wfda = parentblock.create_data_array(
                     wfname, "neo.waveforms",
                     data=attr["waveforms"]
+                )
+                wfda.metadata = nixobj.metadata.create_section(
+                    wfda.name, "neo.waveforms.metadata"
                 )
                 wfda.unit = attr["waveforms.units"]
                 nixobj.create_feature(wfda, nix.LinkType.Indexed)
@@ -956,11 +951,6 @@ class NixIO(BaseIO):
                     attr["sampling_interval.units"]
                 wftime.unit = attr["times.units"]
                 wftime.label = "time"
-                if wfname in metadata.sections:
-                    wfda.metadata = metadata.sections[wfname]
-                else:
-                    wfpath = path + "/waveforms/" + wfname
-                    wfda.metadata = self._get_or_init_metadata(wfda, wfpath)
                 if "left_sweep" in attr:
                     self._write_property(wfda.metadata, "left_sweep",
                                          attr["left_sweep"])
@@ -1149,7 +1139,6 @@ class NixIO(BaseIO):
             neo_attrs["file_datetime"] = datetime.fromtimestamp(
                 neo_attrs["file_datetime"]
             )
-        # neo_attrs["file_origin"] = os.path.basename(self.filename)
         return neo_attrs
 
     @staticmethod

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -155,12 +155,10 @@ class NixIOTest(unittest.TestCase):
             if self.io._find_lazy_loaded(sig) is not None:
                 sig = self.io.load_lazy_object(sig)
             dalist = list()
-            for idx in itertools.count():
-                nixname = "{}.{}".format(sig.annotations["nix_name"], idx)
-                if nixname in data_arrays:
-                    dalist.append(data_arrays[nixname])
-                else:
-                    break
+            nixname = sig.annotations["nix_name"]
+            for da in data_arrays:
+                if da.metadata["nix_name"] == nixname:
+                    dalist.append(da)
             _, nsig = np.shape(sig)
             self.assertEqual(nsig, len(dalist))
             self.compare_signal_dalist(sig, dalist)
@@ -279,6 +277,8 @@ class NixIOTest(unittest.TestCase):
         if neoobj.annotations:
             nixmd = nixobj.metadata
             for k, v, in neoobj.annotations.items():
+                if k == "nix_name":
+                    continue
                 if isinstance(v, pq.Quantity):
                     self.assertEqual(nixmd.props[str(k)].unit,
                                      str(v.dimensionality))

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -180,7 +180,8 @@ class NixIOTest(unittest.TestCase):
             self.assertEqual(neounit, da.unit)
             timedim = da.dimensions[0]
             if isinstance(neosig, AnalogSignal):
-                self.assertIsInstance(timedim, nix.pycore.SampledDimension)
+                self.assertEqual(timedim.dimension_type,
+                                 nix.DimensionType.Sample)
                 self.assertEqual(
                     pq.Quantity(timedim.sampling_interval, timedim.unit),
                     neosig.sampling_period
@@ -190,7 +191,8 @@ class NixIOTest(unittest.TestCase):
                     self.assertEqual(da.metadata["t_start.units"],
                                      str(neosig.t_start.dimensionality))
             elif isinstance(neosig, IrregularlySampledSignal):
-                self.assertIsInstance(timedim, nix.pycore.RangeDimension)
+                self.assertEqual(timedim.dimension_type,
+                                 nix.DimensionType.Range)
                 np.testing.assert_almost_equal(neosig.times.magnitude,
                                                timedim.ticks)
                 self.assertEqual(timedim.unit,
@@ -254,10 +256,12 @@ class NixIOTest(unittest.TestCase):
             self.assertEqual(np.shape(neowf), np.shape(nixwf))
             self.assertEqual(nixwf.unit, str(neowf.units.dimensionality))
             np.testing.assert_almost_equal(neowf.magnitude, nixwf)
-            self.assertIsInstance(nixwf.dimensions[0], nix.pycore.SetDimension)
-            self.assertIsInstance(nixwf.dimensions[1], nix.pycore.SetDimension)
-            self.assertIsInstance(nixwf.dimensions[2],
-                                  nix.pycore.SampledDimension)
+            self.assertEqual(nixwf.dimensions[0].dimension_type,
+                             nix.DimensionType.Set)
+            self.assertEqual(nixwf.dimensions[1].dimension_type,
+                             nix.DimensionType.Set)
+            self.assertEqual(nixwf.dimensions[2].dimension_type,
+                             nix.DimensionType.Sample)
 
     def compare_attr(self, neoobj, nixobj):
         if isinstance(neoobj, (AnalogSignal, IrregularlySampledSignal)):

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -395,7 +395,7 @@ class NixIOTest(unittest.TestCase):
             )
             mtag_st.metadata = mtag_st_md
             mtag_st_md.create_property(
-                "t_stop", nix.Value(max(times_da).item()+1)
+                "t_stop", nix.Value(times[-1]+1.0)
             )
 
             waveforms = cls.rquant((10, 8, 5), 1)
@@ -796,7 +796,8 @@ class NixIOWriteTest(NixIOTest):
                 for evidx in range(nevents):
                     seg.events.append(Event(times=times))
                 for stidx in range(nspiketrains):
-                    seg.spiketrains.append(SpikeTrain(times=times, t_stop=pq.s,
+                    seg.spiketrains.append(SpikeTrain(times=times,
+                                                      t_stop=times[-1]+pq.s,
                                                       units=pq.s))
             for chidx in range(nchx):
                 chx = ChannelIndex(name="chx{}".format(chidx),

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -24,7 +24,6 @@ try:
 except ImportError:
     import mock
 import string
-import itertools
 
 import numpy as np
 import quantities as pq

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -438,6 +438,9 @@ class NixIOTest(unittest.TestCase):
             mtag_ep = blk.create_multi_tag(
                 epname, "neo.epoch", times_da
             )
+            mtag_ep.metadata = group.metadata.create_section(
+                epname, epname+".metadata"
+            )
             group.multi_tags.append(mtag_ep)
             mtag_ep.definition = cls.rsentence(2)
             mtag_ep.extents = extents_da
@@ -460,6 +463,9 @@ class NixIOTest(unittest.TestCase):
 
             mtag_ev = blk.create_multi_tag(
                 evname, "neo.event", times_da
+            )
+            mtag_ev.metadata = group.metadata.create_section(
+                evname, evname+".metadata"
             )
             group.multi_tags.append(mtag_ev)
             mtag_ev.definition = cls.rsentence(2)
@@ -495,6 +501,9 @@ class NixIOTest(unittest.TestCase):
         for idx in range(nunits):
             unitname = "{}-unit{}".format(cls.rword(5), idx)
             nixunit = nixchx.create_source(unitname, "neo.unit")
+            nixunit.metadata = nixchx.metadata.create_section(
+                unitname, unitname+".metadata"
+            )
             nixunit.definition = cls.rsentence(4, 10)
             for st in stsperunit[idx]:
                 st.sources.append(nixchx)


### PR DESCRIPTION
Implements the naming scheme discussed in #311 for the NixIO:
1. When a Neo object is written to NIX, a unique `nix_name` is generated.
2. The NIX name is added to the Neo object as an annotation (`nix_name`).
3. The Neo object's original name is stored in the NIX object's metadata (`neo_name`).
4. When reading the file, the Neo object's original name is restored and the autogenerated NIX name is stored as an annotation.

During step 1., if the Neo object already has a `nix_name` annotation, that name is used instead of generating a new one.

Other changes:
- Updated tests to comply with new naming scheme.
- Maintains a path->object map for efficiently accessing the same object multiple times during a session based on the internal path representation.
- For every NIX object created, the accompanying metadata section is also created. Previously the metadata section was created on demand. Since almost all objects have metadata associated with them, the on-demand check is unnecessary.

Resolves #306: New naming scheme allows any name since the Neo object's name is not used as a NIX object name.