### PR TITLE
Implement AxographIO module with tests

### DIFF
--- a/.circleci/requirements_testing.txt
+++ b/.circleci/requirements_testing.txt
@@ -4,6 +4,7 @@ igor
 klusta
 tqdm
 nixio>=1.4.3
+axographio>=0.3.1
 matplotlib
 ipython
 https://github.com/nsdf/nsdf/archive/0.1.tar.gz

--- a/doc/source/authors.rst
+++ b/doc/source/authors.rst
@@ -38,6 +38,7 @@ and may not be the current affiliation of a contributor.
 * Matthieu Sénoville [2]
 * Chadwick Boulay [16]
 * Björn Müller [13]
+* William Hart [17]
 
 
 1. Centre de Recherche en Neuroscience de Lyon, CNRS UMR5292 - INSERM U1028 - Universite Claude Bernard Lyon 1
@@ -56,6 +57,6 @@ and may not be the current affiliation of a contributor.
 14. University of Texas at Austin
 15. Arizona State University
 16. Ottawa Hospital Research Institute, Canada
-
+17. Swinburne University of Technology, Australia
 
 If we've somehow missed you off the list we're very sorry - please let us know.

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -21,6 +21,8 @@ Classes:
 
 .. autoclass:: neo.io.AsciiSpikeTrainIO
 
+.. autoclass:: neo.io.AxographIO
+
 .. autoclass:: neo.io.AxonIO
 
 .. autoclass:: neo.io.BCI2000IO
@@ -103,6 +105,7 @@ from neo.io.alphaomegaio import AlphaOmegaIO
 from neo.io.asciisignalio import AsciiSignalIO
 from neo.io.asciispiketrainio import AsciiSpikeTrainIO
 from neo.io.axonio import AxonIO
+from neo.io.axographio import AxographIO
 from neo.io.blackrockio import BlackrockIO
 from neo.io.blackrockio_v4 import BlackrockIO as OldBlackrockIO
 from neo.io.bci2000io import BCI2000IO
@@ -140,6 +143,7 @@ iolist = [
     AsciiSignalIO,
     AsciiSpikeTrainIO,
     AxonIO,
+    AxographIO,
     BCI2000IO,
     BlackrockIO,
     BrainVisionIO,

--- a/neo/io/axographio.py
+++ b/neo/io/axographio.py
@@ -1,0 +1,147 @@
+"""
+README
+===============================================================================
+This is an adapter to represent axographio objects as neo objects.
+
+axographio is a file i/o Python module that can read in axograph ".axgx" files.
+It is available under a BSD-3-Clause license and can be installed from pip.
+The following file types are supported:
+
+ - AXGX/AXGD (Axograph X file format)
+
+Based on stimfitio.pyfrom neo.io
+
+11 JUL 2018, W. Hart, Swinburne University, Australia
+"""
+
+# needed for python 3 compatibility
+from __future__ import absolute_import
+
+from datetime import datetime
+import os
+import re
+import sys
+
+import numpy as np
+import quantities as pq
+
+from neo.io.baseio import BaseIO
+from neo.core import Block, Segment, AnalogSignal
+
+try:
+    import axographio
+except ImportError as err:
+    HAS_AXOGRAPHIO = False
+    AXOGRAPHIO_ERR = err
+else:
+    HAS_AXOGRAPHIO = True
+    AXOGRAPHIO_ERR = None
+
+
+class AxographIO(BaseIO):
+    """
+    Class for converting an Axographio object to a Neo object.
+    Provides a standardized representation of the data as defined by the neo
+    project; this is useful to explore the data with an increasing number of
+    electrophysiology software tools that rely on the Neo standard.
+
+    axographio is a file i/o Python module that can read in axograph ".axgx" files.
+    It is available under a BSD-3-Clause license and can be installed from pip.
+    The following file types are supported:
+
+    - AXGX/AXGD (Axograph X file format)
+
+    Example usage:
+        >>> import neo
+        >>> neo_obj = neo.io.AxographIO("file.axgx")
+        or
+        >>> import axographio
+        >>> axo_obj = axographio.read("file.axgx")
+        >>> neo_obj = neo.io.AxographIO(axo_obj)
+    """
+
+    is_readable = True
+    is_writable = False
+
+    supported_objects = [Block, Segment, AnalogSignal]
+    readable_objects = [Block]
+    writeable_objects = []
+
+    has_header = False
+    is_streameable = False
+
+    read_params = {Block: []}
+    write_params = None
+
+    name = 'AXOGRAPH'
+    extensions = ['axgx', 'axgd']
+
+    mode = 'file'
+
+    def __init__(self, filename=None):
+        """
+        Arguments:
+            filename : Either a filename or an axographio object
+        """
+        if not HAS_AXOGRAPHIO:
+            raise AXOGRAPHIO_ERR
+
+        BaseIO.__init__(self)
+
+        if hasattr(filename, 'lower'):
+            self.filename = filename
+            self.axo_obj = None
+        else:
+            self.axo_obj = filename
+            self.filename = None
+
+    def read_block(self, **kargs):
+        if self.filename is not None:
+            self.axo_obj = axographio.read(self.filename)
+
+        # Build up the block
+        blk = Block()
+
+        blk.rec_datetime = None
+        if self.filename is not None:
+            # modified time is not ideal but less prone to
+            # cross-platform issues than created time (ctime)
+            blk.file_datetime = datetime.fromtimestamp(os.path.getmtime(self.filename))
+
+        # determine the channel names and counts
+        channel_names = np.unique(self.axo_obj.names[1:])
+        channel_count = len(channel_names)
+
+        # determine the time signal and sample rate
+        sample_rate = 1 / ((self.axo_obj.data[0][1] - self.axo_obj.data[0][0]) * pq.s)
+        start_time = 0 * pq.s
+
+        # Attempt to read units from the channel names
+        unit_regex = re.compile(r"\((.*?)\)")
+        channel_unit_names = [unit_regex.search(x).group(1) for x in channel_names]
+        channel_units = []
+
+        for unit in channel_unit_names:
+            try:
+                channel_units.append(pq.Quantity(1, unit))
+            except LookupError:
+                channel_units.append(None)
+
+        # build up segments by grouping axograph columns
+        for seg_idx in range(1, len(self.axo_obj.data), channel_count):
+            seg = Segment(index=seg_idx)
+
+            # add in the channels
+            for chan_idx in range(0, channel_count):
+                signal = pq.Quantity(
+                    self.axo_obj.data[seg_idx + chan_idx], channel_units[chan_idx])
+                analog = AnalogSignal(signal,
+                                      sampling_rate=sample_rate, t_start=start_time,
+                                      name=channel_names[chan_idx], channel_index=chan_idx)
+                seg.analogsignals.append(analog)
+
+            blk.segments.append(seg)
+
+        blk.create_many_to_one_relationship()
+
+        return blk

--- a/neo/test/iotest/test_axographio.py
+++ b/neo/test/iotest/test_axographio.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+Tests of neo.io.axographio
+"""
+
+# needed for python 3 compatibility
+from __future__ import absolute_import
+
+import sys
+
+import unittest
+
+from neo.io import AxographIO
+from neo.io.axographio import HAS_AXOGRAPHIO
+from neo.test.iotest.common_io_test import BaseTestIO
+
+
+@unittest.skipUnless(HAS_AXOGRAPHIO, "requires axographio")
+class TestAxographIO(BaseTestIO, unittest.TestCase):
+    files_to_test = [
+        'File_axograph.axgd'
+    ]
+    files_to_download = files_to_test
+    ioclass = AxographIO
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extras_require = {
     'neomatlabio': ['scipy>=0.12.0'],
     'nixio': ['nixio>=1.4.3'],
     'stimfitio': ['stfio'],
+    'axographio': ['axographio']
 }
 
 if os.environ.get('TRAVIS') == 'true' and \


### PR DESCRIPTION
This PR proposes an IO class for reading from AXGX and AXGD files using [`axographio`](https://github.com/CWRUChielLab/axographio). It provides an alternative to `StimfitIO` for importing axograph files which may be a bit easier to get up and running, particularly on Windows.