### PR TITLE
Minor fixes for NeuralynxIO

### DIFF
--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -46,6 +46,8 @@ Classes:
 
 .. autoclass:: neo.io.NestIO
 
+.. autoclass:: neo.io.NeuralynxIO
+
 .. autoclass:: neo.io.NeuroExplorerIO
 
 .. autoclass:: neo.io.NeuroScopeIO

--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -427,6 +427,7 @@ class NeuralynxIO(BaseIO):
 
             analogsignal = merge_analogsignals(empty_seg.analogsignals)
             seg.analogsignals.append(analogsignal)
+            analogsignal.segment = seg
 
         # Reading NEV Files (Events)#
         # reading all files available


### PR DESCRIPTION
This PR fixes

1. An incorrect link within the generated neo structure
2. A missing autoclass entry for the NeuralynxIO