### PR TITLE
Fix duplicate waveform slicing

### DIFF
--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -20,6 +20,7 @@ the old object.
 
 # needed for python 3 compatibility
 from __future__ import absolute_import, division, print_function
+import sys
 
 import copy
 import numpy as np
@@ -429,9 +430,11 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         # I'm not sure how. (If you know, please add an explanatory comment
         # here.) That copies over all of the metadata.
 
-        # update waveforms
-        if obj.waveforms is not None:
-            obj.waveforms = obj.waveforms[i:j]
+        # update waveforms only for python < 2.7. For newer versions,
+        # __getslice__ is calling __getitem__ which is also correcting for this.
+        if not sys.version_info >= (2, 7):
+            if obj.waveforms is not None:
+                obj.waveforms = obj.waveforms[i:j]
         return obj
 
     def __add__(self, time):

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -858,7 +858,7 @@ class TestSlice(unittest.TestCase):
         result = self.train1[1:2]
         assert_arrays_equal(self.train1[1:2], result)
         targwaveforms = np.array([[[2., 3.],
-                                   [2.1, 3.1]]])
+                                   [2.1, 3.1]]]) * pq.mV
 
         # but keep everything else pristine
         assert_neo_object_is_compliant(result)


### PR DESCRIPTION
In Python 2.7, waveforms are sliced twice when slicing a spiketrain. This is due to the double implementation of the waveform slicing in` spiketrain.__getslice__ `and `spiketrain.__getitem__`. However both implementations are necessary, since only `spiketrain.__getslice__` is used for Python 2.6 and only `spiketrain.__getitem__` for recent Python versions.
I don't know why the corresponding tests didn't fail for Travis, but they failed locally on my machine.