### PR TITLE
[MRG] Change filter behaviour to return all objects if no filter parameters are specified

### DIFF
--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -56,27 +56,27 @@ def filterdata(data, targdict=None, objects=None, **kwargs):
         targdict += [kwargs]
 
     if not targdict:
-        return []
+        results = data
 
     # if multiple dicts are provided, apply each filter sequentially
-    if not hasattr(targdict, 'keys'):
+    elif not hasattr(targdict, 'keys'):
         # for performance reasons, only do the object filtering on the first
         # iteration
         results = filterdata(data, targdict=targdict[0], objects=objects)
         for targ in targdict[1:]:
             results = filterdata(results, targdict=targ)
         return results
-
-    # do the actual filtering
-    results = []
-    for key, value in sorted(targdict.items()):
-        for obj in data:
-            if (hasattr(obj, key) and getattr(obj, key) == value and
-                    all([obj is not res for res in results])):
-                results.append(obj)
-            elif (key in obj.annotations and obj.annotations[key] == value and
-                    all([obj is not res for res in results])):
-                results.append(obj)
+    else:
+        # do the actual filtering
+        results = []
+        for key, value in sorted(targdict.items()):
+            for obj in data:
+                if (hasattr(obj, key) and getattr(obj, key) == value and
+                        all([obj is not res for res in results])):
+                    results.append(obj)
+                elif (key in obj.annotations and obj.annotations[key] == value and
+                        all([obj is not res for res in results])):
+                    results.append(obj)
 
     # keep only objects of the correct classes
     if objects:

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -31,6 +31,9 @@ def filterdata(data, targdict=None, objects=None, **kwargs):
     be a list of dictionaries, in which case the filters are applied
     sequentially.  If targdict and kwargs are both supplied, the
     targdict filters are applied first, followed by the kwarg filters.
+    A targdict of None or {} and objects = None corresponds to no filters
+    applied, therefore returning all child objects.
+    Default targdict and objects is None.
 
 
     objects (optional) should be the name of a Neo object type,
@@ -379,6 +382,8 @@ class Container(BaseNeo):
         be a list of dictionaries, in which case the filters are applied
         sequentially.  If targdict and kwargs are both supplied, the
         targdict filters are applied first, followed by the kwarg filters.
+        A targdict of None or {} corresponds to no filters applied, therefore
+        returning all child objects. Default targdict is None.
 
         If data is True (default), include data objects.
         If container is True (default False), include container objects.
@@ -387,14 +392,17 @@ class Container(BaseNeo):
 
         objects (optional) should be the name of a Neo object type,
         a neo object class, or a list of one or both of these.  If specified,
-        only these objects will be returned.  Note that if recursive is True,
-        containers not in objects will still be descended into.
-        This overrides data and container.
+        only these objects will be returned. If not specified any type of
+        object is  returned. Default is None.
+        Note that if recursive is True, containers not in objects will still
+        be descended into. This overrides data and container.
 
 
         Examples::
 
             >>> obj.filter(name="Vm")
+            >>> obj.filter(objects=neo.SpikeTrain)
+            >>> obj.filter(targdict={'myannotation':3})
         """
         # if objects are specified, get the classes
         if objects:

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -474,7 +474,7 @@ class Container(BaseNeo):
                 continue
             if append:
                 target = getattr(child, parent_name)
-                if not self in target:
+                if self not in target:
                     target.append(self)
                 continue
             setattr(child, parent_name, [self])

--- a/neo/test/coretest/test_block.py
+++ b/neo/test/coretest/test_block.py
@@ -22,7 +22,7 @@ else:
 
 from neo.core.block import Block
 from neo.core.container import filterdata
-from neo.core import SpikeTrain, Unit
+from neo.core import SpikeTrain, Unit, AnalogSignal
 from neo.test.tools import (assert_neo_object_is_compliant,
                             assert_same_sub_schema)
 from neo.test.generate_datasets import (get_fake_value, get_fake_values,
@@ -338,6 +338,13 @@ class TestBlock(unittest.TestCase):
 
     def test__filter_none(self):
         targ = []
+        # collecting all data objects in target block
+        for seg in self.targobj.segments:
+            targ.extend(seg.analogsignals)
+            targ.extend(seg.epochs)
+            targ.extend(seg.events)
+            targ.extend(seg.irregularlysampledsignals)
+            targ.extend(seg.spiketrains)
 
         res1 = self.targobj.filter()
         res2 = self.targobj.filter({})
@@ -441,8 +448,8 @@ class TestBlock(unittest.TestCase):
 
         name0 = self.sigarrs2[0].name
         res0 = self.targobj.filter([{'j': 5}, {}])
-        res1 = self.targobj.filter({}, j=0)
-        res2 = self.targobj.filter([{}], i=0)
+        res1 = self.targobj.filter({}, j=5)
+        res2 = self.targobj.filter([{}], i=6)
         res3 = self.targobj.filter({'name': name0}, j=1)
         res4 = self.targobj.filter(targdict={'name': name0}, j=1)
         res5 = self.targobj.filter(name=name0, targdict={'j': 1})
@@ -494,6 +501,26 @@ class TestBlock(unittest.TestCase):
         assert_same_sub_schema(res0, targ)
         assert_same_sub_schema(res1, targ)
         assert_same_sub_schema(res2, targ)
+
+    def test__filter_no_annotation_but_object(self):
+        targ = []
+        for seg in self.targobj.segments:
+            targ.extend(seg.spiketrains)
+        res = self.targobj.filter(objects=SpikeTrain)
+        assert_same_sub_schema(res, targ)
+
+        targ = []
+        for seg in self.targobj.segments:
+            targ.extend(seg.analogsignals)
+        res = self.targobj.filter(objects=AnalogSignal)
+        assert_same_sub_schema(res, targ)
+
+        targ = []
+        for seg in self.targobj.segments:
+            targ.extend(seg.analogsignals)
+            targ.extend(seg.spiketrains)
+        res = self.targobj.filter(objects=[AnalogSignal, SpikeTrain])
+        assert_same_sub_schema(res, targ)
 
     def test__filter_single_annotation_obj_single(self):
         targ = self.trains1[1::2]
@@ -643,9 +670,9 @@ class TestBlock(unittest.TestCase):
 
         name1 = self.sigarrs1[0].name
         name2 = self.sigarrs2[0].name
-        res0 = filterdata(data, [{'j': 0}, {}])
-        res1 = filterdata(data, {}, i=0)
-        res2 = filterdata(data, [{}], i=0)
+        res0 = filterdata(data, [{'j': 5}, {}])
+        res1 = filterdata(data, {}, i=5)
+        res2 = filterdata(data, [{}], i=5)
         res3 = filterdata(data, name=name1, targdict={'j': 1})
         res4 = filterdata(data, {'name': name1}, j=1)
         res5 = filterdata(data, targdict={'name': name1}, j=1)

--- a/neo/test/coretest/test_channelindex.py
+++ b/neo/test/coretest/test_channelindex.py
@@ -19,7 +19,7 @@ else:
 
 from neo.core.channelindex import ChannelIndex
 from neo.core.container import filterdata
-from neo.core import Block, Segment, SpikeTrain
+from neo.core import Block, Segment, SpikeTrain, AnalogSignal
 from neo.test.tools import (assert_neo_object_is_compliant,
                             assert_arrays_equal,
                             assert_same_sub_schema)
@@ -290,6 +290,11 @@ class TestChannelIndex(unittest.TestCase):
 
     def test__filter_none(self):
         targ = []
+        # collecting all data objects in target block
+        targ.extend(self.targobj.analogsignals)
+        targ.extend(self.targobj.irregularlysampledsignals)
+        for unit in self.targobj.units:
+            targ.extend(unit.spiketrains)
 
         res1 = self.targobj.filter()
         res2 = self.targobj.filter({})
@@ -388,8 +393,8 @@ class TestChannelIndex(unittest.TestCase):
 
         name0 = self.sigarrs2[0].name
         res0 = self.targobj.filter([{'j': 5}, {}])
-        res1 = self.targobj.filter({}, j=0)
-        res2 = self.targobj.filter([{}], i=0)
+        res1 = self.targobj.filter({}, j=5)
+        res2 = self.targobj.filter([{}], i=5)
         res3 = self.targobj.filter({'name': name0}, j=1)
         res4 = self.targobj.filter(targdict={'name': name0}, j=1)
         res5 = self.targobj.filter(name=name0, targdict={'j': 1})
@@ -441,6 +446,24 @@ class TestChannelIndex(unittest.TestCase):
         assert_same_sub_schema(res0, targ)
         assert_same_sub_schema(res1, targ)
         assert_same_sub_schema(res2, targ)
+
+    def test__filter_no_annotation_but_object(self):
+        targ = []
+        for unit in self.targobj.units:
+            targ.extend(unit.spiketrains)
+        res = self.targobj.filter(objects=SpikeTrain)
+        assert_same_sub_schema(res, targ)
+
+        targ = self.targobj.analogsignals
+        res = self.targobj.filter(objects=AnalogSignal)
+        assert_same_sub_schema(res, targ)
+
+        targ = self.targobj.analogsignals
+        for unit in self.targobj.units:
+            targ.extend(unit.spiketrains)
+        res = self.targobj.filter(objects=[AnalogSignal, SpikeTrain])
+        assert_same_sub_schema(res, targ)
+        assert_same_sub_schema(res, targ)
 
     def test__filter_single_annotation_obj_single(self):
         targ = [self.trains1[1], self.trains1[3]]
@@ -579,9 +602,9 @@ class TestChannelIndex(unittest.TestCase):
 
         name1 = self.sigarrs1a[0].name
         name2 = self.sigarrs2[0].name
-        res0 = filterdata(data, [{'j': 0}, {}])
-        res1 = filterdata(data, {}, i=0)
-        res2 = filterdata(data, [{}], i=0)
+        res0 = filterdata(data, [{'j': 5}, {}])
+        res1 = filterdata(data, {}, i=5)
+        res2 = filterdata(data, [{}], i=5)
         res3 = filterdata(data, name=name1, targdict={'j': 1})
         res4 = filterdata(data, {'name': name1}, j=1)
         res5 = filterdata(data, targdict={'name': name1}, j=1)

--- a/neo/test/coretest/test_channelindex.py
+++ b/neo/test/coretest/test_channelindex.py
@@ -458,11 +458,11 @@ class TestChannelIndex(unittest.TestCase):
         res = self.targobj.filter(objects=AnalogSignal)
         assert_same_sub_schema(res, targ)
 
-        targ = self.targobj.analogsignals
+        targ = []
+        targ.extend(self.targobj.analogsignals)
         for unit in self.targobj.units:
             targ.extend(unit.spiketrains)
         res = self.targobj.filter(objects=[AnalogSignal, SpikeTrain])
-        assert_same_sub_schema(res, targ)
         assert_same_sub_schema(res, targ)
 
     def test__filter_single_annotation_obj_single(self):

--- a/neo/test/coretest/test_segment.py
+++ b/neo/test/coretest/test_segment.py
@@ -318,6 +318,17 @@ class TestSegment(unittest.TestCase):
 
     def test__filter_none(self):
         targ = []
+        # collecting all data objects in target block
+        targ.extend(self.targobj.analogsignals)
+        targ.extend(self.targobj.epochs)
+        targ.extend(self.targobj.events)
+        targ.extend(self.targobj.irregularlysampledsignals)
+        targ.extend(self.targobj.spiketrains)
+
+
+        # for unit in self.targobj.units:
+        #     targ.extend(unit.spiketrains)
+
 
         res0 = self.targobj.filter()
         res1 = self.targobj.filter({})
@@ -417,9 +428,9 @@ class TestSegment(unittest.TestCase):
     def test__filter_multi_nores(self):
         targ = []
 
-        res0 = self.targobj.filter([{'j': 0}, {}])
-        res1 = self.targobj.filter({}, ttype=0)
-        res2 = self.targobj.filter([{}], ttype=0)
+        res0 = self.targobj.filter([{'j': 5}, {}])
+        res1 = self.targobj.filter({}, ttype=6)
+        res2 = self.targobj.filter([{}], ttype=6)
         res3 = self.targobj.filter({'name': self.epcs1a[1].name}, j=0)
         res4 = self.targobj.filter(targdict={'name': self.epcs1a[1].name},
                                    j=0)
@@ -473,6 +484,20 @@ class TestSegment(unittest.TestCase):
         assert_same_sub_schema(res3, targ)
         assert_same_sub_schema(res4, targ)
         assert_same_sub_schema(res5, targ)
+
+    def test__filter_no_annotation_but_object(self):
+        targ = self.targobj.spiketrains
+        res = self.targobj.filter(objects=SpikeTrain)
+        assert_same_sub_schema(res, targ)
+
+        targ = self.targobj.analogsignals
+        res = self.targobj.filter(objects=AnalogSignal)
+        assert_same_sub_schema(res, targ)
+
+        targ = self.targobj.analogsignals + self.targobj.spiketrains
+        res = self.targobj.filter(objects=[AnalogSignal, SpikeTrain])
+        assert_same_sub_schema(res, targ)
+        assert_same_sub_schema(res, targ)
 
     def test__filter_single_annotation_obj_single(self):
         targ = [self.epcs1a[1]]
@@ -617,7 +642,7 @@ class TestSegment(unittest.TestCase):
 
         targ = []
 
-        res0 = filterdata(data, [{'j': 0}, {}])
+        res0 = filterdata(data, [{'j': 5}, {}])
         res1 = filterdata(data, {}, ttype=0)
         res2 = filterdata(data, [{}], ttype=0)
         res3 = filterdata(data, {'name': self.epcs1a[1].name}, j=0)

--- a/neo/test/coretest/test_segment.py
+++ b/neo/test/coretest/test_segment.py
@@ -325,11 +325,6 @@ class TestSegment(unittest.TestCase):
         targ.extend(self.targobj.irregularlysampledsignals)
         targ.extend(self.targobj.spiketrains)
 
-
-        # for unit in self.targobj.units:
-        #     targ.extend(unit.spiketrains)
-
-
         res0 = self.targobj.filter()
         res1 = self.targobj.filter({})
         res2 = self.targobj.filter([])

--- a/neo/test/coretest/test_unit.py
+++ b/neo/test/coretest/test_unit.py
@@ -207,7 +207,7 @@ class TestUnit(unittest.TestCase):
         self.assertEqual(self.targobj.size, targ)
 
     def test__filter_none(self):
-        targ = []
+        targ = self.targobj.spiketrains
 
         res1 = self.targobj.filter()
         res2 = self.targobj.filter({})
@@ -302,8 +302,8 @@ class TestUnit(unittest.TestCase):
 
         name0 = self.trains2[0].name
         res0 = self.targobj.filter([{'j': 5}, {}])
-        res1 = self.targobj.filter({}, j=0)
-        res2 = self.targobj.filter([{}], i=0)
+        res1 = self.targobj.filter({}, j=5)
+        res2 = self.targobj.filter([{}], i=5)
         res3 = self.targobj.filter({'name': name0}, j=1)
         res4 = self.targobj.filter(targdict={'name': name0}, j=1)
         res5 = self.targobj.filter(name=name0, targdict={'j': 1})
@@ -350,6 +350,11 @@ class TestUnit(unittest.TestCase):
         assert_same_sub_schema(res3, targ)
         assert_same_sub_schema(res4, targ)
         assert_same_sub_schema(res5, targ)
+
+    def test__filter_no_annotation_but_object(self):
+        targ = self.targobj.spiketrains
+        res = self.targobj.filter(objects=SpikeTrain)
+        assert_same_sub_schema(res, targ)
 
     def test__filter_single_annotation_obj_single(self):
         targ = [self.trains1a[1]]
@@ -478,9 +483,9 @@ class TestUnit(unittest.TestCase):
 
         name1 = self.trains1a[0].name
         name2 = self.trains2[0].name
-        res0 = filterdata(data, [{'j': 0}, {}])
-        res1 = filterdata(data, {}, i=0)
-        res2 = filterdata(data, [{}], i=0)
+        res0 = filterdata(data, [{'j': 5}, {}])
+        res1 = filterdata(data, {}, i=5)
+        res2 = filterdata(data, [{}], i=5)
         res3 = filterdata(data, name=name1, targdict={'j': 1})
         res4 = filterdata(data, {'name': name1}, j=1)
         res5 = filterdata(data, targdict={'name': name1}, j=1)


### PR DESCRIPTION
Closes issue #493

This allows to filter for objects of a specific type without specifying another filter attribute.
Previously filters like ```targdict={}, object=neo.SpikeTrain``` returned an empty list, where as now this returns all SpikeTrain objects available.