### PR TITLE
Blackrock comments

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -1772,7 +1772,8 @@ class BlackrockRawIO(BaseRawIO):
             'digital_input_port': {
                 'name': 'digital_input_port',
                 'field': 'digital_input',
-                'mask': self.__is_set(data['packet_insertion_reason'], 0),
+                'mask': self.__is_set(data['packet_insertion_reason'], 0) &
+                        ~self.__is_set(data['packet_insertion_reason'], 7),
                 'desc': "Events of the digital input port"},
             'serial_input_port': {
                 'name': 'serial_input_port',

--- a/neo/rawio/tests/test_blackrockrawio.py
+++ b/neo/rawio/tests/test_blackrockrawio.py
@@ -101,15 +101,16 @@ class TestBlackrockRawIO(BaseTestRawIO, unittest.TestCase, ):
         for ev_chan in range(nb_ev_chan):
             name = reader.header['event_channels']['name'][ev_chan]
             # ~ print(name)
+            all_timestamps, _, labels = reader.get_event_timestamps(
+                event_channel_index=ev_chan)
             if name == 'digital_input_port':
-
-                all_timestamps, _, labels = reader.get_event_timestamps(
-                    event_channel_index=ev_chan)
-
                 for label in np.unique(labels):
                     python_digievents = all_timestamps[labels == label]
                     matlab_digievents = mts_ml[mid_ml == int(label)]
                     assert_equal(python_digievents, matlab_digievents)
+            elif name == 'comments':
+                pass
+                # TODO: Save comments to Matlab file.
 
     @unittest.skipUnless(HAVE_SCIPY, "requires scipy")
     def test_compare_blackrockio_with_matlabloader_v21(self):


### PR DESCRIPTION
(Note: First 2 commits are part of #560)

This is just to get the ball rolling on a modification to the Blackrock importer to include Comment events. Related to #289 

With this modification, comments are now showing up as a 3rd event channel, behind `digital_input_port` and `serial_input_port`.

I'm sure it can be made better by someone with a deeper understanding of the Blackrock importer.