### PR TITLE
Add deep_copy option for spiketrain duplication

### DIFF
--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -21,6 +21,7 @@ the old object.
 # needed for python 3 compatibility
 from __future__ import absolute_import, division, print_function
 
+import copy
 import numpy as np
 import quantities as pq
 
@@ -496,16 +497,19 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         _check_time_in_range(value, self.t_start, self.t_stop)
         super(SpikeTrain, self).__setslice__(i, j, value)
 
-    def _copy_data_complement(self, other):
+    def _copy_data_complement(self, other, deep_copy=False):
         '''
         Copy the metadata from another :class:`SpikeTrain`.
         '''
         for attr in ("left_sweep", "sampling_rate", "name", "file_origin",
                      "description", "annotations"):
-            setattr(self, attr, getattr(other, attr, None))
+            attr_value = getattr(other, attr, None)
+            if deep_copy:
+                attr_value = copy.deepcopy(attr_value)
+            setattr(self, attr, attr_value)
 
     def duplicate_with_new_data(self, signal, t_start=None, t_stop=None,
-                                waveforms=None):
+                                waveforms=None, deep_copy=True):
         '''
         Create a new :class:`SpikeTrain` with the same metadata
         but different data (times, t_start, t_stop)
@@ -520,7 +524,7 @@ class SpikeTrain(BaseNeo, pq.Quantity):
 
         new_st = self.__class__(signal, t_start=t_start, t_stop=t_stop,
                                 waveforms=waveforms, units=self.units)
-        new_st._copy_data_complement(self)
+        new_st._copy_data_complement(self, deep_copy=deep_copy)
 
         # overwriting t_start and t_stop with new values
         new_st.t_start = t_start

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -1180,6 +1180,20 @@ class TestDuplicateWithNewData(unittest.TestCase):
         self.assertEqual(signal1b.t_stop, new_t_stop)
         self.assertEqual(signal1b.sampling_rate, signal1.sampling_rate)
 
+    def test_deep_copy_attributes(self):
+        signal1 = self.train
+        new_t_start = -10*pq.s
+        new_t_stop = 10*pq.s
+        new_data = np.sort(np.random.uniform(new_t_start.magnitude,
+                                             new_t_stop.magnitude,
+                                             len(self.train))) * pq.ms
+
+        signal1b = signal1.duplicate_with_new_data(new_data,
+                                                   t_start=new_t_start,
+                                                   t_stop=new_t_stop)
+        signal1.annotate(new_annotation='for signal 1')
+        self.assertTrue('new_annotation' not in signal1b.annotations)
+
 class TestAttributesAnnotations(unittest.TestCase):
     def test_set_universally_recommended_attributes(self):
         train = SpikeTrain([3, 4, 5], units='sec', name='Name',


### PR DESCRIPTION
In the current SpikeTrain implementation the attributes and annotations of a SpikeTrain are only shallow copied when duplicating the SpikeTrain. With this PR the attributes and annotations of a SpikeTrain can be copied using the 'deep_copy' keyword of the duplicate_with_new_data function. 