### PR TITLE
[NixIO] Proper handling of multiple references to the same object

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -262,8 +262,11 @@ class NixIO(BaseIO):
                    for c in nix_source.sources
                    if c.type == "neo.channelindex")
         chan_names = list(c["neo_name"] for c in chx if "neo_name" in c)
+        chan_ids = list(c["channel_id"] for c in chx if "channel_id" in c)
         if chan_names:
             neo_attrs["channel_names"] = chan_names
+        if chan_ids:
+            neo_attrs["channel_ids"] = chan_ids
         neo_attrs["index"] = np.array([c["index"] for c in chx])
         if "coordinates" in chx[0]:
             coord_units = chx[0]["coordinates.units"]
@@ -685,10 +688,13 @@ class NixIO(BaseIO):
                 )
             nixchan.definition = nixsource.definition
             chanmd = nixchan.metadata
+            chanmd["index"] = nix.Value(int(channel))
             if len(chx.channel_names):
                 neochanname = stringify(chx.channel_names[idx])
                 chanmd["neo_name"] = nix.Value(neochanname)
-            chanmd["index"] = nix.Value(int(channel))
+            if len(chx.channel_ids):
+                chanid = chx.channel_ids[idx]
+                chanmd["channel_id"] = nix.Value(chanid)
             if chx.coordinates is not None:
                 coords = chx.coordinates[idx]
                 coordunits = stringify(coords[0].dimensionality)

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -789,20 +789,20 @@ class NixIO(BaseIO):
                     mtag.references.extend([sig for sig in group_signals
                                             if sig not in mtag.references])
         for rcg in block.channel_indexes:
-            rcgsource = self._get_mapped_object(rcg)
+            chidxsrc = self._get_mapped_object(rcg)
             das = self._get_mapped_objects(rcg.analogsignals +
                                            rcg.irregularlysampledsignals)
             # flatten nested lists
             das = [da for dalist in das for da in dalist]
             for da in das:
-                if rcgsource not in da.sources:
-                    da.sources.append(rcgsource)
+                if chidxsrc not in da.sources:
+                    da.sources.append(chidxsrc)
             for unit in rcg.units:
                 unitsource = self._get_mapped_object(unit)
                 for st in unit.spiketrains:
                     stmtag = self._get_mapped_object(st)
-                    if rcgsource not in stmtag.sources:
-                        stmtag.sources.append(rcgsource)
+                    if chidxsrc not in stmtag.sources:
+                        stmtag.sources.append(chidxsrc)
                     if unitsource not in stmtag.sources:
                         stmtag.sources.append(unitsource)
 

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -822,6 +822,20 @@ class NixIOWriteTest(NixIOTest):
         self.writer.write_all_blocks(blocks)
         self.compare_blocks(blocks, self.reader.blocks)
 
+    def test_multiref_write(self):
+        blk = Block("blk1")
+        signal = AnalogSignal(name="sig1", signal=[0, 1, 2], units="mV",
+                              sampling_period=pq.Quantity(1, "ms"))
+
+        for idx in range(3):
+            segname = "seg" + str(idx)
+            seg = Segment(segname)
+            blk.segments.append(seg)
+            seg.analogsignals.append(signal)
+
+        self.writer.write_block(blk)
+        self.compare_blocks([blk], self.reader.blocks)
+
     def test_to_value(self):
         section = self.io.nix_file.create_section("Metadata value test",
                                                   "Test")

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -611,6 +611,7 @@ class NixIOTest(unittest.TestCase):
         return blk
 
 
+@unittest.skipUnless(HAVE_NIX, "Requires NIX")
 class NixIOWriteTest(NixIOTest):
 
     def setUp(self):
@@ -867,6 +868,7 @@ class NixIOWriteTest(NixIOTest):
         self.assertEqual(val, section["val"])
 
 
+@unittest.skipUnless(HAVE_NIX, "Requires NIX")
 class NixIOReadTest(NixIOTest):
 
     filename = "testfile_readtest.h5"
@@ -974,6 +976,7 @@ class NixIOReadTest(NixIOTest):
         self.assertEqual(np.shape(segment.analogsignals[0]), (100, 3))
 
 
+@unittest.skipUnless(HAVE_NIX, "Requires NIX")
 class NixIOHashTest(NixIOTest):
 
     def setUp(self):
@@ -1072,6 +1075,7 @@ class NixIOHashTest(NixIOTest):
         self._hash_test(SpikeTrain, argfuncs)
 
 
+@unittest.skipUnless(HAVE_NIX, "Requires NIX")
 class NixIOPartialWriteTest(NixIOTest):
 
     filename = "testfile_partialwrite.h5"
@@ -1163,6 +1167,7 @@ class NixIOPartialWriteTest(NixIOTest):
         self.compare_blocks(self.neo_blocks, self.io.nix_file.blocks)
 
 
+@unittest.skipUnless(HAVE_NIX, "Requires NIX")
 class NixIOContextTests(NixIOTest):
 
     filename = "context_test.h5"

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -640,7 +640,7 @@ class NixIOWriteTest(NixIOTest):
 
     def write_and_compare(self, blocks):
         self.writer.write_all_blocks(blocks)
-        self.compare_blocks(self.writer.read_all_blocks(), self.reader.blocks)
+        self.compare_blocks(blocks, self.reader.blocks)
 
     def test_block_write(self):
         block = Block(name=self.rword(),
@@ -693,7 +693,7 @@ class NixIOWriteTest(NixIOTest):
             units=pq.A
         )
         seg.irregularlysampledsignals.append(irsig)
-        self.write_and_compare([anotherblock])
+        self.write_and_compare([block, anotherblock])
 
         block.segments[0].analogsignals.append(
             AnalogSignal(signal=[10.0, 1.0, 3.0], units=pq.S,

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -65,6 +65,13 @@ class NixIOTest(unittest.TestCase):
         nix_channels = list(src for src in nixsrc.sources
                             if src.type == "neo.channelindex")
         self.assertEqual(len(neochx.index), len(nix_channels))
+
+        if neochx.channel_ids:
+            nix_chanids = list(src.metadata["channel_id"] for src
+                               in nixsrc.sources
+                               if src.type == "neo.channelindex")
+            self.assertEqual(len(neochx.channel_ids), len(nix_chanids))
+
         for nixchan in nix_channels:
             nixchanidx = nixchan.metadata["index"]
             try:
@@ -78,6 +85,10 @@ class NixIOTest(unittest.TestCase):
                     neochanname = neochanname.decode()
                 nixchanname = nixchan.metadata["neo_name"]
                 self.assertEqual(neochanname, nixchanname)
+            if neochx.channel_ids:
+                neochanid = neochx.channel_ids[neochanpos]
+                nixchanid = nixchan.metadata["channel_id"]
+                self.assertEqual(neochanid, nixchanid)
         nix_units = list(src for src in nixsrc.sources
                          if src.type == "neo.unit")
         self.assertEqual(len(neochx.units), len(nix_units))

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -833,6 +833,17 @@ class NixIOWriteTest(NixIOTest):
             blk.segments.append(seg)
             seg.analogsignals.append(signal)
 
+        chidx = ChannelIndex([10, 20, 29])
+        seg = blk.segments[0]
+        st = SpikeTrain(name="choochoo", times=[10, 11, 80], t_stop=1000,
+                        units="s")
+        seg.spiketrains.append(st)
+        blk.channel_indexes.append(chidx)
+        for idx in range(6):
+            unit = Unit("unit" + str(idx))
+            chidx.units.append(unit)
+            unit.spiketrains.append(st)
+
         self.writer.write_block(blk)
         self.compare_blocks([blk], self.reader.blocks)
 

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -915,6 +915,7 @@ class NixIOReadTest(NixIOTest):
     def tearDownClass(cls):
         if HAVE_NIX:
             cls.nixfile.close()
+            os.remove(cls.filename)
 
     def tearDown(self):
         self.io.close()
@@ -1123,6 +1124,7 @@ class NixIOPartialWriteTest(NixIOTest):
     def tearDownClass(cls):
         if HAVE_NIX:
             cls.nixfile.close()
+            os.remove(cls.filename)
 
     def tearDown(self):
         self.restore_methods()
@@ -1214,6 +1216,7 @@ class NixIOContextTests(NixIOTest):
                                 backend="h5py")
         self.compare_blocks([neoblock], nixfile.blocks)
         nixfile.close()
+        os.remove(self.filename)
 
     def test_context_read(self):
         nixfile = nix.File.open(self.filename, nix.FileMode.Overwrite,
@@ -1229,6 +1232,7 @@ class NixIOContextTests(NixIOTest):
 
         self.assertEqual(blocks[0].annotations["nix_name"], name_one)
         self.assertEqual(blocks[1].annotations["nix_name"], name_two)
+        os.remove(self.filename)
 
 
 @unittest.skipUnless(HAVE_NIX, "Requires NIX")

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -903,7 +903,8 @@ class NixIOReadTest(NixIOTest):
 
     @classmethod
     def setUpClass(cls):
-        cls.nixfile = cls.create_full_nix_file(cls.filename)
+        if HAVE_NIX:
+            cls.nixfile = cls.create_full_nix_file(cls.filename)
 
     def setUp(self):
         self.io = NixIO(self.filename, "ro")
@@ -912,8 +913,9 @@ class NixIOReadTest(NixIOTest):
 
     @classmethod
     def tearDownClass(cls):
-        cls.nixfile.close()
-        os.remove(cls.filename)
+        if HAVE_NIX:
+            cls.nixfile.close()
+            os.remove(cls.filename)
 
     def tearDown(self):
         self.io.close()
@@ -1109,7 +1111,8 @@ class NixIOPartialWriteTest(NixIOTest):
 
     @classmethod
     def setUpClass(cls):
-        cls.nixfile = cls.create_full_nix_file(cls.filename)
+        if HAVE_NIX:
+            cls.nixfile = cls.create_full_nix_file(cls.filename)
 
     def setUp(self):
         self.io = NixIO(self.filename, "rw")
@@ -1119,8 +1122,9 @@ class NixIOPartialWriteTest(NixIOTest):
 
     @classmethod
     def tearDownClass(cls):
-        cls.nixfile.close()
-        os.remove(cls.filename)
+        if HAVE_NIX:
+            cls.nixfile.close()
+            os.remove(cls.filename)
 
     def tearDown(self):
         self.restore_methods()

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -903,8 +903,7 @@ class NixIOReadTest(NixIOTest):
 
     @classmethod
     def setUpClass(cls):
-        if HAVE_NIX:
-            cls.nixfile = cls.create_full_nix_file(cls.filename)
+        cls.nixfile = cls.create_full_nix_file(cls.filename)
 
     def setUp(self):
         self.io = NixIO(self.filename, "ro")
@@ -913,9 +912,8 @@ class NixIOReadTest(NixIOTest):
 
     @classmethod
     def tearDownClass(cls):
-        if HAVE_NIX:
-            cls.nixfile.close()
-            os.remove(cls.filename)
+        cls.nixfile.close()
+        os.remove(cls.filename)
 
     def tearDown(self):
         self.io.close()
@@ -1111,8 +1109,7 @@ class NixIOPartialWriteTest(NixIOTest):
 
     @classmethod
     def setUpClass(cls):
-        if HAVE_NIX:
-            cls.nixfile = cls.create_full_nix_file(cls.filename)
+        cls.nixfile = cls.create_full_nix_file(cls.filename)
 
     def setUp(self):
         self.io = NixIO(self.filename, "rw")
@@ -1122,9 +1119,8 @@ class NixIOPartialWriteTest(NixIOTest):
 
     @classmethod
     def tearDownClass(cls):
-        if HAVE_NIX:
-            cls.nixfile.close()
-            os.remove(cls.filename)
+        cls.nixfile.close()
+        os.remove(cls.filename)
 
     def tearDown(self):
         self.restore_methods()


### PR DESCRIPTION
Currently, the NixIO does not properly handle cases where the same Neo object is attached to multiple locations. For instance, if an AnalogSignal is attached to multiple Segments, the NixIO will fail on write while attempting to create the same object a second time.

With this PR the IO now detects such cases and mirrors the references between Neo objects as closely as possible in the NIX file (e.g., the DataArray created from the AnalogSignal in the above example will be attached to multiple Groups).

An IO test has been added for this behaviour (`test_multiref_write`).

The issue was first described in https://github.com/NeuralEnsemble/python-neo/issues/311#issuecomment-307563228. Since the new naming scheme was already merged and the problem mentioned in the issue is fixed, this PR closes #311.