### PR TITLE
Added back list of available files as annotations to block in BlackRockRawIO

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -354,6 +354,12 @@ class BlackrockRawIO(BaseRawIO):
         block_ann['file_origin'] = self.filename
         block_ann['name'] = "Blackrock Data Block"
         block_ann['rec_datetime'] = rec_datetime
+        block_ann['avail_file_set'] = [k for k, v in self._avail_files.items() if v]
+        block_ann['avail_nsx'] = self._avail_nsx
+        block_ann['avail_nev'] = self._avail_files['nev']
+#        block_ann['avail_sif'] = self._avail_files['sif']  #  'sif' and 'ccf' files not yet supported
+#        block_ann['avail_ccf'] = self._avail_files['ccf']
+        block_ann['rec_pauses'] = False
 
         for c in range(unit_channels.size):
             unit_ann = self.raw_annotations['unit_channels'][c]


### PR DESCRIPTION
The latest version of BlackrockIO using the RawIO API was missing a few annotations for the Block objects that contained information on available files and recording pauses. Using the already existing structure for annotations in RawIO I added the checks for those annotations like it was done in earlier versions of BlackrockIO.