### PR TITLE
Make Unittests fail if the required data are unavailable

### DIFF
--- a/neo/rawio/tests/tools.py
+++ b/neo/rawio/tests/tools.py
@@ -12,9 +12,9 @@ import shutil
 import tempfile
 
 try:
-    from urllib import urlretrieve  # Py2
+    from urllib2 import urlopen
 except ImportError:
-    from urllib.request import urlretrieve  # Py3
+    from urllib.request import urlopen
 
 
 def can_use_network():
@@ -66,7 +66,9 @@ def download_test_file(filename, localdir, url):
 
     if not os.path.exists(localfile):
         logging.info('Downloading %s here %s', distantfile, localfile)
-        urlretrieve(distantfile, localfile)
+        dist = urlopen(distantfile)
+        with open(localfile, 'wb') as f:
+            f.write(dist.read())
 
 
 def create_local_temp_dir(name, directory=None):

--- a/neo/test/iotest/common_io_test.py
+++ b/neo/test/iotest/common_io_test.py
@@ -130,7 +130,7 @@ class BaseTestIO(object):
             download_test_file(self.files_to_download,
                                self.local_test_dir, url)
         except IOError as exc:
-            raise unittest.TestCase.failureException()
+            raise unittest.TestCase.failureException(exc)
 
     download_test_files_if_not_present.__test__ = False
 

--- a/neo/test/iotest/common_io_test.py
+++ b/neo/test/iotest/common_io_test.py
@@ -130,7 +130,7 @@ class BaseTestIO(object):
             download_test_file(self.files_to_download,
                                self.local_test_dir, url)
         except IOError as exc:
-            raise unittest.SkipTest(exc)
+            raise unittest.TestCase.failureException()
 
     download_test_files_if_not_present.__test__ = False
 


### PR DESCRIPTION
In the current state (in Python3, Python2 see below) when a file that is required for testing is unvailable on gin (e.g. Error 404), the unittest will just be skipped. This means, in case only a single file required for one test class is not available, the whole class of tests will just be skipped. Consequently, if there was a failure on gin, all IO tests (and any other tests requiring data from gin) would just be skipped. So CircleCI would just mark every pull request that only makes changes to IO as correct (Skipped tests mean the overall test is passed). This could even go unnoticed for quite a while, so it's probably better to make tests fail and explicitly state that something is wrong about the data. This is done in this pull request.

Apart from that, in Python 2.7 when a file was unavailable, no error would occur. Instead, the file would be created as an HTML file containing the 404 Error page you would see in a browser. So I changed the code that downloads the files to use urllib2.urlopen instead urllib.urlretrieve.

In general, this pull request should make tests fail whenever files required for those tests are requested from a server but could not be downloaded.