### PR TITLE
New URL for documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ More information
 
 - Home page: http://neuralensemble.org/neo
 - Mailing list: https://groups.google.com/forum/?fromgroups#!forum/neuralensemble
-- Documentation: http://packages.python.org/neo/
+- Documentation: http://neo.readthedocs.io/
 - Bug reports: https://github.com/NeuralEnsemble/python-neo/issues
 
 For installation instructions, see doc/source/install.rst


### PR DESCRIPTION
On pypi this is borken: python setup.py upload_docs
The doc at pythonhosted was a very old one. (0.3.3).
So I have manually remove the old doc
Now http://packages.python.org/neo/ do not exist anymore.
