### PR TITLE
Raise a `ValueError` if `t_stop` is earlier than `t_start` when creating an empty `SpikeTrain`

### DIFF
--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -54,6 +54,9 @@ def _check_time_in_range(value, t_start, t_stop, view=False):
     certain that the dtype and units are the same
     '''
 
+    if t_start > t_stop:
+        raise ValueError("t_stop (%s) is before t_start (%s)" % (t_stop, t_start))
+
     if not value.size:
         return
 

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -220,8 +220,8 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         constructor, but not when slicing.
         '''
         if len(times) != 0 and waveforms is not None and len(times) != \
-                waveforms.shape[
-                    0]:  # len(times)!=0 has been used to workaround a bug occuring during neo import)
+                waveforms.shape[0]:
+            # len(times)!=0 has been used to workaround a bug occuring during neo import
             raise ValueError(
                 "the number of waveforms should be equal to the number of spikes")
 

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -1564,7 +1564,7 @@ class TestPropertiesMethods(unittest.TestCase):
     def test__repr(self):
         result = repr(self.train1)
         if np.__version__.split(".")[:2] > ['1', '13']:
-            # see https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst#many-changes-to-array-printing-disableable-with-the-new-legacy-printing-mode
+            # see https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst#many-changes-to-array-printing-disableable-with-the-new-legacy-printing-mode  # nopep8
             targ = '<SpikeTrain(array([3., 4., 5.]) * ms, [0.5 ms, 10.0 ms])>'
         else:
             targ = '<SpikeTrain(array([ 3.,  4.,  5.]) * ms, [0.5 ms, 10.0 ms])>'

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -142,6 +142,12 @@ class Testcheck_time_in_range(unittest.TestCase):
         _check_time_in_range(value, t_start=t_start, t_stop=t_stop, view=False)
         _check_time_in_range(value, t_start=t_start, t_stop=t_stop, view=True)
 
+    def test__check_time_in_range_empty_array_invalid_t_stop(self):
+        value = np.array([])
+        t_start = 6 * pq.s
+        t_stop = 4 * pq.s
+        self.assertRaises(ValueError, _check_time_in_range, value, t_start=t_start, t_stop=t_stop)
+
     def test__check_time_in_range_exact(self):
         value = np.array([0., 5., 10.]) * pq.s
         t_start = 0. * pq.s

--- a/neo/test/iotest/test_nestio.py
+++ b/neo/test/iotest/test_nestio.py
@@ -673,8 +673,8 @@ class TestNestIO_Spiketrains(BaseTestIO, unittest.TestCase):
             filename='0gid-1time-1256-0.gdf',
             directory=self.local_test_dir, clean=False)
         r = NestIO(filenames=filename)
-        seg = r.read_segment(gid_list=[], t_start=400. * pq.ms,
-                             t_stop=1. * pq.ms)
+        seg = r.read_segment(gid_list=[], t_start=400.4 * pq.ms,
+                             t_stop=400.5 * pq.ms)
         for st in seg.spiketrains:
             self.assertEqual(st.size, 0)
 
@@ -689,7 +689,7 @@ class TestNestIO_Spiketrains(BaseTestIO, unittest.TestCase):
             directory=self.local_test_dir, clean=False)
         r = NestIO(filenames=filename)
         st = r.read_spiketrain(gdf_id=0, t_start=400. * pq.ms,
-                               t_stop=1. * pq.ms)
+                               t_stop=410. * pq.ms)
         self.assertEqual(st.size, 0)
 
 


### PR DESCRIPTION
Fixes #430