### PR TITLE
extract epoch based signal

### DIFF
--- a/neo/core/basesignal.py
+++ b/neo/core/basesignal.py
@@ -326,7 +326,7 @@ class BaseSignal(BaseNeo, pq.Quantity):
     def extract_for_epoch(self, epoch):
         """
         Checks self (which is the instance, neo.AnalogSignal or neo.SpikeTrain) for
-        specified neo.Epoch and returns signals for respetive epochs within neo.Epoch
+        specified neo.Epoch and returns signals for respective epochs within neo.Epoch
 
         Arguments:
         epoch; a created neo.Epoch


### PR DESCRIPTION
Added two methods within the class `BaseSignal` these are: (staticmethod) `_rescale_epoch_time` and `extract_for_epoch`. Therefore when a neo object signal is created (which in turn is an instance of the child class of `BaseSignal`) it has the method `extract_for_epoch`. Passing the epochs (created neo.Epoch) into this method will return a list of extracted signals (specific to the epochs).
```
>>> import neo
>>> import quantities as pq
>>> import numpy as np
>>> sigarr = neo.AnalogSignal([[1], [2], [3], [4], [5], [6]], units='mV',
                              sampling_rate=1*pq.Hz)
>>> epc = neo.Epoch(times=np.array([0, 3000])*pq.ms, durations=[1000, 2000]*pq.ms,
                    labels=np.array(['btn0', 'btn1'], dtype='S'))
>>> epochsignals = sigarr.extract_for_epoch(epc)
>>> epochsignals
[<AnalogSignal(array([[1]]) * mV, [0.0 s, 1.0 s], sampling rate: 1.0 Hz)>,
 <AnalogSignal(array([], shape=(0, 1), dtype=int64) * mV, [3.0 s, 3.0 s],
 sampling rate: 1.0 Hz)>]
>>> len(epochsignals)
2
>>> epochsignals[0]
<AnalogSignal(array([[1]]) * mV, [0.0 s, 1.0 s], sampling rate: 1.0 Hz)>
```