### PR TITLE
[MRG] Add explicit _repr_pretty_ for events, epochs and spiketrains.

### DIFF
--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -151,6 +151,9 @@ class Epoch(BaseNeo, pq.Quantity):
                 label, time, dur in zip(labels, self.times, self.durations)]
         return '<Epoch: %s>' % ', '.join(objs)
 
+    def _repr_pretty_(self, pp, cycle):
+        super(Epoch, self)._repr_pretty_(pp, cycle)
+
     def rescale(self, units):
         '''
         Return a copy of the :class:`Epoch` converted to the specified

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -142,6 +142,9 @@ class Event(BaseNeo, pq.Quantity):
                                                                self.times)]
         return '<Event: %s>' % ', '.join(objs)
 
+    def _repr_pretty_(self, pp, cycle):
+        super(Event, self)._repr_pretty_(pp, cycle)
+
     def rescale(self, units):
         '''
         Return a copy of the :class:`Event` converted to the specified

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -327,6 +327,9 @@ class SpikeTrain(BaseNeo, pq.Quantity):
         BaseNeo.__init__(self, name=name, file_origin=file_origin,
                          description=description, **annotations)
 
+    def _repr_pretty_(self, pp, cycle):
+        super(SpikeTrain, self)._repr_pretty_(pp, cycle)
+
     def rescale(self, units):
         '''
         Return a copy of the :class:`SpikeTrain` converted to the specified


### PR DESCRIPTION
This PR fixes the unittests failing due to the ipython version 6.3.1 (#518).

The problem was that event, epoch and spiketrain objects were inheriting the _repr_pretty_ method from baseneo, but this is not used in the new ipython version, since it is not listed in the __dict__. A quick solution is to explicitely have the _repr_pretty_ being listed in the neo.Event.__dict__ by implementing it in the corresponding classes.
I am not sure if this is the best way to solve this issue, as it introduces changes in 3 classes, even though the problem seems to be a central one. I would be happy about alternative ideas to solve the issue.