### PR TITLE
Fix waveform and time handling when duplicating spiketrains

### DIFF
--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -497,9 +497,8 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         '''
         Copy the metadata from another :class:`SpikeTrain`.
         '''
-        for attr in ("t_start", "t_stop", "waveforms", "left_sweep",
-                     "sampling_rate", "name", "file_origin", "description",
-                     "annotations"):
+        for attr in ("left_sweep", "sampling_rate", "name", "file_origin",
+                     "description", "annotations"):
             setattr(self, attr, getattr(other, attr, None))
 
     def duplicate_with_new_data(self, signal, t_start=None, t_stop=None,
@@ -516,7 +515,7 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         if waveforms is None:
             waveforms = self.waveforms
 
-        new_st = self.__class__(signal,t_start=t_start, t_stop=t_stop,
+        new_st = self.__class__(signal, t_start=t_start, t_stop=t_stop,
                                 waveforms=waveforms, units=self.units)
         new_st._copy_data_complement(self)
 
@@ -525,7 +524,7 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         new_st.t_stop = t_stop
 
         # consistency check
-        _check_time_in_range(new_st, new_st.t_start, new_st.t_stop, view=True)
+        _check_time_in_range(new_st, new_st.t_start, new_st.t_stop, view=False)
         _check_waveform_dimensions(new_st)
         return new_st
 


### PR DESCRIPTION
This PR solves two bugs in the current implementation of `SpikeTrain.duplicate_with_new_data `
1. Waveforms provided are not considered for the duplicated spiketrain as they are automatically overwritten by the  old version of the waveforms. Same holds true for t_start and t_stop.
2. The time consistency check is not considering the quantity unit of the provided t_start and t_stop, which leads to wrong results in the time consistency check.
Both bugs can be observed in the following code snippet
```
st = neo.SpikeTrain(np.arange(5,15)*pq.s, t_start=0*pq.s,t_stop=20*pq.s, sampling_rate=1*pq.Hz)
wfs = np.arange(100).reshape((10,1,10))*pq.V
st.waveforms = wfs

# Bug 1:
# new spiketrain only contains first half of the original spikes
new_st = st.duplicate_with_new_data(st.times[:5], st.t_start, st.t_stop, waveforms=st.waveforms[:5])
# -> ValueError: Spiketrain length (5) does not match to number of waveforms present (10)

# Bug2:
# inconsistent t_start for duplicated spiketrain
new_st = st.duplicate_with_new_data(st.times, 5000*pq.ms, st.t_stop)
# -> ValueError: The first spike ([  5.   6.   7.   8.   9.  10.  11.  12.  13.  14.]) is before t_start (5000.0)
```

