### PR TITLE
[baseio.py] Correct a typo in name of attribute

### DIFF
--- a/neo/io/baseio.py
+++ b/neo/io/baseio.py
@@ -88,7 +88,7 @@ class BaseIO(object):
 
     name = 'BaseIO'
     description = ''
-    extentions = []
+    extensions = []
 
     mode = 'file'  # or 'fake' or 'dir' or 'database'
 


### PR DESCRIPTION
Change name of attribute from extentions to extensions.