### PR TITLE
IO specific time units

### DIFF
--- a/neo/io/basefromrawio.py
+++ b/neo/io/basefromrawio.py
@@ -273,7 +273,7 @@ class BaseFromRaw(BaseIO):
                 t_stop = seg_t_stop
             
             #in float format in second (for rawio clip)
-            t_start_, t_stop_ = t_start.rescale('s'), t_stop.rescale('s').magnitude
+            t_start_, t_stop_ = t_start.rescale('s').magnitude, t_stop.rescale('s').magnitude
             
             #new spiketrain limits
             seg_t_start = t_start
@@ -288,9 +288,7 @@ class BaseFromRaw(BaseIO):
             for channel_indexes in channel_indexes_list:
                 sr = self.get_signal_sampling_rate(channel_indexes) * pq.Hz
                 sig_t_start = self.get_signal_t_start(block_index, seg_index, channel_indexes)
-                print(sig_t_start)
                 if not hasattr(sig_t_start, 'dimensionality'):
-                    print("HERE")
                     sig_t_start *= pq.s
 
                 sig_size = self.get_signal_size(block_index=block_index, seg_index=seg_index, 
@@ -400,7 +398,9 @@ class BaseFromRaw(BaseIO):
             if not lazy:
                 ev_timestamp, ev_raw_durations, ev_labels = self.get_event_timestamps(block_index=block_index, seg_index=seg_index, 
                                         event_channel_index=chan_ind, t_start=t_start_, t_stop=t_stop_)
-                ev_times = self.rescale_event_timestamp(ev_timestamp, 'float64') * pq.s
+                ev_times = self.rescale_event_timestamp(ev_timestamp, 'float64')
+                if not hasattr(ev_times, 'dimensionality'):
+                    ev_times *= pq.s
                 if ev_raw_durations is None:
                     ev_durations = None
                 else:

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -297,13 +297,13 @@ class BlackrockRawIO(BaseRawIO):
             if spec in ['2.2', '2.3']:
                 ext_header = self.__nsx_ext_header[self.nsx_to_load]
             elif spec == '2.1':
-                self.__nsx_params[spec]('labels', self.nsx_to_load)
                 ext_header = []
                 keys = ['labels', 'units', 'min_analog_val', 'max_analog_val', 'min_digital_val', 'max_digital_val']
-                for i in range(len(self.__nsx_params[spec]('labels', self.nsx_to_load))):
+                params = self.__nsx_params[spec](self.nsx_to_load)
+                for i in range(len(params['labels'])):
                     d = {}
                     for key in keys:
-                        d[key] = self.__nsx_params[spec](key, self.nsx_to_load)[i]
+                        d[key] = params[key][i]
                     ext_header.append(d)
 
             for i, chan in enumerate(ext_header):
@@ -791,9 +791,9 @@ class BlackrockRawIO(BaseRawIO):
 
         # get shape of data
         shape = (
-            self.__nsx_params['2.1']('nb_data_points', nsx_nb),
+            self.__nsx_params['2.1'](nsx_nb)['nb_data_points'],
             self.__nsx_basic_header[nsx_nb]['channel_count'])
-        offset = self.__nsx_params['2.1']('bytes_in_headers', nsx_nb)
+        offset = self.__nsx_params['2.1'](nsx_nb)['bytes_in_headers']
 
         # read nsx data
         # store as dict for compatibility with higher file specs
@@ -1402,7 +1402,7 @@ class BlackrockRawIO(BaseRawIO):
 
         return wf_left_sweep
 
-    def __get_nsx_param_variant_a(self, param_name, nsx_nb):
+    def __get_nsx_param_variant_a(self, nsx_nb):
         """
         Returns parameter (param_name) for a given nsx (nsx_nb) for file spec
         2.1.
@@ -1461,7 +1461,7 @@ class BlackrockRawIO(BaseRawIO):
             'time_unit': pq.CompoundUnit("1.0/{0}*s".format(
                 30000 / self.__nsx_basic_header[nsx_nb]['period']))}
 
-        return nsx_parameters[param_name]
+        return nsx_parameters       # Returns complete dictionary because then it does not need to be called so often
 
     def __get_nsx_param_variant_b(self, param_name, nsx_nb):
         """

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -309,16 +309,14 @@ class BlackrockRawIO(BaseRawIO):
                     for key in keys:
                         d[key] = self.__nsx_params[spec](key, self.nsx_to_load)[i]
                     ext_header.append(d)
-                print(ext_header)
 
             for i, chan in enumerate(ext_header):
-                print(ext_header)
                 if spec in ['2.2', '2.3']:
                     ch_name = chan['electrode_label'].decode()
                     ch_id = chan['electrode_id']
                 elif spec == '2.1':
                     ch_name = chan['labels'].decode()
-                    ch_id = i                                           # Not sure here
+                    ch_id = self.__nsx_ext_header[self.nsx_to_load][i]['electrode_id']
                 sig_dtype = 'int16'
                 units = chan['units'].decode()
                 #max_analog_val/min_analog_val/max_digital_val/min_analog_val are int16!!!!!

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -303,19 +303,19 @@ class BlackrockRawIO(BaseRawIO):
             elif spec == '2.1':
                 self.__get_nsx_param_variant_a('labels', self.nsx_to_load)
                 ext_header = self.nsx_parameters
-                #print(ext_header)
+                print(ext_header)
 
-            for i, chan in enumerate(ext_header):
-                print(chan)
-                ch_name = chan['electrode_label'].decode()
-                ch_id = chan['electrode_id']
+            for i, chan in enumerate(self.__nsx_ext_header[self.nsx_to_load]):
+                print(ext_header)
+                ch_name = ext_header['labels'][i].decode()
+                ch_id = i
                 sig_dtype = 'int16'
-                units = chan['units'].decode()
+                units = ext_header['units'][i].decode()
                 #max_analog_val/min_analog_val/max_digital_val/min_analog_val are int16!!!!!
                 #dangarous situation so cast to float everyone
-                gain = (float(chan['max_analog_val']) - float(chan['min_analog_val']))/\
-                                                    (float(chan['max_digital_val']) - float(chan['min_digital_val']))
-                offset = -float(chan['min_digital_val'])*gain + float(chan['min_analog_val'])
+                gain = (float(ext_header['max_analog_val'][i]) - float(ext_header['min_analog_val'][i]))/\
+                                                    (float(ext_header['max_digital_val'][i]) - float(ext_header['min_digital_val'][i]))
+                offset = -float(ext_header['min_digital_val'][i])*gain + float(ext_header['min_analog_val'][i])
                 group_id = 0
                 sig_channels.append((ch_name, ch_id, sig_sampling_rate, sig_dtype, 
                                                             units, gain, offset,group_id,))

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -464,7 +464,6 @@ class BlackrockRawIO(BaseRawIO):
 
     def _get_signal_t_start(self, block_index, seg_index, channel_indexes):
         #same as segment starts
-        print(self._sigs_t_starts[seg_index])
         return self._sigs_t_starts[seg_index]
 
     def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop, channel_indexes):
@@ -591,7 +590,8 @@ class BlackrockRawIO(BaseRawIO):
     
     def _rescale_event_timestamp(self, event_timestamps, dtype):
         ev_times = event_timestamps.astype(dtype)
-        ev_times /= self.__nev_basic_header['timestamp_resolution']
+        ev_times *= pq.CompoundUnit("1.0/{0} * s".format(
+                self.__nev_basic_header['timestamp_resolution']))
         return ev_times
 
     

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -310,11 +310,12 @@ class BlackrockRawIO(BaseRawIO):
                 if spec in ['2.2', '2.3']:
                     ch_name = chan['electrode_label'].decode()
                     ch_id = chan['electrode_id']
+                    units = chan['units'].decode()
                 elif spec == '2.1':
-                    ch_name = chan['labels'].decode()
+                    ch_name = chan['labels']
                     ch_id = self.__nsx_ext_header[self.nsx_to_load][i]['electrode_id']
+                    units = chan['units']
                 sig_dtype = 'int16'
-                units = chan['units'].decode()
                 #max_analog_val/min_analog_val/max_digital_val/min_analog_val are int16!!!!!
                 #dangarous situation so cast to float everyone
                 gain = (float(chan['max_analog_val']) - float(chan['min_analog_val']))/\


### PR DESCRIPTION
Note: This pull request builds on pull request #435, thus should not be merged before it.
Using the new RawIO I noticed that all times are rescaled to seconds. Me and my colleagues thought it might be better to at least be able to keep the timestamps as integer values in order not to lose precision and to be able to work with them more easily.
So what I did was to pass all timestamps and t_start and t_stop with a pq.unit (e.g. 1.0/30000 * s) from BlackrockRawIO and implement a check for this in BaseFromRawIO. So all IOs that did not change are not affected, because they are treated the same way as before but it can now be decided on RawIO level, which kind of behavior is wanted.
I have not done this consequently, because many methods in the RawIOs require times passed as seconds but I tried to keep them in their original form for as long as possible.