### PR TITLE
Parse EpochSection in ABF2 files to get digital output waveform info

### DIFF
--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -562,6 +562,21 @@ def parse_axon_soup(filename):
                 header['dictEpochInfoPerDAC'][DACNum][EpochNum] = \
                     EpochInfoPerDAC
 
+            # Epoch sections
+            header['EpochInfo'] = []
+            for i in range(sections['EpochSection']['llNumEntries']):
+                # read EpochInfo
+                f.seek(sections['EpochSection']['uBlockIndex'] *
+                       BLOCKSIZE + sections['EpochSection']['uBytes'] * i)
+                EpochInfo = {}
+                for key, fmt in EpochInfoDescription:
+                    val = f.read_f(fmt)
+                    if len(val) == 1:
+                        EpochInfo[key] = val[0]
+                    else:
+                        EpochInfo[key] = np.array(val)
+                header['EpochInfo'].append(EpochInfo)
+
         # date and time
         if header['fFileVersionNumber'] < 2.:
             YY = 1900


### PR DESCRIPTION
Noticed that there was an EpochInfoDescription block sitting around that wasn't being used, so I followed the format of the other sections to parse an 'EpochInfo' block into the ABF2 header. On initial inspection, it seems to work properly and I can see the digital output epochs.

A caveat is that each DAC channel can define it's own epoch durations and the EpochInfo returned doesn't provide a duration field. So for example, if Epoch A is defined as 1 second in CMD#0 and as 5 seconds in CMD#1, it isn't necessarily obvious which length the digital output pulse should be if you were to turn the EpochInfo section into a waveform. (Similar to how read_raw_protocol converts the dictEpochInfoPerDAC into a waveform). Still, I think that parsing the EpochInfo block is useful.