### PR TITLE
NIXIO data ordering fix

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -374,7 +374,6 @@ class NixIO(BaseIO):
         :param nix_da_group: a list of NIX DataArray objects
         :return: a Neo AnalogSignal object
         """
-        nix_da_group = sorted(nix_da_group, key=lambda d: d.name)
         neo_attrs = self._nix_attr_to_neo(nix_da_group[0])
         metadata = nix_da_group[0].metadata
         neo_attrs["nix_name"] = metadata.name  # use the common base name
@@ -418,7 +417,6 @@ class NixIO(BaseIO):
         :param nix_da_group: a list of NIX DataArray objects
         :return: a Neo IrregularlySampledSignal object
         """
-        nix_da_group = sorted(nix_da_group, key=lambda d: d.name)
         neo_attrs = self._nix_attr_to_neo(nix_da_group[0])
         metadata = nix_da_group[0].metadata
         neo_attrs["nix_name"] = metadata.name  # use the common base name
@@ -1151,9 +1149,6 @@ class NixIO(BaseIO):
         :return: A dictionary mapping a base name to a list of DataArrays which
         belong to the same Signal
         """
-        # first sort by name
-        dataarrays = sorted(dataarrays, key=lambda x: x.name)
-
         # now start grouping
         groups = dict()
         for da in dataarrays:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -1127,7 +1127,9 @@ class NixIO(BaseIO):
                     values = create_quantity(values, units)
                 if len(values) == 1:
                     values = values[0]
-                if values == "" and prop.definition == EMPTYANNOTATION:
+                if (not isinstance(values, pq.Quantity) and
+                        values == "" and
+                        prop.definition == EMPTYANNOTATION):
                     values = list()
                 neo_attrs[prop.name] = values
         neo_attrs["name"] = stringify(neo_attrs.get("neo_name"))

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -182,8 +182,7 @@ class NixIOTest(unittest.TestCase):
         nixmd = nixdalist[0].metadata
         self.assertTrue(all(nixmd == da.metadata for da in nixdalist))
         neounit = neosig.units
-        for sig, da in zip(np.transpose(neosig),
-                           sorted(nixdalist, key=lambda d: d.name)):
+        for sig, da in zip(np.transpose(neosig), nixdalist):
             self.compare_attr(neosig, da)
             daquant = create_quantity(da[:], da.unit)
             np.testing.assert_almost_equal(sig, daquant)
@@ -696,7 +695,7 @@ class NixIOWriteTest(NixIOTest):
         seg = Segment()
         block.segments.append(seg)
 
-        asig = AnalogSignal(signal=self.rquant((10, 3), pq.mV),
+        asig = AnalogSignal(signal=self.rquant((19, 15), pq.mV),
                             sampling_rate=pq.Quantity(10, "Hz"))
         seg.analogsignals.append(asig)
         self.write_and_compare([block])
@@ -705,7 +704,7 @@ class NixIOWriteTest(NixIOTest):
         seg = Segment("ir signal seg")
         anotherblock.segments.append(seg)
         irsig = IrregularlySampledSignal(
-            signal=np.random.random((20, 3)),
+            signal=np.random.random((20, 30)),
             times=self.rquant(20, pq.ms, True),
             units=pq.A
         )
@@ -723,7 +722,7 @@ class NixIOWriteTest(NixIOTest):
 
         block.segments[0].irregularlysampledsignals.append(
             IrregularlySampledSignal(times=np.random.random(10),
-                                     signal=np.random.random((10, 3)),
+                                     signal=np.random.random((10, 13)),
                                      units="mV", time_units="s",
                                      dtype=np.float,
                                      name="some sort of signal",
@@ -738,7 +737,7 @@ class NixIOWriteTest(NixIOTest):
 
         units = pq.CompoundUnit("1/30000*V")
         srate = pq.Quantity(10, pq.CompoundUnit("1.0/10 * Hz"))
-        asig = AnalogSignal(signal=self.rquant((10, 3), units),
+        asig = AnalogSignal(signal=self.rquant((10, 23), units),
                             sampling_rate=srate)
         seg.analogsignals.append(asig)
 


### PR DESCRIPTION
Sorting creates issues with lexicographical ordering of numbers.
This PR removes all name-based sorting of DataArrays (signals) and lets the HDF5 creation order tracking take care of the signal order.