### PR TITLE
BlackrockIO loading of multiple blackrock nsx files

### DIFF
--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -4,17 +4,71 @@ from neo.io.basefromrawio import BaseFromRaw
 from neo.rawio.blackrockrawio import BlackrockRawIO
 
 
+def _move_channel_indexes_and_analogsignals(from_block, to_block):
+    if len(from_block.segments) != len(to_block.segments):
+        raise ValueError('Can not assign segments between block 1 and 2. Different number of '
+                         'segments present.')
+
+    for seg_id in range(len(from_block.segments)):
+        for ana in from_block.segments[seg_id].analogsignals:
+            # redirect links from data object to container objects
+            ana.segment = to_block.segments[seg_id]
+            ana.channel_index.block = to_block
+
+            # add links from container objects to analogsignal
+            ana.segment.analogsignals.append(ana)
+            # channel index was already relinked for another segment
+            if ana.channel_index not in to_block.channel_indexes:
+                to_block.channel_indexes.append(ana.channel_index)
+
+            # remove (now) duplicated units from channel_index, remove irregular signals
+            ana.channel_index.units = []
+            ana.channel_index.irregularlysampledsignals = []
+
+
 class BlackrockIO(BlackrockRawIO, BaseFromRaw):
-    """
-    This IO reads .nev/.nsX files of the Blackrock
-    (Cerebus) recording system.
-    """
     name = 'Blackrock IO'
-    description = "This IO reads .nev/.nsX files of the Blackrock " + \
-                  "(Cerebus) recording system."
+    description = "This IO reads .nev/.nsX files of the Blackrock (Cerebus) recording system."
 
-    _prefered_signal_group_mode = 'split-all'
+    class BlackrockIO_single_nsx(BlackrockRawIO, BaseFromRaw):
+        """
+        Supplementary class for reading BlackRock data using only a single nsx file.
+        """
+        name = 'Blackrock IO for single nsx'
+        description = "This IO reads a pair of corresponding nev and nsX files of the Blackrock " \
+                      "" + "(Cerebus) recording system."
 
-    def __init__(self, filename, nsx_to_load=None, **kargs):
-        BlackrockRawIO.__init__(self, filename=filename, nsx_to_load=nsx_to_load, **kargs)
-        BaseFromRaw.__init__(self, filename)
+        _prefered_signal_group_mode = 'split-all'
+
+        def __init__(self, filename, nsx_to_load=None, **kargs):
+            BlackrockRawIO.__init__(self, filename=filename, nsx_to_load=nsx_to_load, **kargs)
+            BaseFromRaw.__init__(self, filename)
+
+    def __init__(self, filename, nsx_to_load='all', **kargs):
+        self.BlackrockIO_single_nsx.__init__(self, filename)
+        if nsx_to_load == 'all':
+            self._selected_nsx = self._avail_nsx
+        else:
+            self._selected_nsx = [nsx_to_load]
+        self._nsx_ios = []
+        for nsx in self._selected_nsx:
+            self._nsx_ios.append(self.BlackrockIO_single_nsx(filename, nsx_to_load=nsx, **kargs))
+
+    def read_block(self, **kargs):
+        bl = self._nsx_ios[0].read_block(**kargs)
+        for nsx_ios in self._nsx_ios[1:]:
+            nsx_block = nsx_ios.read_block(**kargs)
+            _move_channel_indexes_and_analogsignals(nsx_block, bl)
+            del nsx_block
+        return bl
+
+    def read_segment(self, **kargs):
+        seg = self._nsx_ios[0].read_segment(**kargs)
+        for nsx_ios in self._nsx_ios[1:]:
+            nsx_seg = nsx_ios.read_segment(**kargs)
+            seg.analogsignals.extend(nsx_seg.analogsignals)
+            for ana in nsx_seg.analogsignals:
+                ana.segment = seg
+                ana.channel_index = None
+            del nsx_seg
+        return seg

--- a/neo/io/blackrockio.py
+++ b/neo/io/blackrockio.py
@@ -26,33 +26,34 @@ def _move_channel_indexes_and_analogsignals(from_block, to_block):
             ana.channel_index.irregularlysampledsignals = []
 
 
-class BlackrockIO(BlackrockRawIO, BaseFromRaw):
+class BlackrockIO_single_nsx(BlackrockRawIO, BaseFromRaw):
+    """
+    Supplementary class for reading BlackRock data using only a single nsx file.
+    """
+    name = 'Blackrock IO for single nsx'
+    description = "This IO reads a pair of corresponding nev and nsX files of the Blackrock " \
+                  "" + "(Cerebus) recording system."
+
+    _prefered_signal_group_mode = 'split-all'
+
+    def __init__(self, filename, nsx_to_load=None, **kargs):
+        BlackrockRawIO.__init__(self, filename=filename, nsx_to_load=nsx_to_load, **kargs)
+        BaseFromRaw.__init__(self, filename)
+
+
+class BlackrockIO(BlackrockIO_single_nsx):
     name = 'Blackrock IO'
     description = "This IO reads .nev/.nsX files of the Blackrock (Cerebus) recording system."
 
-    class BlackrockIO_single_nsx(BlackrockRawIO, BaseFromRaw):
-        """
-        Supplementary class for reading BlackRock data using only a single nsx file.
-        """
-        name = 'Blackrock IO for single nsx'
-        description = "This IO reads a pair of corresponding nev and nsX files of the Blackrock " \
-                      "" + "(Cerebus) recording system."
-
-        _prefered_signal_group_mode = 'split-all'
-
-        def __init__(self, filename, nsx_to_load=None, **kargs):
-            BlackrockRawIO.__init__(self, filename=filename, nsx_to_load=nsx_to_load, **kargs)
-            BaseFromRaw.__init__(self, filename)
-
     def __init__(self, filename, nsx_to_load='all', **kargs):
-        self.BlackrockIO_single_nsx.__init__(self, filename)
+        BlackrockIO_single_nsx.__init__(self, filename)
         if nsx_to_load == 'all':
             self._selected_nsx = self._avail_nsx
         else:
             self._selected_nsx = [nsx_to_load]
         self._nsx_ios = []
         for nsx in self._selected_nsx:
-            self._nsx_ios.append(self.BlackrockIO_single_nsx(filename, nsx_to_load=nsx, **kargs))
+            self._nsx_ios.append(BlackrockIO_single_nsx(filename, nsx_to_load=nsx, **kargs))
 
     def read_block(self, **kargs):
         bl = self._nsx_ios[0].read_block(**kargs)

--- a/neo/test/iotest/test_blackrockio.py
+++ b/neo/test/iotest/test_blackrockio.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 import unittest
 import warnings
+warnings.simplefilter("always")  # required for reliable test for warnings
 
 from numpy.testing import assert_equal
 

--- a/neo/test/iotest/test_blackrockio.py
+++ b/neo/test/iotest/test_blackrockio.py
@@ -316,7 +316,8 @@ class CommonTests(BaseTestIO, unittest.TestCase):
             self.assertGreaterEqual(len(w), 1)
             self.assertEqual(w[-1].category, UserWarning)
             self.assertSequenceEqual(str(w[-1].message),
-                    "Detected 1 undocumented segments within nev data after timestamps [5451].")
+                                     "Detected 1 undocumented segments within nev data after "
+                                     "timestamps [5451].")
 
         block = reader.read_block(load_waveforms=False, signal_group_mode="split-all")
 

--- a/neo/test/iotest/test_blackrockio.py
+++ b/neo/test/iotest/test_blackrockio.py
@@ -169,6 +169,25 @@ class CommonTests(BaseTestIO, unittest.TestCase):
         anasig = block.segments[0].analogsignals[0]
         self.assertIsNotNone(anasig.file_origin)
 
+    def test_load_muliple_nsx(self):
+        """
+        Test if multiple nsx signals can be loaded at the same time.
+        """
+        filename = self.get_filename_path('blackrock_2_1/l101210-001')
+        reader = BlackrockIO(filename=filename, verbose=False, nsx_to_load='all')
+
+        # number of different sampling rates corresponds to number of nsx signals, because
+        # single nsx contains only signals of identical sampling rate
+        block = reader.read_block(load_waveforms=False)
+        sampling_rates = np.unique(
+            [a.sampling_rate.rescale('Hz') for a in block.filter(objects='AnalogSignal')])
+        self.assertEqual(len(sampling_rates), len(reader._selected_nsx))
+
+        segment = reader.read_segment()
+        sampling_rates = np.unique(
+            [a.sampling_rate.rescale('Hz') for a in segment.filter(objects='AnalogSignal')])
+        self.assertEqual(len(sampling_rates), len(reader._selected_nsx))
+
     @unittest.skipUnless(HAVE_SCIPY, "requires scipy")
     def test_compare_blackrockio_with_matlabloader_v21(self):
         """

--- a/neo/test/iotest/test_blackrockio.py
+++ b/neo/test/iotest/test_blackrockio.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 
 import unittest
 import warnings
-warnings.simplefilter("always")  # required for reliable test for warnings
 
 from numpy.testing import assert_equal
 
@@ -39,6 +38,8 @@ else:
         HAVE_SCIPY = True
         SCIPY_ERR = None
 
+# printing all warnings, so testing for warning handling works reliably
+warnings.simplefilter("always")
 
 class CommonTests(BaseTestIO, unittest.TestCase):
     ioclass = BlackrockIO


### PR DESCRIPTION
This PR tackles #419 by allowing to specify nsx_to_load='all' when initialising the BlackrockIO. The implementation is probably not the most elegant one, but it comes with a test covering the new feature.
