### PR TITLE
[nixio] Convert file_datetime to int when writing

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -529,7 +529,8 @@ class NixIO(BaseIO):
                 calculate_timestamp(block.rec_datetime)
             )
         if block.file_datetime:
-            metadata["file_datetime"] = block.file_datetime
+            fdt = calculate_timestamp(block.file_datetime)
+            metadata["file_datetime"] = fdt
         if block.annotations:
             for k, v in block.annotations.items():
                 self._write_property(metadata, k, v)
@@ -625,7 +626,8 @@ class NixIO(BaseIO):
                 calculate_timestamp(segment.rec_datetime)
             )
         if segment.file_datetime:
-            metadata["file_datetime"] = segment.file_datetime
+            fdt = calculate_timestamp(segment.file_datetime)
+            metadata["file_datetime"] = fdt
         if segment.annotations:
             for k, v in segment.annotations.items():
                 self._write_property(metadata, k, v)

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -588,9 +588,11 @@ class NixIOTest(unittest.TestCase):
         signal = cls.rquant(1, pq.V)
         blk = Block()
         blk.annotate(**cls.rdict(3))
+        cls.populate_dates(blk)
 
         seg = Segment()
         seg.annotate(**cls.rdict(4))
+        cls.populate_dates(seg)
         blk.segments.append(seg)
 
         asig = AnalogSignal(signal=signal, sampling_rate=pq.Hz)


### PR DESCRIPTION
Fix for #548. The `file_datetime` wasn't being converted along with other datetime objects during write. Included instances of `file_datetime` on Block and Segment in test.