### PR TITLE
Loading only a subset of all channels

### DIFF
--- a/neo/io/basefromrawio.py
+++ b/neo/io/basefromrawio.py
@@ -373,7 +373,6 @@ class BaseFromRaw(BaseIO):
         #SpikeTrain and waveforms (optional)
         unit_channels = self.header['unit_channels']
         unit_indexes = compare_unit_channels(unit_channels, channels_to_load)
-        #start1 = time.time()
         for unit_index in unit_indexes:
             if not lazy and load_waveforms:
                 raw_waveforms = self.get_spike_raw_waveforms(block_index=block_index, seg_index=seg_index, 


### PR DESCRIPTION
Currently it is not possible to load only a few channels instead of the whole file. @samuelgarcia mentioned something about doing this on IO level. As far as I can tell this requires a framework at BaseFromRawIO level. Thus I tried implementing it there. This required combining the wanted channels with the existing channels on multiple places. 
What happens now is that when 'channels_to_load=...' is specified in read_block or read_segment, AnalogSignals and SpikeTrains are only loaded if they belong to one of the specified channels. 
If nothing is specified, all channels are loaded in order not to change the current default behavior.