### PR TITLE
Remove mutated copy of `AnalogSignal.splice()`

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -519,41 +519,5 @@ class AnalogSignal(BaseSignal):
             new_signal[i:j, :] = signal
             return new_signal
         else:
-          signal.channel_index = ChannelIndex(index=np.arange(signal.shape[1]))
-
-        if hasattr(self, "lazy_shape"):
-            signal.lazy_shape = merged_lazy_shape
-        return signal
-
-    def splice(self, signal, copy=False):
-        """
-        Replace part of the current signal by a new piece of signal.
-        
-        The new piece of signal will overwrite part of the current signal
-        starting at the time given by the new piece's `t_start` attribute.
-        
-        The signal to be spliced in must have the same physical dimensions,
-        sampling rate, and number of channels as the current signal and
-        fit within it.
-        
-        If `copy` is False (the default), modify the current signal in place.
-        If `copy` is True, return a new signal and leave the current one untouched.
-        In this case, the new signal will not be linked to any parent objects.        
-        """
-        if signal.t_start < self.t_start:
-            raise ValueError("Cannot splice earlier than the start of the signal")
-        if signal.t_stop > self.t_stop:
-            raise ValueError("Splice extends beyond signal")
-        if signal.sampling_rate != self.sampling_rate:
-            raise ValueError("Sampling rates do not match")
-        i = self.time_index(signal.t_start)
-        j = i + signal.shape[0]
-        if copy:
-            new_signal = deepcopy(self)
-            new_signal.segment = None
-            new_signal.channel_index = None
-            new_signal[i:j, :] = signal
-            return new_signal
-        else:
             self[i:j, :] = signal
             return self


### PR DESCRIPTION
Ironically, this seems to have been spliced in during a merge