### PR TITLE
nixio doesn't support lazy loading.

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -199,7 +199,7 @@ class NixIO(BaseIO):
         elif neoname is not None:
             for blk in self.nix_file.blocks:
                 if ("neo_name" in blk.metadata
-                    and blk.metadata["neo_name"] == neoname):
+                        and blk.metadata["neo_name"] == neoname):
                     nix_block = blk
                     break
             else:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -156,7 +156,9 @@ class NixIO(BaseIO):
     def __exit__(self, *args):
         self.close()
 
-    def read_all_blocks(self):
+    def read_all_blocks(self, lazy=False):
+        if lazy:
+            raise Exception("Lazy loading is not supported for NixIO")
         return list(self._nix_to_neo_block(blk)
                     for blk in self.nix_file.blocks)
 
@@ -186,7 +188,9 @@ class NixIO(BaseIO):
         :param nixname: The name of the Block in NIX
         :param neoname: The name of the original Neo Block
         """
-        assert not lazy, "Lazy loading not supported"
+        if lazy:
+            raise Exception("Lazy loading is not supported for NixIO")
+
         nix_block = None
         if index is not None:
             nix_block = self.nix_file.blocks[index]


### PR DESCRIPTION
After installing Neo 0.6.1, I tried to load a Nix file using Neo with the following lines:

```py
neo_file = NixIO(filename, "ro")
block = neo_file.read()
```

which prompted the following error:
```
Traceback (most recent call last):
  File "C:/Users/CPL/PycharmProjects/ephys_analysis/ephys_analysis/free_playground.py", line 85, in <module>
    raw_signal = get_electrode_data(h5_filename, LFP_electrode_name)
  File "C:\Users\CPL\PycharmProjects\ephys_analysis\ephys_analysis\elephant_main.py", line 21, in get_electrode_data
    block = neo_file.read()
  File "C:\python_venv\lib\site-packages\neo\io\baseio.py", line 116, in read
    return self.read_all_blocks(lazy=lazy, **kargs)
TypeError: read_all_blocks() got an unexpected keyword argument 'lazy'
```
I fixed this error by adding the lazy keyword to the `read_all_blocks()` function. While this bypasses the error, the lazy keyword is still going to raise an exception if set to `True`, because Nix does not support lazy loading.
Additionally, we changed the assert to an exception because we are value checking, and an assert is not appropriate for this.