### PR TITLE
Cumulative set of fixes for blackrockio

### DIFF
--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -131,9 +131,9 @@ class BlackrockIO(BaseIO):
     is_writable = False
 
     # This IO can only manipulate continuous data, spikes, and events
-    supported_objects  = [Block, Segment, Event, AnalogSignal, SpikeTrain,
-                          Unit, ChannelIndex]
-    readable_objects    = [Block, Segment]
+    supported_objects = [
+        Block, Segment, Event, AnalogSignal, SpikeTrain, Unit, ChannelIndex]
+    readable_objects = [Block, Segment]
     writeable_objects = []
 
     # TODO: Not sure what header and streamable does

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1517,10 +1517,14 @@ class BlackrockIO(BaseIO):
 
         if channels:
             if len(set(all_channels) & set(channels)) < len(channels):
-                raise ValueError("Unknown channel id in channels.")
+                self._print_verbose(
+                    "Ignoring unknown channel ID(s) specified in in channels.")
+
+            # Make sure, all channels are valid and contain no duplicates
+            channels = list(set(all_channels).intersection(set(channels)))
         else:
             self._print_verbose("No channel is specified, therefore no "
-                                "recordingchannelgroup and unit is loaded.")
+                                "time series and unit data is loaded.")
 
         return channels
 
@@ -1598,8 +1602,8 @@ class BlackrockIO(BaseIO):
             self, user_n_starts, user_n_stops, nsx_to_load):
         """
         Merges after a validation the user specified n_starts and n_stops with
-        the intrinsicly given n_starts and n_stops (from e.g, recording pauses)
-        of the file set.
+        the intrinsically given n_starts and n_stops (from e.g, recording
+        pauses) of the file set.
 
         Final n_starts and n_stops are chosen, so that the time range of each
         resulting segment is set to the best meaningful maximum. This means

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1804,7 +1804,7 @@ class BlackrockIO(BaseIO):
                     self.__nev_params('digitization_factor')[channel_id] /
                     1000.)
             elif scaling == 'raw':
-                st.waveforms = waveforms[mask]*pq.dimensionless
+                st.waveforms = waveforms[mask] * pq.dimensionless
             else:
                 raise ValueError(
                     'Unkown option {1} for parameter scaling.'.format(scaling))
@@ -2043,7 +2043,7 @@ class BlackrockIO(BaseIO):
     def read_segment(
             self, n_start, n_stop, name=None, description=None, index=None,
             nsx_to_load='none', channels='none', units='none',
-            load_waveforms=False, load_events=False,  scaling='raw',
+            load_waveforms=False, load_events=False, scaling='raw',
             lazy=False, cascade=True):
         """
         Returns an annotated neo.core.segment.Segment.
@@ -2094,14 +2094,8 @@ class BlackrockIO(BaseIO):
             cascade (boolean):
                 If True, only the segment without children is returned.
 
-        Returns (neo.segment.Segment):
-            Annotations:
-                t_min (Quantity):
-                    Minimum time point possible for signals in segment
-                    (corresponds to n_start).
-                t_max (Quantity):
-                    Maximum time point possible for signals in segment
-                    (corresponds to n_stop).
+        Returns (neo.Segment):
+            The Segment contains no annotations.
         """
         self._print_verbose("######## INFO SEGMENT {0} ########".format(index))
         self._print_verbose("n_start: {0}".format(n_start.rescale('s')))
@@ -2112,9 +2106,8 @@ class BlackrockIO(BaseIO):
         units = self.__transform_units(units, channels)
 
         seg = Segment(file_origin=self.filename)
-        seg.annotate(
-            t_min=n_start,
-            t_max=n_stop)
+        seg.t_start = n_start
+        seg.t_stop = n_stop
 
         # set user defined annotations if they were provided
         if index is None:

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1869,6 +1869,7 @@ class BlackrockIO(BaseIO):
         if lazy:
             lazy_shape = (np.sum(mask), )
             sig_ch = np.array([], dtype='float32')
+            sig_unit = pq.dimensionless
             t_start = n_start.rescale('s')
         else:
             data_times = data_times[mask].astype(float)

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -218,8 +218,8 @@ class BlackrockIO(BaseIO):
         """
         BaseIO.__init__(self)
 
-        # Remember choice whether to print diagnostic messages or not
-        self._verbose = verbose
+        # Used to avoid unnecessary repetition of verbose messages
+        self.__verbose_messages = []
 
         # remove extension from base _filenames
         for ext in self.extensions:
@@ -346,7 +346,9 @@ class BlackrockIO(BaseIO):
         Print a verbose diagnostic message (string).
         """
         if self._verbose:
-            print('BlackrockIO: ' + text)
+            if text not in self.__verbose_messages:
+                self.__verbose_messages.append(text)
+                print(str(self.__class__.__name__) + ': ' + text)
 
     def __extract_nsx_file_spec(self, nsx_nb):
         """

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1200,15 +1200,16 @@ class BlackrockIO(BaseIO):
         as the time from the beginning of the waveform to the trigger time of
         the corresponding spike.
         """
-        # TODO: not sure if this is the actual setting for Blackrock
+        # TODO: Double check if this is the actual setting for Blackrock
         wf_t_unit = self.__nev_params('waveform_time_unit')
         all_ch = self.__nev_params('channel_ids')
-        wf_size = self.__nev_params('waveform_size')
 
+        # TODO: Double check if this is the correct assumption (10 samples)
         # default value: threshold crossing after 10 samples of waveform
         wf_left_sweep = dict([(ch, 10 * wf_t_unit) for ch in all_ch])
 
         # non-default: threshold crossing at center of waveform
+        # wf_size = self.__nev_params('waveform_size')
         # wf_left_sweep = dict(
         #     [(ch, (wf_size[ch] / 2) * wf_t_unit) for ch in all_ch])
 

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -136,11 +136,9 @@ class BlackrockIO(BaseIO):
     readable_objects = [Block, Segment]
     writeable_objects = []
 
-    # TODO: Not sure what header and streamable does
     has_header = False
     is_streameable = False
 
-    # TODO: Not sure if this is needed
     read_params = {
         neo.Block: [
             ('nsx_to_load', {

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -645,7 +645,6 @@ class BlackrockIO(BaseIO):
         nev_ext_header = {}
         for packet_id in ext_header_variants.keys():
             mask = (raw_ext_header['packet_id'] == packet_id)
-            assert isinstance(mask, np.ndarray)
             dt2 = self.__nev_ext_header_types()[packet_id][
                 ext_header_variants[packet_id]]
 
@@ -1610,7 +1609,6 @@ class BlackrockIO(BaseIO):
         that the duration of the signals stored in the segments might be
         smaller than the actually set duration of the segment.
         """
-        self._print_verbose("######## INFO TIME SETTINGS ########")
 
         # define the higest time resolution
         # (for accurate manipulations of the time settings)
@@ -2097,9 +2095,7 @@ class BlackrockIO(BaseIO):
         Returns (neo.Segment):
             The Segment contains no annotations.
         """
-        self._print_verbose("######## INFO SEGMENT {0} ########".format(index))
-        self._print_verbose("n_start: {0}".format(n_start.rescale('s')))
-        self._print_verbose("n_stop: {0}".format(n_stop.rescale('s')))
+
         # Make sure that input args are transformed into correct instances
         nsx_to_load = self.__transform_nsx_to_load(nsx_to_load)
         channels = self.__transform_channels(channels, nsx_to_load)

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -2102,8 +2102,6 @@ class BlackrockIO(BaseIO):
         units = self.__transform_units(units, channels)
 
         seg = Segment(file_origin=self.filename)
-        seg.t_start = n_start
-        seg.t_stop = n_stop
 
         # set user defined annotations if they were provided
         if index is None:

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -48,7 +48,6 @@ from __future__ import division
 import datetime
 import os
 import re
-import types
 
 import numpy as np
 import quantities as pq

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1811,8 +1811,8 @@ class BlackrockIO(BaseIO):
 
         # add additional annotations
         st.annotate(
-            ch_idx=int(channel_id),
-            unit_id=int(unit_id))
+            unit_id=int(unit_id),
+            channel_id=int(channel_id))
 
         return st
 
@@ -1915,7 +1915,7 @@ class BlackrockIO(BaseIO):
             anasig.lazy_shape = lazy_shape
         anasig.annotate(
             nsx=nsx_nb,
-            ch_idx=int(channel_id))
+            channel_id=int(channel_id))
         return anasig
 
     def __read_unit(self, unit_id, channel_id):
@@ -1936,8 +1936,8 @@ class BlackrockIO(BaseIO):
 
         # add additional annotations
         un.annotate(
-            ch_idx=int(channel_id),
-            unit_id=int(unit_id))
+            unit_id=int(unit_id),
+            channel_id=int(channel_id))
 
         return un
 

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -312,7 +312,7 @@ class BlackrockIO(BaseIO):
             '2.1': self.__get_nonneural_evtypes_variant_a,
             '2.2': self.__get_nonneural_evtypes_variant_a,
             '2.3': self.__get_nonneural_evtypes_variant_b}
-        
+
         # Load file spec and headers of available nev file
         if self._avail_files['nev']:
             # read nev file specification
@@ -646,12 +646,10 @@ class BlackrockIO(BaseIO):
         for packet_id in ext_header_variants.keys():
             mask = (raw_ext_header['packet_id'] == packet_id)
             assert isinstance(mask, np.ndarray)
-
             dt2 = self.__nev_ext_header_types()[packet_id][
                 ext_header_variants[packet_id]]
 
             nev_ext_header[packet_id] = raw_ext_header.view(dt2)[mask]
-
         return nev_basic_header, nev_ext_header
 
     def __read_nev_header_variant_a(self):

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -541,7 +541,7 @@ class BlackrockIO(BaseIO):
                 'offset_to_data_block': offset + dh.dtype.itemsize}
 
             # data size = number of data points * (2bytes * number of channels)
-            #int for avoid overflow problem
+            # use of `int` avoids overflow problem
             data_size = int(dh['nb_data_points']) * \
                 int(self.__nsx_basic_header[nsx_nb]['channel_count']) * 2
             # define new offset (to possible next data block)

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1177,7 +1177,7 @@ class BlackrockIO(BaseIO):
         nb_bytes_wf = self.__nev_basic_header['bytes_in_data_packets'] - 8
 
         wf_sizes = dict([
-            (ch, nb_bytes_wf / np.dtype(dt).itemsize) for ch, dt in
+            (ch, int(nb_bytes_wf / np.dtype(dt).itemsize)) for ch, dt in
             wf_dtypes.items()])
 
         return wf_sizes

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -92,19 +92,19 @@ class BlackrockIO(BaseIO):
             ignored when parsing this parameter.
         nsx_override (string):
             File name of the .nsX files (without extension). If None,
-            _filenames is used.
+            filename is used.
             Default: None.
         nev_override (string):
             File name of the .nev file (without extension). If None,
-            _filenames is used.
+            filename is used.
             Default: None.
         sif_override (string):
             File name of the .sif file (without extension). If None,
-            _filenames is used.
+            filename is used.
             Default: None.
         ccf_override (string):
             File name of the .ccf file (without extension). If None,
-            _filenames is used.
+            filename is used.
             Default: None.
         verbose (boolean):
             If True, the class will output additional diagnostic

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1495,9 +1495,8 @@ class BlackrockIO(BaseIO):
             for nsx_nb in nsx_to_load:
                 all_channels.extend(
                     self.__nsx_ext_header[nsx_nb]['electrode_id'].astype(int))
-        else:
-            elec_id = self.__nev_ext_header[b'NEUEVWAV']['electrode_id']
-            all_channels.extend(elec_id.astype(int))
+        elec_id = self.__nev_ext_header[b'NEUEVWAV']['electrode_id']
+        all_channels.extend(elec_id.astype(int))
         all_channels = np.unique(all_channels).tolist()
 
         if hasattr(channels, "__len__") and len(channels) == 0:

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1865,6 +1865,7 @@ class BlackrockIO(BaseIO):
             "AnalogSignal from channel: {0}, label: {1}, nsx: {2}".format(
                 channel_id, labels[idx_ch], nsx_nb)
 
+        # TODO: Find a more time/memory efficient way to handle lazy loading
         data_times = np.arange(
             t_start.item(), t_stop.item(),
             self.__nsx_basic_header[nsx_nb]['period']) * t_start.units

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -2244,7 +2244,7 @@ class BlackrockIO(BaseIO):
     def read_block(
             self, index=None, name=None, description=None, nsx_to_load='none',
             n_starts=None, n_stops=None, channels='none', units='none',
-            load_waveforms=False, load_events=False, scaling='raw', 
+            load_waveforms=False, load_events=False, scaling='raw',
             lazy=False, cascade=True):
         """
         Args:

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1349,21 +1349,24 @@ class BlackrockIO(BaseIO):
                 return data_parameters[param_name]
             elif n_start < t_starts[d_bl - 1] < n_stop <= t_stops[d_bl - 1]:
                 self._print_verbose(
-                    "User n_start (%s) is smaller than the corresponding "
-                    "t_start of the available ns%i datablock" % (
-                        str(n_start), nsx_nb))
+                    "User n_start ({0}) is smaller than the corresponding "
+                    "t_start of the available ns{1} datablock "
+                    "({2}).".format(n_start, nsx_nb, t_starts[d_bl - 1]))
                 return data_parameters[param_name]
             elif t_starts[d_bl - 1] <= n_start < t_stops[d_bl - 1] < n_stop:
                 self._print_verbose(
-                    "User n_stop (%s) is larger than the corresponding t_stop "
-                    "of the available ns%i datablock" % (str(n_stop), nsx_nb))
+                    "User n_stop ({0}) is larger than the corresponding "
+                    "t_stop of the available ns{1} datablock "
+                    "({2}).".format(n_stop, nsx_nb, t_stops[d_bl - 1]))
                 return data_parameters[param_name]
             elif n_start < t_starts[d_bl - 1] < t_stops[d_bl - 1] < n_stop:
                 self._print_verbose(
-                    "User n_start (%s) and is smaller than the corresponding "
-                    "t_start and user n_stop (%s) is larger than the "
-                    "corresponding t_stop of the available ns%i datablock" % (
-                        str(n_start), str(n_stop), nsx_nb))
+                    "User n_start ({0}) is smaller than the corresponding "
+                    "t_start and user n_stop ({1}) is larger than the "
+                    "corresponding t_stop of the available ns{2} datablock "
+                    "({3}).".format(
+                        n_start, n_stop, nsx_nb,
+                        (t_starts[d_bl - 1], t_stops[d_bl - 1])))
                 return data_parameters[param_name]
             else:
                 continue

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1009,6 +1009,9 @@ class BlackrockIO(BaseIO):
             'nb_units': dict(zip(
                 self.__nev_ext_header[b'NEUEVWAV']['electrode_id'],
                 self.__nev_ext_header[b'NEUEVWAV']['nb_sorted_units'])),
+            'digitization_factor': dict(zip(
+                self.__nev_ext_header[b'NEUEVWAV']['electrode_id'],
+                self.__nev_ext_header[b'NEUEVWAV']['digitization_factor'])),
             'data_size': self.__nev_basic_header['bytes_in_data_packets'],
             'waveform_size': self.__waveform_size[self.__nev_spec](),
             'waveform_dtypes': self.__get_waveforms_dtype(),

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -2315,11 +2315,8 @@ class BlackrockIO(BaseIO):
                     specified by user with the intrinsic ones of the file set.
         """
         # Make sure that input args are transformed into correct instances
-        # Arg: nsx_to_load
         nsx_to_load = self.__transform_nsx_to_load(nsx_to_load)
-        # Arg: channels
         channels = self.__transform_channels(channels, nsx_to_load)
-        # Arg: units
         units = self.__transform_units(units, channels)
 
         # Create block
@@ -2377,15 +2374,15 @@ class BlackrockIO(BaseIO):
 
         # read channelindexes
         if channels:
-            for i, ch_id in enumerate(channels):
-                if units and ch_id in units.keys() and units[ch_id] is not None:
+            for ch_id in channels:
+                if units and ch_id in units.keys():
                     ch_units = units[ch_id]
                 else:
                     ch_units = None
 
                 chidx = self.__read_channelindex(
                     channel_id=ch_id,
-                    index=i,
+                    index=0,
                     channel_units=ch_units,
                     cascade=cascade)
 

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1499,7 +1499,6 @@ class BlackrockIO(BaseIO):
                 all_channels.extend(
                     self.__nsx_ext_header[nsx_nb]['electrode_id'].astype(int))
         else:
-            hdr = self.__nev_ext_header
             elec_id = self.__nev_ext_header[b'NEUEVWAV']['electrode_id']
             all_channels.extend(elec_id.astype(int))
         all_channels = np.unique(all_channels).tolist()

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1917,19 +1917,19 @@ class BlackrockIO(BaseIO):
             anasig.lazy_shape = lazy_shape
         anasig.annotate(
             nsx=nsx_nb,
-            ch_idx=channel_id)
+            ch_idx=int(channel_id))
         return anasig
 
-    def __read_unit(self, unit_id, channel_idx):
+    def __read_unit(self, unit_id, channel_id):
         """
         Creates unit with unit id for given channel id.
         """
         # define a name for spiketrain
         # (unique identifier: 1000 * elid + unit_nb)
-        name = "Unit {0}".format(1000 * channel_idx + unit_id)
+        name = "Unit {0}".format(1000 * channel_id + unit_id)
         # define description for spiketrain
         desc = 'Unit from channel: {0}, id: {1}'.format(
-            channel_idx, self.__get_unit_classification(unit_id))
+            channel_id, self.__get_unit_classification(unit_id))
 
         un = Unit(
             name=name,
@@ -1937,8 +1937,9 @@ class BlackrockIO(BaseIO):
             file_origin='.'.join([self._filenames['nev'], 'nev']))
 
         # add additional annotations
-        un.annotate(ch_idx=int(channel_idx))
-        un.annotate(unit_id=int(unit_id))
+        un.annotate(
+            ch_idx=int(channel_id),
+            unit_id=int(unit_id))
 
         return un
 
@@ -2010,7 +2011,7 @@ class BlackrockIO(BaseIO):
                     if un_id in np.unique(data_ch['unit_class_nb']):
 
                         un = self.__read_unit(
-                            unit_id=un_id, channel_idx=channel_idx)
+                            unit_id=un_id, channel_id=channel_idx)
 
                         rcg.units.append(un)
 

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -345,7 +345,7 @@ class BlackrockIO(BaseIO):
         """
         Print a verbose diagnostic message (string).
         """
-        if __verbose_messages:
+        if self.__verbose_messages:
             if text not in self.__verbose_messages:
                 self.__verbose_messages.append(text)
                 print(str(self.__class__.__name__) + ': ' + text)

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -2092,8 +2092,11 @@ class BlackrockIO(BaseIO):
             cascade (boolean):
                 If True, only the segment without children is returned.
 
-        Returns (neo.Segment):
-            The Segment contains no annotations.
+        Returns:
+            Segment (neo.Segment):
+                Returns the specified segment. See documentation of
+                `read_block()` for a full list of annotations of all child
+                objects.
         """
 
         # Make sure that input args are transformed into correct instances
@@ -2312,19 +2315,11 @@ class BlackrockIO(BaseIO):
                     None.
 
                 ChannelIndex annotations:
-                    TODO: This is an array of bool for HFC, for some reason.
-                    electrode_reject_XXX (bool):
-                        For different filter ranges XXX (as defined in the odML
-                        file), if this variable is True it indicates whether
-                        the spikes were recorded on an electrode that should be
-                        rejected based on preprocessing analysis for removing
-                        electrodes due to noise/artefacts in the respective
-                        frequency range.
-                    waveform_size (quantitiy):
+                    waveform_size (Quantitiy):
                         Length of time used to save spike waveforms (in units
                         of 1/30000 s).
-                    nev_hi_freq_corner (quantitiy), 
-                    nev_lo_freq_corner (quantitiy),
+                    nev_hi_freq_corner (Quantitiy),
+                    nev_lo_freq_corner (Quantitiy),
                     nev_hi_freq_order (int), nev_lo_freq_order (int),
                     nev_hi_freq_type (str), nev_lo_freq_type (str),
                     nev_hi_threshold, nev_lo_threshold,
@@ -2343,28 +2338,10 @@ class BlackrockIO(BaseIO):
                 Unit annotations:
                     unit_id (int):
                         ID of the unit.
-                    TODO: Also has channel_ids --> inherit from ChannelIndex?
                     channel_id (int):
                         Channel ID (Blackrock ID) from which the unit was
                         loaded (equiv. to the single list entry in the
                         attribute channel_ids of ChannelIndex parent).
-                    noise, mua, sua (bool):
-                        True, if the unit is classified as a noise unit, i.e.,
-                        not considered neural activity (noise), a multi-unit
-                        (mua), or a single unit (sua).
-                        
-                    TODO: electrode_reject_XXX is present in Unit, but not listed here (with bug for HFC).
-                        
-                    TODO: Not present!
-                    SNR (float):
-                        Signal to noise ratio of SUA/MUA waveforms. A higher
-                        value indicates that the unit could be better
-                        distinguished in the spike detection and spike sorting
-                        procedure.
-                    TODO: Not present!
-                    spike_duration (float):
-                        Approximate duration of the spikes of SUAs/MUAsSUA in
-                        microseconds.
 
                 AnalogSignal annotations:
                     nsx (int):
@@ -2373,81 +2350,19 @@ class BlackrockIO(BaseIO):
                     channel_id (int):
                         Channel ID (Blackrock ID) from which the signal was
                         loaded.
-                        
-                    TODO: These are not present
-                    electrode_reject_XXX (bool):
-                        For different filter ranges XXX (as defined in the odML
-                        file), if this variable is True it indicates whether
-                        the spikes were recorded on an electrode that should be
-                        rejected based on preprocessing analysis for removing
-                        electrodes due to noise/artefacts in the respective
-                        frequency range.
 
                 Spiketrain annotations:
-                    TODO: See Unit above
+                    unit_id (int):
+                        ID of the unit from which the spikes were recorded.
                     channel_id (int):
                         Channel ID (Blackrock ID) from which the spikes were
                         loaded.
-                    unit_id (int):
-                        ID of the unit from which the spikes were recorded.
-                    electrode_reject_XXX (bool):
-                        For different filter ranges XXX (as defined in the odML
-                        file), if this variable is True it indicates whether
-                        the spikes were recorded on an electrode that should be
-                        rejected based on preprocessing analysis for removing
-                        electrodes due to noise/artefacts in the respective
-                        frequency range.
-                    noise, mua, sua (bool):
-                        True, if the unit is classified as a noise unit, i.e.,
-                        not considered neural activity (noise), a multi-unit
-                        (mua), or a single unit (sua).
-                    # TODO: Missing
-                    SNR (float):
-                        Signal to noise ratio of SUA/MUA waveforms. A higher
-                        value indicates that the unit could be better
-                        distinguished in the spike detection and spike sorting
-                        procedure.
-                    spike_duration (float):
-                        Approximate duration of the spikes of SUAs/MUAsSUA in
-                        microseconds.
 
                 Event annotations:
-                    The resulting Block contains three Event objects with the
-                    following names:
-                    "DigitalTrialEvents' contains all digitally recorded events
-                        returned by BlackrockIO, annotated with semantic labels in
-                        accordance with the reach-to-grasp experiment (e.g.,
-                        'TS-ON').
-                    'AnalogTrialEvents' contains events extracted from the
-                        analog behavioral signals during preprocessing and stored
-                        in the odML (e.g., 'OT').
-                    'TrialEvents' contains all events of DigitalTrialEvents and
-                        AnalogTrialEvents merged into a single Neo object.
-
-                    Each annotation is a list containing one entry per time
-                    point stored in the event.
-
-                    # TODO: Double check this is correct
-                    trial_event_labels (list of str):
-                        Name identifying the name of the event, e.g., 'TS-ON'.
-                    trial_id (list of int):
-                        Trial ID the event belongs to.
-                    trial_timestamp_id (list of int):
-                        Timestamp-based trial ID (equivalent to the time of TS-
-                        ON of a trial) the event belongs to.
-                    TODO: Relate to performance codes above
-                    belongs_to_trialtype (str):
-                        String identifying the trial type (e.g., SGHF) the
-                        trial belongs to.
-                    performance_in_trial (list of int):
-                        Performance code of the trial that the event belongs
-                        to.
-                    trial_reject_XXX:
-                        For different filter ranges XXX (defined in the odML
-                        file), if True this variable indicates whether the
-                        trial was rejected based on preprocessing analysis.
-
-            Annotations:
+                    The resulting Block contains one Event object with the name
+                    `digital_input_port`. It contains all digitally recorded
+                    events, with the event code coded in the labels of the
+                    Event. The Event object contains no further annotation.
         """
         # Make sure that input args are transformed into correct instances
         nsx_to_load = self.__transform_nsx_to_load(nsx_to_load)

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1720,7 +1720,8 @@ class BlackrockIO(BaseIO):
                 n_starts.extend(merged_n_starts)
                 n_stops.extend(merged_n_stops)
 
-        if len(n_starts) > len(user_n_starts) and len(n_stops) > len(user_n_stops):
+        if len(n_starts) > len(user_n_starts) and \
+                len(n_stops) > len(user_n_stops):
             self._print_verbose(
                 "Additional recording pauses were detected. There will be "
                 "more segments than the user expects.")

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -2446,7 +2446,7 @@ class BlackrockIO(BaseIO):
                                 un.spiketrains.append(st)
 
                     anasigs = seg.filter(
-                        targdict={'ch_id': ch_id},
+                        targdict={'channel_id': ch_id},
                         objects='AnalogSignal')
                     for anasig in anasigs:
                         chidx.analogsignals.append(anasig)

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1547,7 +1547,7 @@ class BlackrockIO(BaseIO):
                     if u.lower() == 'none':
                         units[ch] = None
                     elif u.lower() == 'all':
-                        units[ch] = range(17)
+                        units[ch] = list(range(17))
                         units[ch].append(255)
                     else:
                         raise ValueError("Invalid unit specification.")

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -1959,7 +1959,7 @@ class BlackrockIO(BaseIO):
         if self._avail_files['nev']:
             channel_labels = self.__nev_params('channel_labels')
             if channel_labels is not None:
-                chidx.channel_names = np.array([channel_labels[channel_idx]])
+                chidx.channel_names = np.array([channel_labels[channel_id]])
             chidx.channel_ids = np.array([channel_id])
 
             # additional annotations from nev
@@ -2009,7 +2009,6 @@ class BlackrockIO(BaseIO):
         chidx.description = \
             "Container for units and groups analogsignals of one recording " \
             "channel across segments."
->>>>>>> Added additional metadata to ChannelIndex objects (+beautifications)
 
         if not cascade:
             return chidx


### PR DESCRIPTION
This PR includes a package of several fixes to the revised blackrockio that is available since Neo 0.5, which were contributed by various people. In particular, this PR fixes:

* New parameter `scaling` to indicate whether analog signals are scaled to mV ('voltage'), or left as raw integer values ('raw'). Note that the default was set to "raw", since for file spec 2.1 and below, only in the presence of a `nev` file the conversion to voltage can be done. However, note that this may lead to different behavior since the initial inclusion of the new blackrockio. Changing the default to `voltage` is of course discussable.
* Fixed issue where one unit test was not actually testing correctly
* Fix issue where available channels were pooled only from nsX files, not the nev.
* Fixed issue where AnalogSignals were not connected to the ChannelIndex
* Updates to docstrings
* Corrected use of "index" in ChannelIndex object (now always set to 0, since the IO creates one ChannelIndex object for each recording channel)
* Additional annotations for ChannelIndex objects
* Removal of print statements
* PEP8 issies, code cleaning
* Minor fixes