### PR TITLE
Fix reading blackrock digital events.

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -1854,18 +1854,18 @@ class BlackrockRawIO(BaseRawIO):
         a 2.3 nev file.
         """
         # digital events
+        if not np.all(np.in1d(data['packet_insertion_reason'], [1,129])):
+            raise ValueError('Unknown event codes found.')  # Blackrock spec gives reason==64 means PERIODIC, but never seen this live
         event_types = {
             'digital_input_port': {
                 'name': 'digital_input_port',
                 'field': 'digital_input',
-                'mask': self.__is_set(data['packet_insertion_reason'], 0),
+                'mask': data['packet_insertion_reason'] == 1,
                 'desc': "Events of the digital input port"},
             'serial_input_port': {
                 'name': 'serial_input_port',
                 'field': 'digital_input',
-                'mask':
-                    self.__is_set(data['packet_insertion_reason'], 0) &
-                    self.__is_set(data['packet_insertion_reason'], 7),
+                'mask': data['packet_insertion_reason'] == 129,
                 'desc': "Events of the serial input port"}}
 
         return event_types


### PR DESCRIPTION
Blackrock specs say packet_insertion_reason is
1 for PARALLEL and 129 for SERIAL.  (also 64 for PERIODIC, not implemented)
i.e. bit 1 is set for parallel and bits 1 and 7 are set for serial.

Because the bitfield is just a unique ID, I removed the bit testing and use equality instead.


------------------------
Apologies: I didn't write tests for this code.  But this fixes a bug where both parallel and serial events were being returned as parallel due to the bit testing above.