### PR TITLE
New RawIO for NIX files

### DIFF
--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -128,6 +128,7 @@ from neo.io.neuralynxio_v1 import NeuralynxIO as OldNeuralynxIO
 from neo.io.neuroexplorerio import NeuroExplorerIO
 from neo.io.neuroscopeio import NeuroScopeIO
 from neo.io.nixio import NixIO
+from neo.io.nixio_fr import NixIO as NixIOFr
 from neo.io.nsdfio import NSDFIO
 from neo.io.pickleio import PickleIO
 from neo.io.plexonio import PlexonIO

--- a/neo/io/nixio_fr.py
+++ b/neo/io/nixio_fr.py
@@ -19,5 +19,6 @@ class NixIO(NIXRawIO, BaseFromRaw):
         return self
 
     def __exit__(self, *args):
+        self.header = None
         self.file.close()
-        NIXRawIO.header = None
+

--- a/neo/io/nixio_fr.py
+++ b/neo/io/nixio_fr.py
@@ -9,7 +9,7 @@ class NixIO(NIXRawIO, BaseFromRaw):
     name = 'NIX IO'
 
     _prefered_signal_group_mode = 'group-by-same-units'
-    _prefered_units_group_mode = 'all-in-one'
+    _prefered_units_group_mode = 'split-all'
 
     def __init__(self, filename):
         NIXRawIO.__init__(self, filename)

--- a/neo/io/nixio_fr.py
+++ b/neo/io/nixio_fr.py
@@ -1,7 +1,7 @@
 from neo.io.basefromrawio import BaseFromRaw
 from neo.rawio.nixrawio import NIXRawIO
 
-#This class subjects to limitations when there are multiple asymmetric blocks
+# This class subjects to limitations when there are multiple asymmetric blocks
 
 
 class NixIO(NIXRawIO, BaseFromRaw):

--- a/neo/io/nixio_fr.py
+++ b/neo/io/nixio_fr.py
@@ -14,3 +14,10 @@ class NixIO(NIXRawIO, BaseFromRaw):
     def __init__(self, filename):
         NIXRawIO.__init__(self, filename)
         BaseFromRaw.__init__(self, filename)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.file.close()
+        NIXRawIO.header = None

--- a/neo/io/nixio_fr.py
+++ b/neo/io/nixio_fr.py
@@ -1,0 +1,16 @@
+from neo.io.basefromrawio import BaseFromRaw
+from neo.rawio.nixrawio import NIXRawIO
+
+#This class subjects to limitations when there are multiple asymmetric blocks
+
+
+class NixIO(NIXRawIO, BaseFromRaw):
+
+    name = 'NIX IO'
+
+    _prefered_signal_group_mode = 'group-by-same-units'
+    _prefered_units_group_mode = 'all-in-one'
+
+    def __init__(self, filename):
+        NIXRawIO.__init__(self, filename)
+        BaseFromRaw.__init__(self, filename)

--- a/neo/rawio/__init__.py
+++ b/neo/rawio/__init__.py
@@ -19,6 +19,7 @@ from neo.rawio.micromedrawio import MicromedRawIO
 from neo.rawio.neuralynxrawio import NeuralynxRawIO
 from neo.rawio.neuroexplorerrawio import NeuroExplorerRawIO
 from neo.rawio.neuroscoperawio import NeuroScopeRawIO
+from neo.rawio.nixrawio import NIXRawIO
 from neo.rawio.plexonrawio import PlexonRawIO
 from neo.rawio.rawbinarysignalrawio import RawBinarySignalRawIO
 from neo.rawio.spike2rawio import Spike2RawIO
@@ -35,6 +36,7 @@ rawiolist = [
     NeuralynxRawIO,
     NeuroExplorerRawIO,
     NeuroScopeRawIO,
+    NIXRawIO,
     PlexonRawIO,
     RawBinarySignalRawIO,
     Spike2RawIO,

--- a/neo/rawio/nixrawio.py
+++ b/neo/rawio/nixrawio.py
@@ -20,7 +20,7 @@ except ImportError:
     nix = None
 
 
-class NixRawIO (BaseRawIO):
+class NIXRawIO (BaseRawIO):
 
     extensions = ['nix']
     rawmode = 'one-file'

--- a/neo/rawio/nixrawio.py
+++ b/neo/rawio/nixrawio.py
@@ -1,0 +1,314 @@
+"""
+RawIO Class for NIX files
+
+The RawIO assumes all segments and all blocks have the same structure. It supports all kinds of NEO objects.
+
+Author: Chek Yin Choi
+"""
+
+from __future__ import print_function, division, absolute_import
+from neo.rawio.baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype, _event_channel_dtype)
+import numpy as np
+import nixio as nix
+
+
+class NIXRawIO (BaseRawIO):
+
+    extensions = ['nix']
+    rawmode = 'one-file'
+
+    def __init__(self, filename=''):
+        BaseRawIO.__init__(self)
+        self.filename = filename
+        print(filename)
+
+    def _source_name(self):
+        return self.filename
+
+    def _parse_header(self):
+
+        self.file = nix.File.open(self.filename, nix.FileMode.ReadOnly)
+        channel_name = []
+        for blk in self.file.blocks:
+            for ch, src in enumerate(blk.sources):
+                channel_name.append(src.name)
+            break
+        sig_channels = []
+        for bl in self.file.blocks:
+            for seg in bl.groups:
+                for da in seg.data_arrays:
+                    if da.type == "neo.analogsignal":
+                        nixname = da.name
+                        nixidx = int(nixname.split('.')[-1])
+                        src = da.sources[0].sources[nixidx]
+                        chan_id = src.metadata['channel_id']
+                        ch_name = src.metadata['neo_name']
+                        units = str(da.unit)
+                        dtype = str(da.dtype)
+                        sr = 1 / da.dimensions[0].sampling_interval
+                        group_id = 0
+                        for cid, name in enumerate(channel_name):
+                            if name == da.sources[0].name:
+                                group_id = cid  # very important! group_id use to store channel groups!!!
+                                # use only for different signal length
+                        gain = 1
+                        offset = 0.
+                        sig_channels.append((ch_name, chan_id, sr, dtype, units, gain, offset, group_id))
+                break
+            break
+        sig_channels = np.array(sig_channels, dtype=_signal_channel_dtype)
+
+        unit_channels = []
+        unit_name = ""
+        unit_id = ""
+        for bl in self.file.blocks:
+            for seg in bl.groups:
+                for mt in seg.multi_tags:
+                    if mt.type == "neo.spiketrain":
+                        for usrc in mt.sources:
+                            if usrc.type == "neo.unit":
+                                unit_name = usrc.metadata['neo_name']
+                                unit_id = usrc.id
+                                continue
+                        wf_units = mt.features[0].data.unit
+                        wf_gain = 1
+                        wf_offset = 0.
+                        if "left_sweep" in mt.features[0].data.metadata:
+                            wf_left_sweep = mt.features[0].data.metadata["left_sweep"]
+                        else:
+                            wf_left_sweep = 0
+                        wf_sampling_rate = 1 / mt.features[0].data.dimensions[2].sampling_interval
+                        unit_channels.append((unit_name, unit_id, wf_units, wf_gain,
+                                              wf_offset, wf_left_sweep, wf_sampling_rate))
+                break
+            break
+        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+
+        event_channels = []
+        event_count = 0
+        epoch_count = 0
+        for bl in self.file.blocks:
+            for seg in bl.groups:
+                for mt in seg.multi_tags:
+                    if mt.type == "neo.event":
+                        ev_name = mt.metadata['neo_name']
+                        ev_id = event_count
+                        event_count += 1
+                        ev_type = "event"
+                        event_channels.append((ev_name, ev_id, ev_type))
+                    if mt.type == "neo.epoch":
+                        ep_name = mt.metadata['neo_name']
+                        ep_id = epoch_count
+                        epoch_count += 1
+                        ep_type = "epoch"
+                        event_channels.append((ep_name, ep_id, ep_type))
+                break
+            break
+        event_channels = np.array(event_channels, dtype=_event_channel_dtype)
+
+        self.da_list = {'blocks': []}
+        for block_index, blk in enumerate(self.file.blocks):
+            d = {'segments': []}
+            self.da_list['blocks'].append(d)
+            for seg_index, seg in enumerate(blk.groups):
+                d = {'signals': []}
+                self.da_list['blocks'][block_index]['segments'].append(d)
+                size_list = []
+                data_list = []
+                ch_name_list = []
+                for da in seg.data_arrays:
+                    if da.type == 'neo.analogsignal':
+                        size_list.append(da.size)
+                        data_list.append(da)
+                        ch_name_list.append(da.sources[0].name)
+                self.da_list['blocks'][block_index]['segments'][seg_index]['data_size'] = size_list
+                self.da_list['blocks'][block_index]['segments'][seg_index]['data'] = data_list
+                self.da_list['blocks'][block_index]['segments'][seg_index]['ch_name'] = ch_name_list
+
+        self.unit_list = {'blocks': []}
+        for block_index, blk in enumerate(self.file.blocks):
+            d = {'segments': []}
+            self.unit_list['blocks'].append(d)
+            for seg_index, seg in enumerate(blk.groups):
+                d = {'spiketrains': [], 'spiketrains_id': [], 'spiketrains_unit': []}
+                self.unit_list['blocks'][block_index]['segments'].append(d)
+                st_idx = 0
+                for st in seg.multi_tags:
+                    d = {'waveforms': []}
+                    self.unit_list['blocks'][block_index]['segments'][seg_index]['spiketrains_unit'].append(d)
+                    for src in st.sources:
+                        if st.type == 'neo.spiketrain' and [src.type == "neo.unit"]:
+                            seg = self.unit_list['blocks'][block_index]['segments'][seg_index]
+                            seg['spiketrains'].append(st.positions)
+                            seg['spiketrains_id'].append(src.id)
+                            if st.features[0].data.type == "neo.waveforms":
+                                waveforms = st.features[0].data
+                                seg['spiketrains_unit'][st_idx]['waveforms'] = waveforms
+                                # assume one spiketrain one waveform
+                                st_idx += 1
+
+        self.header = {}
+        self.header['nb_block'] = len(self.file.blocks)
+        self.header['nb_segment'] = [len(bl.groups) for bl in self.file.blocks]
+        self.header['signal_channels'] = sig_channels
+        self.header['unit_channels'] = unit_channels
+        self.header['event_channels'] = event_channels
+
+        self._generate_minimal_annotations()
+
+    def _segment_t_start(self, block_index, seg_index):
+        t_start = 0
+        for mt in self.file.blocks[block_index].groups[seg_index].multi_tags:
+            if mt.type == "neo.spiketrain":
+                t_start = mt.metadata['t_start']
+        return t_start
+
+    def _segment_t_stop(self, block_index, seg_index):
+        t_stop = 0
+        for mt in self.file.blocks[block_index].groups[seg_index].multi_tags:
+            if mt.type == "neo.spiketrain":
+                t_stop = mt.metadata['t_stop']
+        return t_stop
+
+    def _get_signal_size(self, block_index, seg_index, channel_indexes):
+        size = 0
+        ch_list = np.unique(self.header['signal_channels'][channel_indexes]['group_id'])
+        for ch in ch_list:
+            ch = int(ch)
+            chan_name = self.file.blocks[block_index].sources[ch].name
+            for da in self.file.blocks[block_index].groups[seg_index].data_arrays:
+                if da.type == 'neo.analogsignal' and da.sources[0].name == chan_name:
+                    size = da.size
+                    break
+        return size  # size is per signal, not the sum of all channel_indexes
+
+    def _get_signal_t_start(self, block_index, seg_index, channel_indexes):
+        sig_t_start = 0
+        ch_list = np.unique(self.header['signal_channels'][channel_indexes]['group_id'])
+        for ch in ch_list:
+            ch = int(ch)
+            chan_name = self.file.blocks[block_index].sources[ch].name
+            for da in self.file.blocks[block_index].groups[seg_index].data_arrays:
+                if da.type == 'neo.analogsignal' and da.sources[0].name == chan_name:
+                    sig_t_start = float(da.metadata['t_start'])
+                    break
+        return sig_t_start  # assume same group_id always same t_start
+
+    def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop, channel_indexes):
+
+        if i_start is None:
+            i_start = 0
+        if i_stop is None:
+            for c in channel_indexes:
+                i_stop = self.da_list['blocks'][block_index]['segments'][seg_index]['data_size'][c]
+                break
+
+        nb_chan = int(np.unique(self.header['signal_channels'][channel_indexes]['group_id'])[0])
+        raw_signals_list = []
+        chan_name = self.file.blocks[block_index].sources[nb_chan].name
+        da_list = self.da_list['blocks'][block_index]['segments'][seg_index]
+        for idx in channel_indexes:
+            da = da_list['data'][idx]
+            if da_list['ch_name'][idx] == chan_name:
+                raw_signals_list.append(da[i_start:i_stop])
+
+        raw_signals = np.array(raw_signals_list)
+        raw_signals = np.transpose(raw_signals)
+        return raw_signals
+
+    def _spike_count(self, block_index, seg_index, unit_index):
+        count = 0
+        head_id = self.header['unit_channels'][unit_index][1]
+        for mt in self.file.blocks[block_index].groups[seg_index].multi_tags:
+            for src in mt.sources:
+                if mt.type == 'neo.spiketrain' and [src.type == "neo.unit"]:
+                    if head_id == src.id:
+                        return len(mt.positions)
+        return count
+
+    def _get_spike_timestamps(self, block_index, seg_index, unit_index, t_start, t_stop):
+        spike_dict = self.unit_list['blocks'][block_index]['segments'][seg_index]['spiketrains']
+        spike_timestamps = spike_dict[unit_index]
+        spike_timestamps = np.transpose(spike_timestamps)
+
+        if t_start is not None or t_stop is not None:
+            lim0 = t_start
+            lim1 = t_stop
+            mask = (spike_timestamps >= lim0) & (spike_timestamps <= lim1)
+            spike_timestamps = spike_timestamps[mask]
+        return spike_timestamps
+
+    def _rescale_spike_timestamp(self, spike_timestamps, dtype):
+        spike_times = spike_timestamps.astype(dtype)
+        sr = self.header['signal_channels'][0][2]
+        spike_times *= sr
+        return spike_times
+
+    def _get_spike_raw_waveforms(self, block_index, seg_index, unit_index, t_start, t_stop):
+        # this must return a 3D numpy array (nb_spike, nb_channel, nb_sample)
+        seg = self.unit_list['blocks'][block_index]['segments'][seg_index]
+        waveforms = seg['spiketrains_unit'][unit_index]['waveforms']
+        raw_waveforms = np.array(waveforms)
+
+        if t_start is not None:
+            lim0 = t_start
+            mask = (raw_waveforms >= lim0)
+            raw_waveforms = np.where(mask, raw_waveforms, np.nan)  # use nan to keep the shape
+        if t_stop is not None:
+            lim1 = t_stop
+            mask = (raw_waveforms <= lim1)
+            raw_waveforms = np.where(mask, raw_waveforms, np.nan)
+        return raw_waveforms
+
+    def _event_count(self, block_index, seg_index, event_channel_index):
+        event_count = 0
+        for event in self.file.blocks[block_index].groups[seg_index].multi_tags:
+            if event.type == 'neo.event':
+                event_count += 1
+        return event_count
+
+    def _get_event_timestamps(self, block_index, seg_index, event_channel_index, t_start, t_stop):
+        seg_t_start = self._segment_t_start(block_index, seg_index)
+        timestamp = []
+        labels = []
+
+        for mt in self.file.blocks[block_index].groups[seg_index].multi_tags:
+            if mt.type == "neo.event":
+                labels.append(mt.positions.dimensions[0].labels)
+                po = mt.positions
+                if po.type == "neo.event.times":
+                    timestamp.append(po)
+        timestamp = np.array(timestamp, dtype="float") + seg_t_start
+        labels = np.array(labels, dtype='U')
+
+        if t_start is not None:
+            keep = timestamp >= t_start
+            timestamp, labels = timestamp[keep], labels[keep]
+
+        if t_stop is not None:
+            keep = timestamp <= t_stop
+            timestamp, labels = timestamp[keep], labels[keep]
+        durations = None
+        return timestamp, durations, labels  # only the first fits in rescale
+
+    def _rescale_event_timestamp(self, event_timestamps, dtype):
+        ev_unit = ''
+        for mt in self.file.blocks[0].groups[0].multi_tags:
+            if mt.type == "neo.event":
+                ev_unit = mt.positions.unit
+                break
+        if ev_unit == 'ms':
+            event_timestamps /= 1000
+        event_times = event_timestamps.astype(dtype)  # supposing unit is second, other possibilies maybe mS microS...
+        return event_times  # return in seconds
+
+    def _rescale_epoch_duration(self, raw_duration, dtype):
+        ep_unit = ''
+        for mt in self.file.blocks[0].groups[0].multi_tags:
+            if mt.type == "neo.epoch":
+                ep_unit = mt.positions.unit
+                break
+        if ep_unit == 'ms':
+            raw_duration /= 1000
+        durations = raw_duration.astype(dtype)  # supposing unit is second, other possibilies maybe mS microS...
+        return durations  # return in seconds

--- a/neo/rawio/nixrawio.py
+++ b/neo/rawio/nixrawio.py
@@ -20,16 +20,12 @@ except ImportError:
     nix = None
 
 
-class NIXRawIO (BaseRawIO):
+class NixRawIO (BaseRawIO):
 
     extensions = ['nix']
     rawmode = 'one-file'
 
     def __init__(self, filename=''):
-        if not HAVE_NIX:
-            raise Exception("Failed to import NIX. "
-                            "The NixIO requires the Python bindings for NIX "
-                            "(nixio on PyPi). Try `pip install nixio`.")
         BaseRawIO.__init__(self)
         self.filename = filename
 
@@ -39,34 +35,29 @@ class NIXRawIO (BaseRawIO):
     def _parse_header(self):
 
         self.file = nix.File.open(self.filename, nix.FileMode.ReadOnly)
-        channel_name = []
-        for blk in self.file.blocks:
-            for ch, src in enumerate(blk.sources):
-                channel_name.append(src.name)
-            break
         sig_channels = []
+        size_list = []
         for bl in self.file.blocks:
             for seg in bl.groups:
-                for da in seg.data_arrays:
+                for da_idx, da in enumerate(seg.data_arrays):
                     if da.type == "neo.analogsignal":
-                        nixname = da.name
-                        nixidx = int(nixname.split('.')[-1])
-                        src = da.sources[0].sources[nixidx]
-                        chan_id = src.metadata['channel_id']
-                        ch_name = src.metadata['neo_name']
+                        chan_id = da_idx
+                        ch_name = da.metadata['neo_name']
                         units = str(da.unit)
                         dtype = str(da.dtype)
                         sr = 1 / da.dimensions[0].sampling_interval
+                        da_leng = da.size
+                        if da_leng not in size_list:
+                            size_list.append(da_leng)
                         group_id = 0
-                        for cid, name in enumerate(channel_name):
-                            if name == da.sources[0].name:
-                                group_id = cid
+                        for sid, li_leng in enumerate(size_list):
+                            if li_leng == da_leng:
+                                group_id = sid
                                 # very important! group_id use to store channel groups!!!
                                 # use only for different signal length
                         gain = 1
                         offset = 0.
-                        sig_channels.append((ch_name, chan_id, sr, dtype,
-                                             units, gain, offset, group_id))
+                        sig_channels.append((ch_name, chan_id, sr, dtype, units, gain, offset, group_id))
                 break
             break
         sig_channels = np.array(sig_channels, dtype=_signal_channel_dtype)
@@ -78,19 +69,21 @@ class NIXRawIO (BaseRawIO):
             for seg in bl.groups:
                 for mt in seg.multi_tags:
                     if mt.type == "neo.spiketrain":
-                        for usrc in mt.sources:
-                            if usrc.type == "neo.unit":
-                                unit_name = usrc.metadata['neo_name']
-                                unit_id = usrc.id
-                                continue
-                        wf_units = mt.features[0].data.unit
+                        unit_name = mt.metadata['neo_name']
+                        unit_id = mt.id
+                        if mt.features:
+                            wf_units = mt.features[0].data.unit
+                            wf_sampling_rate = 1 / mt.features[0].data.dimensions[
+                                2].sampling_interval
+                        else:
+                            wf_units = None
+                            wf_sampling_rate = 0
                         wf_gain = 1
                         wf_offset = 0.
-                        if "left_sweep" in mt.features[0].data.metadata:
+                        if mt.features and "left_sweep" in mt.features[0].data.metadata:
                             wf_left_sweep = mt.features[0].data.metadata["left_sweep"]
                         else:
                             wf_left_sweep = 0
-                        wf_sampling_rate = 1 / mt.features[0].data.dimensions[2].sampling_interval
                         unit_channels.append((unit_name, unit_id, wf_units, wf_gain,
                                               wf_offset, wf_left_sweep, wf_sampling_rate))
                 break
@@ -128,16 +121,15 @@ class NIXRawIO (BaseRawIO):
                 self.da_list['blocks'][block_index]['segments'].append(d)
                 size_list = []
                 data_list = []
-                ch_name_list = []
+                da_name_list = []
                 for da in seg.data_arrays:
                     if da.type == 'neo.analogsignal':
                         size_list.append(da.size)
                         data_list.append(da)
-                        ch_name_list.append(da.sources[0].name)
-                seg = self.da_list['blocks'][block_index]['segments'][seg_index]
-                seg['data_size'] = size_list
-                seg['data'] = data_list
-                seg['ch_name'] = ch_name_list
+                        da_name_list.append(da.metadata['neo_name'])
+                self.da_list['blocks'][block_index]['segments'][seg_index]['data_size'] = size_list
+                self.da_list['blocks'][block_index]['segments'][seg_index]['data'] = data_list
+                self.da_list['blocks'][block_index]['segments'][seg_index]['ch_name'] = da_name_list
 
         self.unit_list = {'blocks': []}
         for block_index, blk in enumerate(self.file.blocks):
@@ -149,17 +141,20 @@ class NIXRawIO (BaseRawIO):
                 st_idx = 0
                 for st in seg.multi_tags:
                     d = {'waveforms': []}
-                    segd = self.unit_list['blocks'][block_index]['segments'][seg_index]
-                    segd['spiketrains_unit'].append(d)
-                    for src in st.sources:
-                        if st.type == 'neo.spiketrain' and [src.type == "neo.unit"]:
-                            segd['spiketrains'].append(st.positions)
-                            segd['spiketrains_id'].append(src.id)
-                            if st.features[0].data.type == "neo.waveforms":
-                                waveforms = st.features[0].data
-                                segd['spiketrains_unit'][st_idx]['waveforms'] = waveforms
-                                # assume one spiketrain one waveform
-                                st_idx += 1
+                    self.unit_list['blocks'][block_index]['segments'][seg_index]\
+                        ['spiketrains_unit'].append(d)
+                    if st.type == 'neo.spiketrain':
+                        seg = self.unit_list['blocks'][block_index]['segments'][seg_index]
+                        seg['spiketrains'].append(st.positions)
+                        seg['spiketrains_id'].append(st.id)
+                        if st.features and st.features[0].data.type == "neo.waveforms":
+                            waveforms = st.features[0].data
+                            if waveforms:
+                                seg['spiketrains_unit'][st_idx]['waveforms'] = waveforms
+                            else:
+                                seg['spiketrains_unit'][st_idx]['waveforms'] = None
+                            # assume one spiketrain one waveform
+                            st_idx += 1
 
         self.header = {}
         self.header['nb_block'] = len(self.file.blocks)
@@ -185,31 +180,24 @@ class NIXRawIO (BaseRawIO):
         return t_stop
 
     def _get_signal_size(self, block_index, seg_index, channel_indexes):
-        size = 0
-        ch_list = np.unique(self.header['signal_channels'][channel_indexes]['group_id'])
-        for ch in ch_list:
-            ch = int(ch)
-            chan_name = self.file.blocks[block_index].sources[ch].name
-            for da in self.file.blocks[block_index].groups[seg_index].data_arrays:
-                if da.type == 'neo.analogsignal' and da.sources[0].name == chan_name:
-                    size = da.size
-                    break
+        if channel_indexes is None:
+            channel_indexes = list(range(self.header['signal_channels'].size))
+        ch_idx = channel_indexes[0]
+        size = self.da_list['blocks'][block_index]['segments'][seg_index]['data_size'][ch_idx]
         return size  # size is per signal, not the sum of all channel_indexes
 
     def _get_signal_t_start(self, block_index, seg_index, channel_indexes):
-        sig_t_start = 0
-        ch_list = np.unique(self.header['signal_channels'][channel_indexes]['group_id'])
-        for ch in ch_list:
-            ch = int(ch)
-            chan_name = self.file.blocks[block_index].sources[ch].name
-            for da in self.file.blocks[block_index].groups[seg_index].data_arrays:
-                if da.type == 'neo.analogsignal' and da.sources[0].name == chan_name:
-                    sig_t_start = float(da.metadata['t_start'])
-                    break
+        if channel_indexes is None:
+            channel_indexes = list(range(self.header['signal_channels'].size))
+        ch_idx = channel_indexes[0]
+        da = [da for da in self.file.blocks[block_index].groups[seg_index].data_arrays][ch_idx]
+        sig_t_start = float(da.metadata['t_start'])
         return sig_t_start  # assume same group_id always same t_start
 
     def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop, channel_indexes):
 
+        if channel_indexes is None:
+            channel_indexes = list(range(self.header['signal_channels'].size))
         if i_start is None:
             i_start = 0
         if i_stop is None:
@@ -217,14 +205,11 @@ class NIXRawIO (BaseRawIO):
                 i_stop = self.da_list['blocks'][block_index]['segments'][seg_index]['data_size'][c]
                 break
 
-        nb_chan = int(np.unique(self.header['signal_channels'][channel_indexes]['group_id'])[0])
         raw_signals_list = []
-        chan_name = self.file.blocks[block_index].sources[nb_chan].name
         da_list = self.da_list['blocks'][block_index]['segments'][seg_index]
         for idx in channel_indexes:
             da = da_list['data'][idx]
-            if da_list['ch_name'][idx] == chan_name:
-                raw_signals_list.append(da[i_start:i_stop])
+            raw_signals_list.append(da[i_start:i_stop])
 
         raw_signals = np.array(raw_signals_list)
         raw_signals = np.transpose(raw_signals)
@@ -254,14 +239,14 @@ class NIXRawIO (BaseRawIO):
 
     def _rescale_spike_timestamp(self, spike_timestamps, dtype):
         spike_times = spike_timestamps.astype(dtype)
-        sr = self.header['signal_channels'][0][2]
-        spike_times *= sr
         return spike_times
 
     def _get_spike_raw_waveforms(self, block_index, seg_index, unit_index, t_start, t_stop):
         # this must return a 3D numpy array (nb_spike, nb_channel, nb_sample)
         seg = self.unit_list['blocks'][block_index]['segments'][seg_index]
         waveforms = seg['spiketrains_unit'][unit_index]['waveforms']
+        if not waveforms:
+            return None
         raw_waveforms = np.array(waveforms)
 
         if t_start is not None:
@@ -282,19 +267,25 @@ class NIXRawIO (BaseRawIO):
         return event_count
 
     def _get_event_timestamps(self, block_index, seg_index, event_channel_index, t_start, t_stop):
-        seg_t_start = self._segment_t_start(block_index, seg_index)
         timestamp = []
         labels = []
-
+        durations = None
+        if event_channel_index == None:
+            event_channel_index = np.arange(self.header['event_channels'].size)
         for mt in self.file.blocks[block_index].groups[seg_index].multi_tags:
-            if mt.type == "neo.event":
+            if mt.type == "neo.event" or mt.type == "neo.epoch":
                 labels.append(mt.positions.dimensions[0].labels)
                 po = mt.positions
-                if po.type == "neo.event.times":
+                if po.type == "neo.event.times" or po.type == "neo.epoch.times":
                     timestamp.append(po)
-        timestamp = np.array(timestamp, dtype="float") + seg_t_start
+                if self.header['event_channels'][event_channel_index][2] == b'epoch' and mt.extents:
+                        if mt.extents.type == 'neo.epoch.durations':
+                            durations = np.array(mt.extents)
+                            break
+        timestamp = timestamp[event_channel_index][:]
+        timestamp = np.array(timestamp, dtype="float")
+        labels = labels[event_channel_index][:]
         labels = np.array(labels, dtype='U')
-
         if t_start is not None:
             keep = timestamp >= t_start
             timestamp, labels = timestamp[keep], labels[keep]
@@ -302,10 +293,9 @@ class NIXRawIO (BaseRawIO):
         if t_stop is not None:
             keep = timestamp <= t_stop
             timestamp, labels = timestamp[keep], labels[keep]
-        durations = None
         return timestamp, durations, labels  # only the first fits in rescale
 
-    def _rescale_event_timestamp(self, event_timestamps, dtype):
+    def _rescale_event_timestamp(self, event_timestamps, dtype='float64'):
         ev_unit = ''
         for mt in self.file.blocks[0].groups[0].multi_tags:
             if mt.type == "neo.event":
@@ -317,7 +307,7 @@ class NIXRawIO (BaseRawIO):
         # supposing unit is second, other possibilies maybe mS microS...
         return event_times  # return in seconds
 
-    def _rescale_epoch_duration(self, raw_duration, dtype):
+    def _rescale_epoch_duration(self, raw_duration, dtype='float64'):
         ep_unit = ''
         for mt in self.file.blocks[0].groups[0].multi_tags:
             if mt.type == "neo.epoch":

--- a/neo/rawio/tests/test_nixrawio.py
+++ b/neo/rawio/tests/test_nixrawio.py
@@ -5,7 +5,6 @@ from neo.rawio.tests.common_rawio_test import BaseTestRawIO
 
 testfname = "neoraw.nix"
 
-
 class TestNixRawIO(BaseTestRawIO, unittest.TestCase, ):
     rawioclass = NIXRawIO
     entities_to_test = [testfname]

--- a/neo/rawio/tests/test_nixrawio.py
+++ b/neo/rawio/tests/test_nixrawio.py
@@ -1,0 +1,16 @@
+import unittest
+from neo.rawio.nixrawio import NIXRawIO
+from neo.rawio.tests.common_rawio_test import BaseTestRawIO
+
+
+testfname = "neoraw.nix"
+
+
+class TestNixRawIO(BaseTestRawIO, unittest.TestCase, ):
+    rawioclass = NIXRawIO
+    entities_to_test = [testfname]
+    files_to_download = [testfname]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the NIXRawIO file and the test for it.

The raw reader assumes that all blocks have the same object tree, since the docstring for baserawio.py says 
>neo tree object is symetric and logical: same channel/units/event along all block and segments.

I noticed that there aren't any other rawios which support multiple blocks and we want to support multiple blocks in NIXRawIO. I think we can add support for asymmetrical blocks but this would require changes in the baserawio (as far as I can tell). Would this be useful or it is redundant for the rawios? 