### PR TITLE
blackrockrawio _get_event_timestamps make use of t_start, t_stop

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -515,7 +515,7 @@ class BlackrockRawIO(BaseRawIO):
             nb = timestamp.size
         return nb
     
-    def _get_event_timestamps(self,  block_index, seg_index, event_channel_index, t_start, t_stop):
+    def _get_event_timestamps(self, block_index, seg_index, event_channel_index, t_start, t_stop):
         name = self.header['event_channels']['name'][event_channel_index]
         events_data = self.nev_data['NonNeural']
         ev_dict = self.__nonneural_evtypes[self.__nev_spec](events_data)[name]
@@ -524,7 +524,7 @@ class BlackrockRawIO(BaseRawIO):
         labels = events_data[ev_dict['mask']][ev_dict['field']]
         
         #time clip
-        sl =  self._get_timestamp_slice(timestamp, seg_index,  None, None)
+        sl = self._get_timestamp_slice(timestamp, seg_index, t_start, t_stop)
         timestamp = timestamp[sl]
         labels = labels[sl]
         durations = None


### PR DESCRIPTION
I promise I'm not combing through the code looking for tiny bugs. I'm writing a new io and I'm using the existing rawio's as examples. Sometimes I find something that I think might be a bug but it may just as well be there on purpose because of some weird idiosyncrasy of the data format. This is one of those times. I think it's a bug but I could easily be wrong.

PR passes test_blackrockio in intel python3.5 on Ubuntu 16.04