### PR TITLE
Made SpikeTrain.times return Quantity instead of SpikeTrain

### DIFF
--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -639,9 +639,9 @@ class SpikeTrain(BaseNeo, pq.Quantity):
     @property
     def times(self):
         '''
-        Returns the :class:`SpikeTrain` without modification or copying.
+        Returns the :class:`SpikeTrain` as a :class:'Quantity' array.
         '''
-        return self
+        return pq.Quantity(self)
 
     @property
     def duration(self):

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -185,8 +185,7 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         :right_sweep: (quantity scalar) Time from the trigger times of the
             spikes to the end of the waveforms, read-only.
             (:attr:`left_sweep` + :attr:`spike_duration`)
-        :times: (:class:`SpikeTrain`) Returns the :class:`SpikeTrain` without
-            modification or copying.
+        :times: (quantity array 1D) Returns the :class:`SpikeTrain` as a quantity array.
 
     *Slicing*:
         :class:`SpikeTrain` objects can be sliced. When this occurs, a new
@@ -639,7 +638,7 @@ class SpikeTrain(BaseNeo, pq.Quantity):
     @property
     def times(self):
         '''
-        Returns the :class:`SpikeTrain` as a :class:'Quantity' array.
+        Returns the :class:`SpikeTrain` as a quantity array.
         '''
         return pq.Quantity(self)
 

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -1656,7 +1656,6 @@ class TestPropertiesMethods(unittest.TestCase):
         self.assertEqual(result1.units, self.train1.units)
         self.assertEqual(result1.dtype, self.train1.dtype)
 
-
     def test__children(self):
         segment = Segment(name='seg1')
         segment.spiketrains = [self.train1]

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -230,16 +230,19 @@ class TestConstructor(unittest.TestCase):
     def result_spike_check(self, train, st_out, t_start_out, t_stop_out,
                            dtype, units):
         assert_arrays_equal(train, st_out)
+        assert_arrays_equal(train, train.times)
         assert_neo_object_is_compliant(train)
 
         self.assertEqual(train.t_start, t_start_out)
         self.assertEqual(train.t_stop, t_stop_out)
 
         self.assertEqual(train.units, units)
+        self.assertEqual(train.units, train.times.units)
         self.assertEqual(train.t_start.units, units)
         self.assertEqual(train.t_stop.units, units)
 
         self.assertEqual(train.dtype, dtype)
+        self.assertEqual(train.dtype, train.times.dtype)
         self.assertEqual(train.t_stop.dtype, dtype)
         self.assertEqual(train.t_start.dtype, dtype)
 
@@ -1644,6 +1647,15 @@ class TestPropertiesMethods(unittest.TestCase):
         self.assertEqual(result2, None)
         self.assertEqual(result3, None)
         self.assertEqual(result4, None)
+
+    def test__times(self):
+        result1 = self.train1.times
+        self.assertIsInstance(result1, pq.Quantity)
+        self.assertTrue((result1 == self.train1).all)
+        self.assertEqual(len(result1), len(self.train1))
+        self.assertEqual(result1.units, self.train1.units)
+        self.assertEqual(result1.dtype, self.train1.dtype)
+
 
     def test__children(self):
         segment = Segment(name='seg1')

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -230,27 +230,18 @@ class TestConstructor(unittest.TestCase):
     def result_spike_check(self, train, st_out, t_start_out, t_stop_out,
                            dtype, units):
         assert_arrays_equal(train, st_out)
-        assert_arrays_equal(train, train.times)
         assert_neo_object_is_compliant(train)
 
         self.assertEqual(train.t_start, t_start_out)
-        self.assertEqual(train.t_start, train.times.t_start)
         self.assertEqual(train.t_stop, t_stop_out)
-        self.assertEqual(train.t_stop, train.times.t_stop)
 
         self.assertEqual(train.units, units)
-        self.assertEqual(train.units, train.times.units)
         self.assertEqual(train.t_start.units, units)
-        self.assertEqual(train.t_start.units, train.times.t_start.units)
         self.assertEqual(train.t_stop.units, units)
-        self.assertEqual(train.t_stop.units, train.times.t_stop.units)
 
         self.assertEqual(train.dtype, dtype)
-        self.assertEqual(train.dtype, train.times.dtype)
         self.assertEqual(train.t_stop.dtype, dtype)
-        self.assertEqual(train.t_stop.dtype, train.times.t_stop.dtype)
         self.assertEqual(train.t_start.dtype, dtype)
-        self.assertEqual(train.t_start.dtype, train.times.t_start.dtype)
 
     def test__create_minimal(self):
         t_start = 0.0


### PR DESCRIPTION
Issue #412 states that SpikeTrain.times should return a Quantity instead of a SpikeTrain. This pull request should fix this behavior. This makes obj.times more consistent across all neo objects, as SpikeTrain was the only one with this behavior.
I also adapted the docstrings and UnitTests accordingly.

However, I'm wondering if there was a reason for having it return a SpikeTrain, because this was tested quite often in the UnitTests and also the documentation explicitly states that a SpikeTrain should be returned.
