### PR TITLE
Proposal: add channel_names/ids in AnalogSignal when channel are grouped

### DIFF
--- a/neo/io/basefromrawio.py
+++ b/neo/io/basefromrawio.py
@@ -297,10 +297,13 @@ class BaseFromRaw(BaseIO):
                             annotations['name'] = signal_channels['name'][chan_index]
                     else:
                         # when channel are grouped by same unit
-                        # annotations are empty...
+                        # annotations have channel_names and channel_ids array
+                        # this will be moved in array annotations soon
                         annotations = {}
                         annotations['name'] = 'Channel bundle ({}) '.format(
                             ','.join(signal_channels[ind_abs]['name']))
+                        annotations['channel_names'] = signal_channels[ind_abs]['name']
+                        annotations['channel_ids'] = signal_channels[ind_abs]['id']
                     annotations = check_annotations(annotations)
                     if lazy:
                         anasig = AnalogSignal(np.array([]), units=units,  copy=False,


### PR DESCRIPTION
Last minut proposal for 0.6: add channel_names and channel_ids in AnalogSignal when channel are grouped.

For beginner it is easier to have directly channel_names in AnalogSignal than in ChannelIndexes.

Example:
```python
reader = neo.MicromedIO(filename='myfilen.trc')
seg = reader.read_segment()
anasig = seg.analogsignals[0] # this have all channels
print(anasig.annotations['channel_names']) # this print all channels
```

This behavior will be superseded by array_annotaiont but it is cool to have then in 0.6.

