### PR TITLE
Fix for loading Blackrock files of version 2.1

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -297,13 +297,13 @@ class BlackrockRawIO(BaseRawIO):
             if spec in ['2.2', '2.3']:
                 ext_header = self.__nsx_ext_header[self.nsx_to_load]
             elif spec == '2.1':
-                self.__nsx_params[spec]('labels', self.nsx_to_load)
                 ext_header = []
                 keys = ['labels', 'units', 'min_analog_val', 'max_analog_val', 'min_digital_val', 'max_digital_val']
-                for i in range(len(self.__nsx_params[spec]('labels', self.nsx_to_load))):
+                params = self.__nsx_params[spec](self.nsx_to_load)
+                for i in range(len(params['labels'])):
                     d = {}
                     for key in keys:
-                        d[key] = self.__nsx_params[spec](key, self.nsx_to_load)[i]
+                        d[key] = params[key][i]
                     ext_header.append(d)
 
             for i, chan in enumerate(ext_header):
@@ -791,9 +791,9 @@ class BlackrockRawIO(BaseRawIO):
 
         # get shape of data
         shape = (
-            self.__nsx_params['2.1']('nb_data_points', nsx_nb),
+            self.__nsx_params['2.1'](nsx_nb)['nb_data_points'],
             self.__nsx_basic_header[nsx_nb]['channel_count'])
-        offset = self.__nsx_params['2.1']('bytes_in_headers', nsx_nb)
+        offset = self.__nsx_params['2.1'](nsx_nb)['bytes_in_headers']
 
         # read nsx data
         # store as dict for compatibility with higher file specs
@@ -1402,7 +1402,7 @@ class BlackrockRawIO(BaseRawIO):
 
         return wf_left_sweep
 
-    def __get_nsx_param_variant_a(self, param_name, nsx_nb):
+    def __get_nsx_param_variant_a(self, nsx_nb):
         """
         Returns parameter (param_name) for a given nsx (nsx_nb) for file spec
         2.1.
@@ -1461,7 +1461,7 @@ class BlackrockRawIO(BaseRawIO):
             'time_unit': pq.CompoundUnit("1.0/{0}*s".format(
                 30000 / self.__nsx_basic_header[nsx_nb]['period']))}
 
-        return nsx_parameters[param_name]
+        return nsx_parameters       # Returns complete dictionary because then it does not need to be called so often
 
     def __get_nsx_param_variant_b(self, param_name, nsx_nb):
         """

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -309,16 +309,14 @@ class BlackrockRawIO(BaseRawIO):
                     for key in keys:
                         d[key] = self.__nsx_params[spec](key, self.nsx_to_load)[i]
                     ext_header.append(d)
-                print(ext_header)
 
             for i, chan in enumerate(ext_header):
-                print(ext_header)
                 if spec in ['2.2', '2.3']:
                     ch_name = chan['electrode_label'].decode()
                     ch_id = chan['electrode_id']
                 elif spec == '2.1':
                     ch_name = chan['labels'].decode()
-                    ch_id = i                                           # Not sure here
+                    ch_id = self.__nsx_ext_header[self.nsx_to_load][i]['electrode_id']
                 sig_dtype = 'int16'
                 units = chan['units'].decode()
                 #max_analog_val/min_analog_val/max_digital_val/min_analog_val are int16!!!!!

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -303,19 +303,19 @@ class BlackrockRawIO(BaseRawIO):
             elif spec == '2.1':
                 self.__get_nsx_param_variant_a('labels', self.nsx_to_load)
                 ext_header = self.nsx_parameters
-                #print(ext_header)
+                print(ext_header)
 
-            for i, chan in enumerate(ext_header):
-                print(chan)
-                ch_name = chan['electrode_label'].decode()
-                ch_id = chan['electrode_id']
+            for i, chan in enumerate(self.__nsx_ext_header[self.nsx_to_load]):
+                print(ext_header)
+                ch_name = ext_header['labels'][i].decode()
+                ch_id = i
                 sig_dtype = 'int16'
-                units = chan['units'].decode()
+                units = ext_header['units'][i].decode()
                 #max_analog_val/min_analog_val/max_digital_val/min_analog_val are int16!!!!!
                 #dangarous situation so cast to float everyone
-                gain = (float(chan['max_analog_val']) - float(chan['min_analog_val']))/\
-                                                    (float(chan['max_digital_val']) - float(chan['min_digital_val']))
-                offset = -float(chan['min_digital_val'])*gain + float(chan['min_analog_val'])
+                gain = (float(ext_header['max_analog_val'][i]) - float(ext_header['min_analog_val'][i]))/\
+                                                    (float(ext_header['max_digital_val'][i]) - float(ext_header['min_digital_val'][i]))
+                offset = -float(ext_header['min_digital_val'][i])*gain + float(ext_header['min_analog_val'][i])
                 group_id = 0
                 sig_channels.append((ch_name, ch_id, sig_sampling_rate, sig_dtype, 
                                                             units, gain, offset,group_id,))

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -310,11 +310,12 @@ class BlackrockRawIO(BaseRawIO):
                 if spec in ['2.2', '2.3']:
                     ch_name = chan['electrode_label'].decode()
                     ch_id = chan['electrode_id']
+                    units = chan['units'].decode()
                 elif spec == '2.1':
-                    ch_name = chan['labels'].decode()
+                    ch_name = chan['labels']
                     ch_id = self.__nsx_ext_header[self.nsx_to_load][i]['electrode_id']
+                    units = chan['units']
                 sig_dtype = 'int16'
-                units = chan['units'].decode()
                 #max_analog_val/min_analog_val/max_digital_val/min_analog_val are int16!!!!!
                 #dangarous situation so cast to float everyone
                 gain = (float(chan['max_analog_val']) - float(chan['min_analog_val']))/\


### PR DESCRIPTION
After playing around a lot with the new BlackrockRawIO I was able to get Blackrock files of version 2.1 to load (see also issue 417). I copied some parts of the old IO over because they were referenced but not yet available and adapted them to fit into the new structure. They originally required more data being available already but this could be eliminated because the needed functionality (a lot less than the original methods had) did not require those. Using this code I was able to fully load files of version 2.1. 