### PR TITLE
Nixio object rewrite

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -195,7 +195,7 @@ class NixIO(BaseIO):
         elif neoname is not None:
             for blk in self.nix_file.blocks:
                 if ("neo_name" in blk.metadata
-                    and blk.metadata["neo_name"] == neoname):
+                        and blk.metadata["neo_name"] == neoname):
                     nix_block = blk
                     break
             else:
@@ -1014,11 +1014,13 @@ class NixIO(BaseIO):
         for chx in neoblock.channel_indexes:
             signames = []
             for asig in chx.analogsignals:
-                if "nix_name" not in asig.annotations:
+                if not ("nix_name" in asig.annotations and
+                        asig.annotations["nix_name"] in self._signal_map):
                     self._write_analogsignal(asig, nixblock, None)
                 signames.append(asig.annotations["nix_name"])
             for isig in chx.irregularlysampledsignals:
-                if "nix_name" not in isig.annotations:
+                if not ("nix_name" in isig.annotations and
+                        isig.annotations["nix_name"] in self._signal_map):
                     self._write_irregularlysampledsignal(isig, nixblock, None)
                 signames.append(isig.annotations["nix_name"])
             chxsource = nixblock.sources[chx.annotations["nix_name"]]
@@ -1029,7 +1031,8 @@ class NixIO(BaseIO):
             for unit in chx.units:
                 unitsource = chxsource.sources[unit.annotations["nix_name"]]
                 for st in unit.spiketrains:
-                    if "nix_name" not in st.annotations:
+                    if not ("nix_name" in st.annotations and
+                            st.annotations["nix_name"] in nixblock.multi_tags):
                         self._write_spiketrain(st, nixblock, None)
                     stmt = nixblock.multi_tags[st.annotations["nix_name"]]
                     stmt.sources.append(chxsource)

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -960,16 +960,87 @@ class NixIOWriteTest(NixIOTest):
         chidx.units.append(unit)
         unit.spiketrains.extend([sta, stb])
         self.writer.write_block(blk)
+        self.writer.close()
 
         self.compare_blocks([blk], self.reader.blocks)
 
-        self.writer.close()
         reader = NixIO(self.filename, "ro")
         blk = reader.read_block(neoname="segmentless block")
         chx = blk.channel_indexes[0]
         self.assertEqual(len(chx.analogsignals), 1)
         self.assertEqual(len(chx.irregularlysampledsignals), 1)
         self.assertEqual(len(chx.units[0].spiketrains), 2)
+
+    def test_rewrite_refs(self):
+
+        def checksignalcounts(fname):
+            with NixIO(fname, "ro") as r:
+                blk = r.read_block()
+            chidx = blk.channel_indexes[0]
+            seg = blk.segments[0]
+            self.assertEqual(len(chidx.analogsignals), 2)
+            self.assertEqual(len(chidx.units[0].spiketrains), 3)
+            self.assertEqual(len(seg.analogsignals), 1)
+            self.assertEqual(len(seg.spiketrains), 1)
+
+        blk = Block()
+        # ChannelIndex
+        chidx = ChannelIndex(index=[1])
+        blk.channel_indexes.append(chidx)
+
+        # Two signals on ChannelIndex
+        for idx in range(2):
+            asigchx = AnalogSignal(signal=[idx], units="mV",
+                                   sampling_rate=pq.Hz)
+            chidx.analogsignals.append(asigchx)
+
+        # Unit
+        unit = Unit()
+        chidx.units.append(unit)
+
+        # Three SpikeTrains on Unit
+        for idx in range(3):
+            st = SpikeTrain([idx], units="ms", t_stop=40)
+            unit.spiketrains.append(st)
+
+        # Segment
+        seg = Segment()
+        blk.segments.append(seg)
+
+        # One signal on Segment
+        asigseg = AnalogSignal(signal=[2], units="uA",
+                               sampling_rate=pq.Hz)
+        seg.analogsignals.append(asigseg)
+
+        # One spiketrain on Segment
+        stseg = SpikeTrain([10], units="ms", t_stop=40)
+        seg.spiketrains.append(stseg)
+
+        # Write, compare, and check counts
+        self.writer.write_block(blk)
+        self.compare_blocks([blk], self.reader.blocks)
+        self.assertEqual(len(chidx.analogsignals), 2)
+        self.assertEqual(len(seg.analogsignals), 1)
+        self.assertEqual(len(chidx.analogsignals), 2)
+        self.assertEqual(len(chidx.units[0].spiketrains), 3)
+        self.assertEqual(len(seg.analogsignals), 1)
+        self.assertEqual(len(seg.spiketrains), 1)
+
+        # Check counts with separate reader
+        checksignalcounts(self.filename)
+
+        # Write again and check counts
+        secondwrite = os.path.join(self.tempdir, "testnixio-2.nix")
+        with NixIO(secondwrite, "ow") as w:
+            w.write_block(blk)
+
+        self.compare_blocks([blk], self.reader.blocks)
+
+        # Read back and check counts
+        scndreader = nix.File.open(secondwrite, mode=nix.FileMode.ReadOnly,
+                                   backend="h5py")
+        self.compare_blocks([blk], scndreader.blocks)
+        checksignalcounts(secondwrite)
 
     def test_to_value(self):
         section = self.io.nix_file.create_section("Metadata value test",


### PR DESCRIPTION
The `nix_name` annotation was mistakenly used to determine if an object had already been written. This PR fixes the writer to check the actual contents of the file or the `_signal_map`, a dictionary it keeps to be able to reference groups of signal objects by name that's created during the writing of a Block.

The issue arises when an object has been annotated by a previous write or from being read from a different file, which was the underlying cause of issue #535. 