### PR TITLE
Add `time_index()` and `splice()` methods to `AnalogSignal`

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -530,6 +530,12 @@ class AnalogSignal(basesignal.BaseSignal):
                      ]:
             _pp(line)
 
+    def time_index(self, t):
+        """Return the array index corresponding to the time `t`"""
+        t = t.rescale(self.sampling_period.units)
+        i = (t - self.t_start) / self.sampling_period
+        i = int(np.rint(i.magnitude))
+        return i
 
     def time_slice(self, t_start, t_stop):
         '''
@@ -544,17 +550,13 @@ class AnalogSignal(basesignal.BaseSignal):
         if t_start is None:
             i = 0
         else:
-            t_start = t_start.rescale(self.sampling_period.units)
-            i = (t_start - self.t_start) / self.sampling_period
-            i = int(np.rint(i.magnitude))
+            i = self.time_index(t_start)
 
         # checking stop time and transforming to stop index
         if t_stop is None:
             j = len(self)
         else:
-            t_stop = t_stop.rescale(self.sampling_period.units)
-            j = (t_stop - self.t_start) / self.sampling_period
-            j = int(np.rint(j.magnitude))
+            j = self.time_index(t_stop)
 
         if (i < 0) or (j > len(self)):
             raise ValueError('t_start, t_stop have to be withing the analog \
@@ -623,3 +625,33 @@ class AnalogSignal(basesignal.BaseSignal):
         if hasattr(self, "lazy_shape"):
             signal.lazy_shape = merged_lazy_shape
         return signal
+
+    def splice(self, signal, copy=False):
+        """
+        Replace part of the current signal by a new piece of signal.
+        
+        The signal to be spliced in must have the same physical dimensions,
+        sampling rate, and number of channels as the current signal and
+        fit within it.
+        
+        If `copy` is False (the default), modify the current signal in place.
+        If `copy` is True, return a new signal and leave the current one untouched.
+        In this case, the new signal will not be linked to any parent objects.        
+        """
+        if signal.t_start < self.t_start:
+            raise ValueError("Cannot splice earlier than the start of the signal")
+        if signal.t_stop > self.t_stop:
+            raise ValueError("Splice extends beyond signal")
+        if signal.sampling_rate != self.sampling_rate:
+            raise ValueError("Sampling rates do not match")
+        i = self.time_index(signal.t_start)
+        j = i + signal.shape[0]
+        if copy:
+            new_signal = deepcopy(self)
+            new_signal.segment = None
+            new_signal.channel_index = None
+            new_signal[i:j, :] = signal
+            return new_signal
+        else:
+            self[i:j, :] = signal
+            return self

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -630,6 +630,9 @@ class AnalogSignal(basesignal.BaseSignal):
         """
         Replace part of the current signal by a new piece of signal.
         
+        The new piece of signal will overwrite part of the current signal
+        starting at the time given by the new piece's `t_start` attribute.
+        
         The signal to be spliced in must have the same physical dimensions,
         sampling rate, and number of channels as the current signal and
         fit within it.

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -508,6 +508,7 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
                            np.array([0.0, 1.0, 2.0, 100.0, 100.0, 100.0, 6.0, 7.0, 8.0, 9.0]))
         assert_array_equal(self.signal1, result)  # in-place
         self.assertEqual(result.segment, self.signal1.segment)
+        self.assertEqual(result.channel_index, self.signal1.channel_index)
 
     def test_splice_1channel_with_copy(self):
         signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1],
@@ -520,6 +521,7 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         assert_array_equal(self.signal1.magnitude.flatten(),
                            np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]))
         self.assertIs(result.segment, None)
+        self.assertIs(result.channel_index, None)
 
     def test_splice_2channels_inplace(self):
         signal = AnalogSignal(np.arange(20.0).reshape((10, 2)),
@@ -559,14 +561,14 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
 
     def test_splice_1channel_invalid_sampling_rate(self):
             signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1],
-                                               t_start=3 * pq.ms,  # too close to the end of the signal
+                                               t_start=3 * pq.ms,
                                                sampling_rate=2 * self.signal1.sampling_rate,
                                                units=pq.uA)
             self.assertRaises(ValueError, self.signal1.splice, signal_for_splicing, copy=False)
 
     def test_splice_1channel_invalid_units(self):
             signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1],
-                                               t_start=3 * pq.ms,  # too close to the end of the signal
+                                               t_start=3 * pq.ms,
                                                sampling_rate=self.signal1.sampling_rate,
                                                units=pq.uV)
             self.assertRaises(ValueError, self.signal1.splice, signal_for_splicing, copy=False)


### PR DESCRIPTION
The former gives the array index corresponding to a given time, the latter replaces part of a signal with another (generally smaller) signal. It is intended to be used for removing transients and other artefacts.