### PR TITLE
Indexing of AnalogSignals and IrregularlySampledSignals using numpy arrays

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -304,8 +304,19 @@ class AnalogSignal(BaseSignal):
         elif isinstance(i, slice):
             if i.start:
                 obj.t_start = self.t_start + i.start * self.sampling_period
+        elif isinstance(i, np.ndarray):
+            # Indexing of an AnalogSignal is only consistent if the resulting number of
+            # samples is the same for each trace. The time axis for these samples is not
+            # guaranteed to be continuous, so returning a Quantity instead of an AnalogSignal here.
+            new_time_dims = np.sum(i, axis=0)
+            if len(new_time_dims) and all(new_time_dims == new_time_dims[0]):
+                obj = obj.reshape(-1, self.shape[1])
+                obj = pq.Quantity(obj.magnitude, units=obj.units)
+            else:
+                raise IndexError("indexing of an AnalogSignals needs to keep the same number of "
+                                 "sample for each trace contained")
         else:
-            raise IndexError("index should be an integer, tuple or slice")
+            raise IndexError("index should be an integer, tuple, slice or boolean numpy array")
         return obj
 
     def __setitem__(self, i, value):

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -262,10 +262,11 @@ class AnalogSignal(BaseSignal):
         '''
         Get the item or slice :attr:`i`.
         '''
-        obj = super(AnalogSignal, self).__getitem__(i)
         if isinstance(i, (int, np.integer)):  # a single point in time across all channels
+            obj = super(AnalogSignal, self).__getitem__(i)
             obj = pq.Quantity(obj.magnitude, units=obj.units)
         elif isinstance(i, tuple):
+            obj = super(AnalogSignal, self).__getitem__(i)
             j, k = i
             if isinstance(j, (int, np.integer)):  # extract a quantity array
                 obj = pq.Quantity(obj.magnitude, units=obj.units)
@@ -286,6 +287,7 @@ class AnalogSignal(BaseSignal):
                 if self.channel_index:
                     obj.channel_index = self.channel_index.__getitem__(k)
         elif isinstance(i, slice):
+            obj = super(AnalogSignal, self).__getitem__(i)
             if i.start:
                 obj.t_start = self.t_start + i.start * self.sampling_period
         elif isinstance(i, np.ndarray):
@@ -294,8 +296,9 @@ class AnalogSignal(BaseSignal):
             # guaranteed to be continuous, so returning a Quantity instead of an AnalogSignal here.
             new_time_dims = np.sum(i, axis=0)
             if len(new_time_dims) and all(new_time_dims == new_time_dims[0]):
-                obj = obj.reshape(-1, self.shape[1])
-                obj = pq.Quantity(obj.magnitude, units=obj.units)
+                obj = np.asarray(self).T.__getitem__(i.T)
+                obj = obj.T.reshape(self.shape[1], -1).T
+                obj = pq.Quantity(obj, units=self.units)
             else:
                 raise IndexError("indexing of an AnalogSignals needs to keep the same number of "
                                  "sample for each trace contained")

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -430,8 +430,10 @@ class AnalogSignal(BaseSignal):
         '''
         pp.text("{cls} with {channels} channels of length {length}; "
                 "units {units}; datatype {dtype} ".format(cls=self.__class__.__name__,
-            channels=self.shape[1], length=self.shape[0], units=self.units.dimensionality.string,
-            dtype=self.dtype))
+                                                          channels=self.shape[1],
+                                                          length=self.shape[0],
+                                                          units=self.units.dimensionality.string,
+                                                          dtype=self.dtype))
         if self._has_repr_pretty_attrs_():
             pp.breakable()
             self._repr_pretty_attrs_(pp, cycle)

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -154,8 +154,9 @@ class AnalogSignal(BaseSignal):
 
     _single_parent_objects = ('Segment', 'ChannelIndex')
     _quantity_attr = 'signal'
-    _necessary_attrs = (
-    ('signal', pq.Quantity, 2), ('sampling_rate', pq.Quantity, 0), ('t_start', pq.Quantity, 0))
+    _necessary_attrs = (('signal', pq.Quantity, 2),
+                        ('sampling_rate', pq.Quantity, 0),
+                        ('t_start', pq.Quantity, 0))
     _recommended_attrs = BaseNeo._recommended_attrs
 
     def __new__(cls, signal, units=None, dtype=None, copy=True, t_start=0 * pq.s,
@@ -206,10 +207,11 @@ class AnalogSignal(BaseSignal):
         Map the __new__ function onto _new_AnalogSignalArray, so that pickle
         works
         '''
-        return _new_AnalogSignalArray, (
-        self.__class__, np.array(self), self.units, self.dtype, True, self.t_start,
-        self.sampling_rate, self.sampling_period, self.name, self.file_origin, self.description,
-        self.annotations, self.channel_index, self.segment)
+        return _new_AnalogSignalArray, (self.__class__, np.array(self), self.units, self.dtype,
+                                        True, self.t_start, self.sampling_rate,
+                                        self.sampling_period, self.name, self.file_origin,
+                                        self.description, self.annotations, self.channel_index,
+                                        self.segment)
 
     def _array_finalize_spec(self, obj):
         '''
@@ -243,9 +245,10 @@ class AnalogSignal(BaseSignal):
         '''
         Returns a string representing the :class:`AnalogSignal`.
         '''
-        return ('<%s(%s, [%s, %s], sampling rate: %s)>' % (
-        self.__class__.__name__, super(AnalogSignal, self).__repr__(), self.t_start, self.t_stop,
-        self.sampling_rate))
+        return ('<%s(%s, [%s, %s], sampling rate: %s)>' % (self.__class__.__name__,
+                                                           super(AnalogSignal, self).__repr__(),
+                                                           self.t_start, self.t_stop,
+                                                           self.sampling_rate))
 
     def get_channel_index(self):
         """

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -2,8 +2,8 @@
 '''
 This module implements :class:`AnalogSignal`, an array of analog signals.
 
-:class:`AnalogSignal` inherits from :class:`basesignal.BaseSignal` which 
-derives from :class:`BaseNeo`, and from :class:`quantites.Quantity`which 
+:class:`AnalogSignal` inherits from :class:`basesignal.BaseSignal` which
+derives from :class:`BaseNeo`, and from :class:`quantites.Quantity`which
 in turn inherits from :class:`numpy.array`.
 
 Inheritance from :class:`numpy.array` is explained here:
@@ -30,9 +30,9 @@ from neo.core.baseneo import BaseNeo, MergeError, merge_annotations
 from neo.core.channelindex import ChannelIndex
 from copy import copy, deepcopy
 
-logger = logging.getLogger("Neo")
-
 from neo.core.basesignal import BaseSignal
+
+logger = logging.getLogger("Neo")
 
 
 def _get_sampling_rate(sampling_rate, sampling_period):
@@ -42,8 +42,7 @@ def _get_sampling_rate(sampling_rate, sampling_period):
     '''
     if sampling_period is None:
         if sampling_rate is None:
-            raise ValueError("You must provide either the sampling rate or " +
-                             "sampling period")
+            raise ValueError("You must provide either the sampling rate or " + "sampling period")
     elif sampling_rate is None:
         sampling_rate = 1.0 / sampling_period
     elif sampling_period != 1.0 / sampling_rate:
@@ -53,20 +52,16 @@ def _get_sampling_rate(sampling_rate, sampling_period):
     return sampling_rate
 
 
-def _new_AnalogSignalArray(cls, signal, units=None, dtype=None, copy=True,
-                           t_start=0 * pq.s, sampling_rate=None,
-                           sampling_period=None, name=None, file_origin=None,
-                           description=None, annotations=None,
-                           channel_index=None, segment=None):
+def _new_AnalogSignalArray(cls, signal, units=None, dtype=None, copy=True, t_start=0 * pq.s,
+                           sampling_rate=None, sampling_period=None, name=None, file_origin=None,
+                           description=None, annotations=None, channel_index=None, segment=None):
     '''
     A function to map AnalogSignal.__new__ to function that
         does not do the unit checking. This is needed for pickle to work.
     '''
-    obj = cls(signal=signal, units=units, dtype=dtype, copy=copy,
-              t_start=t_start, sampling_rate=sampling_rate,
-              sampling_period=sampling_period, name=name,
-              file_origin=file_origin, description=description,
-              **annotations)
+    obj = cls(signal=signal, units=units, dtype=dtype, copy=copy, t_start=t_start,
+              sampling_rate=sampling_rate, sampling_period=sampling_period, name=name,
+              file_origin=file_origin, description=description, **annotations)
     obj.channel_index = channel_index
     obj.segment = segment
     return obj
@@ -159,15 +154,13 @@ class AnalogSignal(BaseSignal):
 
     _single_parent_objects = ('Segment', 'ChannelIndex')
     _quantity_attr = 'signal'
-    _necessary_attrs = (('signal', pq.Quantity, 2),
-                        ('sampling_rate', pq.Quantity, 0),
-                        ('t_start', pq.Quantity, 0))
+    _necessary_attrs = (
+    ('signal', pq.Quantity, 2), ('sampling_rate', pq.Quantity, 0), ('t_start', pq.Quantity, 0))
     _recommended_attrs = BaseNeo._recommended_attrs
 
-    def __new__(cls, signal, units=None, dtype=None, copy=True,
-                t_start=0 * pq.s, sampling_rate=None, sampling_period=None,
-                name=None, file_origin=None, description=None,
-                **annotations):
+    def __new__(cls, signal, units=None, dtype=None, copy=True, t_start=0 * pq.s,
+                sampling_rate=None, sampling_period=None, name=None, file_origin=None,
+                description=None, **annotations):
         '''
         Constructs new :class:`AnalogSignal` from data.
 
@@ -192,10 +185,9 @@ class AnalogSignal(BaseSignal):
         obj.channel_index = None
         return obj
 
-    def __init__(self, signal, units=None, dtype=None, copy=True,
-                 t_start=0 * pq.s, sampling_rate=None, sampling_period=None,
-                 name=None, file_origin=None, description=None,
-                 **annotations):
+    def __init__(self, signal, units=None, dtype=None, copy=True, t_start=0 * pq.s,
+                 sampling_rate=None, sampling_period=None, name=None, file_origin=None,
+                 description=None, **annotations):
         '''
         Initializes a newly constructed :class:`AnalogSignal` instance.
         '''
@@ -206,28 +198,18 @@ class AnalogSignal(BaseSignal):
 
         # Calls parent __init__, which grabs universally recommended
         # attributes and sets up self.annotations
-        BaseNeo.__init__(self, name=name, file_origin=file_origin,
-                         description=description, **annotations)
+        BaseNeo.__init__(self, name=name, file_origin=file_origin, description=description,
+                         **annotations)
 
     def __reduce__(self):
         '''
         Map the __new__ function onto _new_AnalogSignalArray, so that pickle
         works
         '''
-        return _new_AnalogSignalArray, (self.__class__,
-                                        np.array(self),
-                                        self.units,
-                                        self.dtype,
-                                        True,
-                                        self.t_start,
-                                        self.sampling_rate,
-                                        self.sampling_period,
-                                        self.name,
-                                        self.file_origin,
-                                        self.description,
-                                        self.annotations,
-                                        self.channel_index,
-                                        self.segment)
+        return _new_AnalogSignalArray, (
+        self.__class__, np.array(self), self.units, self.dtype, True, self.t_start,
+        self.sampling_rate, self.sampling_period, self.name, self.file_origin, self.description,
+        self.annotations, self.channel_index, self.segment)
 
     def _array_finalize_spec(self, obj):
         '''
@@ -244,10 +226,10 @@ class AnalogSignal(BaseSignal):
 
     def __deepcopy__(self, memo):
         cls = self.__class__
-        new_signal = cls(np.array(self), units=self.units, dtype=self.dtype,
-                         t_start=self.t_start, sampling_rate=self.sampling_rate,
-                         sampling_period=self.sampling_period, name=self.name,
-                         file_origin=self.file_origin, description=self.description)
+        new_signal = cls(np.array(self), units=self.units, dtype=self.dtype, t_start=self.t_start,
+                         sampling_rate=self.sampling_rate, sampling_period=self.sampling_period,
+                         name=self.name, file_origin=self.file_origin,
+                         description=self.description)
         new_signal.__dict__.update(self.__dict__)
         memo[id(self)] = new_signal
         for k, v in self.__dict__.items():
@@ -261,10 +243,9 @@ class AnalogSignal(BaseSignal):
         '''
         Returns a string representing the :class:`AnalogSignal`.
         '''
-        return ('<%s(%s, [%s, %s], sampling rate: %s)>' %
-                (self.__class__.__name__,
-                 super(AnalogSignal, self).__repr__(), self.t_start,
-                 self.t_stop, self.sampling_rate))
+        return ('<%s(%s, [%s, %s], sampling rate: %s)>' % (
+        self.__class__.__name__, super(AnalogSignal, self).__repr__(), self.t_start, self.t_stop,
+        self.sampling_rate))
 
     def get_channel_index(self):
         """
@@ -288,13 +269,13 @@ class AnalogSignal(BaseSignal):
             else:
                 if isinstance(j, slice):
                     if j.start:
-                        obj.t_start = (self.t_start +
-                                       j.start * self.sampling_period)
+                        obj.t_start = (self.t_start + j.start * self.sampling_period)
                     if j.step:
                         obj.sampling_period *= j.step
                 elif isinstance(j, np.ndarray):
-                    raise NotImplementedError("Arrays not yet supported")
-                    # in the general case, would need to return IrregularlySampledSignal(Array)
+                    raise NotImplementedError(
+                        "Arrays not yet supported")  # in the general case, would need to return
+                    #  IrregularlySampledSignal(Array)
                 else:
                     raise TypeError("%s not supported" % type(j))
                 if isinstance(k, (int, np.integer)):
@@ -424,9 +405,8 @@ class AnalogSignal(BaseSignal):
         '''
         Equality test (==)
         '''
-        if (isinstance(other, AnalogSignal) and
-                    (self.t_start != other.t_start or
-                     self.sampling_rate != other.sampling_rate)):
+        if (isinstance(other, AnalogSignal) and (
+                self.t_start != other.t_start or self.sampling_rate != other.sampling_rate)):
             return False
         return super(AnalogSignal, self).__eq__(other)
 
@@ -438,19 +418,16 @@ class AnalogSignal(BaseSignal):
         if isinstance(other, AnalogSignal):
             for attr in "t_start", "sampling_rate":
                 if getattr(self, attr) != getattr(other, attr):
-                    raise ValueError("Inconsistent values of %s" % attr)
-                    # how to handle name and annotations?
+                    raise ValueError(
+                        "Inconsistent values of %s" % attr)  # how to handle name and annotations?
 
     def _repr_pretty_(self, pp, cycle):
         '''
         Handle pretty-printing the :class:`AnalogSignal`.
         '''
         pp.text("{cls} with {channels} channels of length {length}; "
-                "units {units}; datatype {dtype} ".format(
-            cls=self.__class__.__name__,
-            channels=self.shape[1],
-            length=self.shape[0],
-            units=self.units.dimensionality.string,
+                "units {units}; datatype {dtype} ".format(cls=self.__class__.__name__,
+            channels=self.shape[1], length=self.shape[0], units=self.units.dimensionality.string,
             dtype=self.dtype))
         if self._has_repr_pretty_attrs_():
             pp.breakable()
@@ -462,8 +439,7 @@ class AnalogSignal(BaseSignal):
                 pp.text(line)
 
         for line in ["sampling rate: {0}".format(self.sampling_rate),
-                     "time: {0} to {1}".format(self.t_start, self.t_stop)
-                     ]:
+                     "time: {0} to {1}".format(self.t_start, self.t_stop)]:
             _pp(line)
 
     def time_index(self, t):
@@ -518,7 +494,7 @@ class AnalogSignal(BaseSignal):
 
         If `copy` is False (the default), modify the current signal in place.
         If `copy` is True, return a new signal and leave the current one untouched.
-        In this case, the new signal will not be linked to any parent objects.        
+        In this case, the new signal will not be linked to any parent objects.
         """
         if signal.t_start < self.t_start:
             raise ValueError("Cannot splice earlier than the start of the signal")

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -413,8 +413,9 @@ class AnalogSignal(BaseSignal):
         '''
         Equality test (==)
         '''
-        if (self.t_start != other.t_start or
-                    self.sampling_rate != other.sampling_rate):
+        if (isinstance(other, AnalogSignal) and
+                    (self.t_start != other.t_start or
+                     self.sampling_rate != other.sampling_rate)):
             return False
         return super(AnalogSignal, self).__eq__(other)
 

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -384,10 +384,10 @@ class IrregularlySampledSignal(BaseSignal):
         id_stop = None
         for i in indices:
             if id_start is None:
-                if i is True:
+                if i == True:
                     id_start = count
             else:
-                if i is False:
+                if i == False:
                     id_stop = count
                     break
             count += 1

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -384,10 +384,10 @@ class IrregularlySampledSignal(BaseSignal):
         id_stop = None
         for i in indices:
             if id_start is None:
-                if i == True:
+                if i is True:
                     id_start = count
             else:
-                if i == False:
+                if i is False:
                     id_stop = count
                     break
             count += 1

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -384,10 +384,10 @@ class IrregularlySampledSignal(BaseSignal):
         id_stop = None
         for i in indices:
             if id_start is None:
-                if i == True:
+                if i :
                     id_start = count
             else:
-                if i == False:
+                if not i:
                     id_stop = count
                     break
             count += 1

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -276,8 +276,10 @@ class IrregularlySampledSignal(BaseSignal):
         '''
         Equality test (==)
         '''
-        return (super(IrregularlySampledSignal, self).__eq__(other).all() and
-                (self.times == other.times).all())
+        if (isinstance(other, IrregularlySampledSignal) and
+                    not (self.times == other.times).all()):
+            return False
+        return super(IrregularlySampledSignal, self).__eq__(other)
 
     def _check_consistency(self, other):
         '''

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -4,8 +4,8 @@ This module implements :class:`IrregularlySampledSignal`, an array of analog
 signals with samples taken at arbitrary time points.
 
 :class:`IrregularlySampledSignal` inherits from :class:`basesignal.BaseSignal`
-which derives from :class:`BaseNeo`, from :module:`neo.core.baseneo`, 
-and from :class:`quantities.Quantity`, which in turn inherits from 
+which derives from :class:`BaseNeo`, from :module:`neo.core.baseneo`,
+and from :class:`quantities.Quantity`, which in turn inherits from
 :class:`numpy.ndarray`.
 
 Inheritance from :class:`numpy.array` is explained here:
@@ -39,9 +39,9 @@ def _new_IrregularlySampledSignal(cls, times, signal, units=None, time_units=Non
     A function to map IrregularlySampledSignal.__new__ to a function that
     does not do the unit checking. This is needed for pickle to work.
     '''
-    iss = cls(times=times, signal=signal, units=units, time_units=time_units,
-              dtype=dtype, copy=copy, name=name, file_origin=file_origin,
-              description=description, **annotations)
+    iss = cls(times=times, signal=signal, units=units, time_units=time_units, dtype=dtype,
+              copy=copy, name=name, file_origin=file_origin, description=description,
+              **annotations)
     iss.segment = segment
     iss.channel_index = channel_index
     return iss
@@ -116,13 +116,10 @@ class IrregularlySampledSignal(BaseSignal):
 
     _single_parent_objects = ('Segment', 'ChannelIndex')
     _quantity_attr = 'signal'
-    _necessary_attrs = (('times', pq.Quantity, 1),
-                        ('signal', pq.Quantity, 2))
+    _necessary_attrs = (('times', pq.Quantity, 1), ('signal', pq.Quantity, 2))
 
-    def __new__(cls, times, signal, units=None, time_units=None, dtype=None,
-                copy=True, name=None, file_origin=None,
-                description=None,
-                **annotations):
+    def __new__(cls, times, signal, units=None, time_units=None, dtype=None, copy=True, name=None,
+                file_origin=None, description=None, **annotations):
         '''
         Construct a new :class:`IrregularlySampledSignal` instance.
 
@@ -140,48 +137,36 @@ class IrregularlySampledSignal(BaseSignal):
             if time_units != times.units:
                 times = times.rescale(time_units)
         # should check time units have correct dimensions
-        obj = pq.Quantity.__new__(cls, signal, units=units,
-                                  dtype=dtype, copy=copy)
+        obj = pq.Quantity.__new__(cls, signal, units=units, dtype=dtype, copy=copy)
         if obj.ndim == 1:
             obj = obj.reshape(-1, 1)
         if len(times) != obj.shape[0]:
             raise ValueError("times array and signal array must "
                              "have same length")
-        obj.times = pq.Quantity(times, units=time_units,
-                                dtype=float, copy=copy)
+        obj.times = pq.Quantity(times, units=time_units, dtype=float, copy=copy)
         obj.segment = None
         obj.channel_index = None
 
         return obj
 
-    def __init__(self, times, signal, units=None, time_units=None, dtype=None,
-                 copy=True, name=None, file_origin=None, description=None,
-                 **annotations):
+    def __init__(self, times, signal, units=None, time_units=None, dtype=None, copy=True,
+                 name=None, file_origin=None, description=None, **annotations):
         '''
         Initializes a newly constructed :class:`IrregularlySampledSignal`
         instance.
         '''
-        BaseNeo.__init__(self, name=name, file_origin=file_origin,
-                         description=description, **annotations)
+        BaseNeo.__init__(self, name=name, file_origin=file_origin, description=description,
+                         **annotations)
 
     def __reduce__(self):
         '''
         Map the __new__ function onto _new_IrregularlySampledSignal, so that pickle
         works
         '''
-        return _new_IrregularlySampledSignal, (self.__class__,
-                                               self.times,
-                                               np.array(self),
-                                               self.units,
-                                               self.times.units,
-                                               self.dtype,
-                                               True,
-                                               self.name,
-                                               self.file_origin,
-                                               self.description,
-                                               self.annotations,
-                                               self.segment,
-                                               self.channel_index)
+        return _new_IrregularlySampledSignal, (
+            self.__class__, self.times, np.array(self), self.units, self.times.units, self.dtype,
+            True, self.name, self.file_origin, self.description, self.annotations, self.segment,
+            self.channel_index)
 
     def _array_finalize_spec(self, obj):
         '''
@@ -197,9 +182,8 @@ class IrregularlySampledSignal(BaseSignal):
 
     def __deepcopy__(self, memo):
         cls = self.__class__
-        new_signal = cls(self.times, np.array(self), units=self.units,
-                         time_units=self.times.units, dtype=self.dtype,
-                         t_start=self.t_start, name=self.name,
+        new_signal = cls(self.times, np.array(self), units=self.units, time_units=self.times.units,
+                         dtype=self.dtype, t_start=self.t_start, name=self.name,
                          file_origin=self.file_origin, description=self.description)
         new_signal.__dict__.update(self.__dict__)
         memo[id(self)] = new_signal
@@ -214,9 +198,8 @@ class IrregularlySampledSignal(BaseSignal):
         '''
         Returns a string representing the :class:`IrregularlySampledSignal`.
         '''
-        return '<%s(%s at times %s)>' % (self.__class__.__name__,
-                                         super(IrregularlySampledSignal,
-                                               self).__repr__(), self.times)
+        return '<%s(%s at times %s)>' % (
+            self.__class__.__name__, super(IrregularlySampledSignal, self).__repr__(), self.times)
 
     def __getitem__(self, i):
         '''
@@ -237,8 +220,7 @@ class IrregularlySampledSignal(BaseSignal):
                 else:
                     raise TypeError("%s not supported" % type(j))
                 if isinstance(k, (int, np.integer)):
-                    obj = obj.reshape(-1, 1)
-                    # add if channel_index
+                    obj = obj.reshape(-1, 1)  # add if channel_index
         elif isinstance(i, slice):
             obj.times = self.times.__getitem__(i)
         elif isinstance(i, np.ndarray):
@@ -288,8 +270,7 @@ class IrregularlySampledSignal(BaseSignal):
         '''
         Equality test (==)
         '''
-        if (isinstance(other, IrregularlySampledSignal) and
-                    not (self.times == other.times).all()):
+        if (isinstance(other, IrregularlySampledSignal) and not (self.times == other.times).all()):
             return False
         return super(IrregularlySampledSignal, self).__eq__(other)
 
@@ -306,8 +287,7 @@ class IrregularlySampledSignal(BaseSignal):
             return
         # dimensionality should match
         if self.ndim != other.ndim:
-            raise ValueError('Dimensionality does not match: %s vs %s' %
-                             (self.ndim, other.ndim))
+            raise ValueError('Dimensionality does not match: %s vs %s' % (self.ndim, other.ndim))
         # if if the other array does not have a times property,
         # then it should be okay to add it directly
         if not hasattr(other, 'times'):
@@ -315,8 +295,7 @@ class IrregularlySampledSignal(BaseSignal):
 
         # if there is a times property, the times need to be the same
         if not (self.times == other.times).all():
-            raise ValueError('Times do not match: %s vs %s' %
-                             (self.times, other.times))
+            raise ValueError('Times do not match: %s vs %s' % (self.times, other.times))
 
     def __rsub__(self, other, *args):
         '''
@@ -329,12 +308,11 @@ class IrregularlySampledSignal(BaseSignal):
         Handle pretty-printing the :class:`IrregularlySampledSignal`.
         '''
         pp.text("{cls} with {channels} channels of length {length}; "
-                "units {units}; datatype {dtype} ".format(
-            cls=self.__class__.__name__,
-            channels=self.shape[1],
-            length=self.shape[0],
-            units=self.units.dimensionality.string,
-            dtype=self.dtype))
+                "units {units}; datatype {dtype} ".format(cls=self.__class__.__name__,
+                                                          channels=self.shape[1],
+                                                          length=self.shape[0],
+                                                          units=self.units.dimensionality.string,
+                                                          dtype=self.dtype))
         if self._has_repr_pretty_attrs_():
             pp.breakable()
             self._repr_pretty_attrs_(pp, cycle)
@@ -455,11 +433,10 @@ class IrregularlySampledSignal(BaseSignal):
                 kwargs[name] = attr_self
             else:
                 kwargs[name] = "merge(%s, %s)" % (attr_self, attr_other)
-        merged_annotations = merge_annotations(self.annotations,
-                                               other.annotations)
+        merged_annotations = merge_annotations(self.annotations, other.annotations)
         kwargs.update(merged_annotations)
-        signal = self.__class__(self.times, stack, units=self.units, dtype=self.dtype,
-                                copy=False, **kwargs)
+        signal = self.__class__(self.times, stack, units=self.units, dtype=self.dtype, copy=False,
+                                **kwargs)
         signal.segment = self.segment
 
         if hasattr(self, "lazy_shape"):
@@ -467,12 +444,13 @@ class IrregularlySampledSignal(BaseSignal):
 
         # merge channel_index (move to ChannelIndex.merge()?)
         if self.channel_index and other.channel_index:
-            signal.channel_index = ChannelIndex(
-                index=np.arange(signal.shape[1]),
-                channel_ids=np.hstack([self.channel_index.channel_ids,
-                                       other.channel_index.channel_ids]),
-                channel_names=np.hstack([self.channel_index.channel_names,
-                                         other.channel_index.channel_names]))
+            signal.channel_index = ChannelIndex(index=np.arange(signal.shape[1]),
+                                                channel_ids=np.hstack(
+                                                    [self.channel_index.channel_ids,
+                                                     other.channel_index.channel_ids]),
+                                                channel_names=np.hstack(
+                                                    [self.channel_index.channel_names,
+                                                     other.channel_index.channel_names]))
         else:
             signal.channel_index = ChannelIndex(index=np.arange(signal.shape[1]))
 

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -205,10 +205,11 @@ class IrregularlySampledSignal(BaseSignal):
         '''
         Get the item or slice :attr:`i`.
         '''
-        obj = super(IrregularlySampledSignal, self).__getitem__(i)
         if isinstance(i, (int, np.integer)):  # a single point in time across all channels
+            obj = super(IrregularlySampledSignal, self).__getitem__(i)
             obj = pq.Quantity(obj.magnitude, units=obj.units)
         elif isinstance(i, tuple):
+            obj = super(IrregularlySampledSignal, self).__getitem__(i)
             j, k = i
             if isinstance(j, (int, np.integer)):  # a single point in time across some channels
                 obj = pq.Quantity(obj.magnitude, units=obj.units)
@@ -222,6 +223,7 @@ class IrregularlySampledSignal(BaseSignal):
                 if isinstance(k, (int, np.integer)):
                     obj = obj.reshape(-1, 1)  # add if channel_index
         elif isinstance(i, slice):
+            obj = super(IrregularlySampledSignal, self).__getitem__(i)
             obj.times = self.times.__getitem__(i)
         elif isinstance(i, np.ndarray):
             # Indexing of an IrregularlySampledSignal is only consistent if the resulting
@@ -230,8 +232,9 @@ class IrregularlySampledSignal(BaseSignal):
             # IrregularlySampledSignal here.
             new_time_dims = np.sum(i, axis=0)
             if len(new_time_dims) and all(new_time_dims == new_time_dims[0]):
-                obj = obj.reshape(-1, self.shape[1])
-                obj = pq.Quantity(obj.magnitude, units=obj.units)
+                obj = np.asarray(self).T.__getitem__(i.T)
+                obj = obj.T.reshape(self.shape[1], -1).T
+                obj = pq.Quantity(obj, units=self.units)
             else:
                 raise IndexError("indexing of an IrregularlySampledSignal needs to keep the same "
                                  "number of sample for each trace contained")

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -384,7 +384,7 @@ class IrregularlySampledSignal(BaseSignal):
         id_stop = None
         for i in indices:
             if id_start is None:
-                if i :
+                if i:
                     id_start = count
             else:
                 if not i:

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -26,21 +26,18 @@ from numpy.testing import assert_array_equal
 from neo.core.analogsignal import AnalogSignal, _get_sampling_rate
 from neo.core.channelindex import ChannelIndex
 from neo.core import Segment
-from neo.test.tools import (assert_arrays_almost_equal,
-                            assert_neo_object_is_compliant,
-                            assert_same_sub_schema,
-                            assert_objects_equivalent,
-                            assert_same_attributes,
-                            assert_same_sub_schema)
-from neo.test.generate_datasets import (get_fake_value, get_fake_values,
-                                        fake_neo, TEST_ANNOTATIONS)
+from neo.test.tools import (assert_arrays_almost_equal, assert_neo_object_is_compliant,
+                            assert_same_sub_schema, assert_objects_equivalent,
+                            assert_same_attributes, assert_same_sub_schema)
+from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_neo,
+                                        TEST_ANNOTATIONS)
 
 
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict([(str(x), TEST_ANNOTATIONS[x]) for x in
-                                 range(len(TEST_ANNOTATIONS))])
+        self.annotations = dict(
+            [(str(x), TEST_ANNOTATIONS[x]) for x in range(len(TEST_ANNOTATIONS))])
 
     def test__fake_neo__cascade(self):
         self.annotations['seed'] = None
@@ -93,13 +90,11 @@ class TestAnalogSignalConstructor(unittest.TestCase):
 
     def test__create_from_array_no_units_ValueError(self):
         data = np.arange(10.0)
-        self.assertRaises(ValueError, AnalogSignal, data,
-                          sampling_rate=1 * pq.kHz)
+        self.assertRaises(ValueError, AnalogSignal, data, sampling_rate=1 * pq.kHz)
 
     def test__create_from_quantities_array_inconsistent_units_ValueError(self):
         data = np.arange(10.0) * pq.mV
-        self.assertRaises(ValueError, AnalogSignal, data,
-                          sampling_rate=1 * pq.kHz, units="nA")
+        self.assertRaises(ValueError, AnalogSignal, data, sampling_rate=1 * pq.kHz, units="nA")
 
     def test__create_without_sampling_rate_or_period_ValueError(self):
         data = np.arange(10.0) * pq.mV
@@ -112,13 +107,12 @@ class TestAnalogSignalConstructor(unittest.TestCase):
     def test__create_with_None_t_start_should_raise_ValueError(self):
         data = np.arange(10.0) * pq.mV
         rate = 5000 * pq.Hz
-        self.assertRaises(ValueError, AnalogSignal, data,
-                          sampling_rate=rate, t_start=None)
+        self.assertRaises(ValueError, AnalogSignal, data, sampling_rate=rate, t_start=None)
 
     def test__create_inconsistent_sampling_rate_and_period_ValueError(self):
         data = np.arange(10.0) * pq.mV
-        self.assertRaises(ValueError, AnalogSignal, data,
-                          sampling_rate=1 * pq.kHz, sampling_period=5 * pq.s)
+        self.assertRaises(ValueError, AnalogSignal, data, sampling_rate=1 * pq.kHz,
+                          sampling_period=5 * pq.s)
 
     def test__create_with_copy_true_should_return_copy(self):
         data = np.arange(10.0) * pq.mV
@@ -162,14 +156,10 @@ class TestAnalogSignalProperties(unittest.TestCase):
         self.t_start = [0.0 * pq.ms, 100 * pq.ms, -200 * pq.ms]
         self.rates = [1 * pq.kHz, 420 * pq.Hz, 999 * pq.Hz]
         self.rates2 = [2 * pq.kHz, 290 * pq.Hz, 1111 * pq.Hz]
-        self.data = [np.arange(10.0) * pq.nA,
-                     np.arange(-100.0, 100.0, 10.0) * pq.mV,
+        self.data = [np.arange(10.0) * pq.nA, np.arange(-100.0, 100.0, 10.0) * pq.mV,
                      np.random.uniform(size=100) * pq.uV]
-        self.signals = [AnalogSignal(D, sampling_rate=r, t_start=t,
-                                     testattr='test')
-                        for r, D, t in zip(self.rates,
-                                           self.data,
-                                           self.t_start)]
+        self.signals = [AnalogSignal(D, sampling_rate=r, t_start=t, testattr='test') for r, D, t in
+                        zip(self.rates, self.data, self.t_start)]
 
     def test__compliant(self):
         for signal in self.signals:
@@ -177,14 +167,11 @@ class TestAnalogSignalProperties(unittest.TestCase):
 
     def test__t_stop_getter(self):
         for i, signal in enumerate(self.signals):
-            self.assertEqual(signal.t_stop,
-                             self.t_start[i] + self.data[i].size / self.rates[i])
+            self.assertEqual(signal.t_stop, self.t_start[i] + self.data[i].size / self.rates[i])
 
     def test__duration_getter(self):
         for signal in self.signals:
-            self.assertAlmostEqual(signal.duration,
-                                   signal.t_stop - signal.t_start,
-                                   delta=1e-15)
+            self.assertAlmostEqual(signal.duration, signal.t_stop - signal.t_start, delta=1e-15)
 
     def test__sampling_rate_getter(self):
         for signal, rate in zip(self.signals, self.rates):
@@ -209,12 +196,10 @@ class TestAnalogSignalProperties(unittest.TestCase):
             self.assertEqual(signal.sampling_period, 1 / rate)
 
     def test__sampling_rate_setter_None_ValueError(self):
-        self.assertRaises(ValueError, setattr, self.signals[0],
-                          'sampling_rate', None)
+        self.assertRaises(ValueError, setattr, self.signals[0], 'sampling_rate', None)
 
     def test__sampling_rate_setter_not_quantity_ValueError(self):
-        self.assertRaises(ValueError, setattr, self.signals[0],
-                          'sampling_rate', 5.5)
+        self.assertRaises(ValueError, setattr, self.signals[0], 'sampling_rate', 5.5)
 
     def test__sampling_period_setter_None_ValueError(self):
         signal = self.signals[0]
@@ -222,8 +207,7 @@ class TestAnalogSignalProperties(unittest.TestCase):
         self.assertRaises(ValueError, setattr, signal, 'sampling_period', None)
 
     def test__sampling_period_setter_not_quantity_ValueError(self):
-        self.assertRaises(ValueError, setattr, self.signals[0],
-                          'sampling_period', 5.5)
+        self.assertRaises(ValueError, setattr, self.signals[0], 'sampling_period', 5.5)
 
     def test__t_start_setter_None_ValueError(self):
         signal = self.signals[0]
@@ -242,8 +226,7 @@ class TestAnalogSignalProperties(unittest.TestCase):
         signal2 = self.signals[2]
         data2 = self.data[2]
         signal1b = signal1.duplicate_with_new_array(data2)
-        assert_arrays_almost_equal(np.asarray(signal1b),
-                                   np.asarray(signal2 / 1000.), 1e-12)
+        assert_arrays_almost_equal(np.asarray(signal1b), np.asarray(signal2 / 1000.), 1e-12)
         self.assertEqual(signal1b.t_start, signal1.t_start)
         self.assertEqual(signal1b.sampling_rate, signal1.sampling_rate)
 
@@ -280,23 +263,20 @@ class TestAnalogSignalProperties(unittest.TestCase):
     def test__repr(self):
         for i, signal in enumerate(self.signals):
             prepr = repr(signal)
-            targ = '<AnalogSignal(%s, [%s, %s], sampling rate: %s)>' % \
-                   (repr(self.data[i].reshape(-1, 1)),
-                    self.t_start[i],
-                    self.t_start[i] + len(self.data[i]) / self.rates[i],
-                    self.rates[i])
+            targ = '<AnalogSignal(%s, [%s, %s], sampling rate: %s)>' % (
+            repr(self.data[i].reshape(-1, 1)), self.t_start[i],
+            self.t_start[i] + len(self.data[i]) / self.rates[i], self.rates[i])
             self.assertEqual(prepr, targ)
 
     @unittest.skipUnless(HAVE_IPYTHON, "requires IPython")
     def test__pretty(self):
         for i, signal in enumerate(self.signals):
             prepr = pretty(signal)
-            targ = (('AnalogSignal with %d channels of length %d; units %s; datatype %s \n' %
-                     (signal.shape[1], signal.shape[0], signal.units.dimensionality.unicode,
-                      signal.dtype)) +
-                    ('annotations: %s\n' % signal.annotations) +
-                    ('sampling rate: {}\n'.format(signal.sampling_rate)) +
-                    ('time: {} to {}'.format(signal.t_start, signal.t_stop)))
+            targ = (('AnalogSignal with %d channels of length %d; units %s; datatype %s \n' % (
+            signal.shape[1], signal.shape[0], signal.units.dimensionality.unicode,
+            signal.dtype)) + ('annotations: %s\n' % signal.annotations) + (
+                        'sampling rate: {}\n'.format(signal.sampling_rate)) + (
+                        'time: {} to {}'.format(signal.t_start, signal.t_stop)))
             self.assertEqual(prepr, targ)
 
 
@@ -304,9 +284,8 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
     def setUp(self):
         self.data1 = np.arange(10.0)
         self.data1quant = self.data1 * pq.nA
-        self.signal1 = AnalogSignal(self.data1quant, sampling_rate=1 * pq.kHz,
-                                    name='spam', description='eggs',
-                                    file_origin='testfile.txt', arg1='test')
+        self.signal1 = AnalogSignal(self.data1quant, sampling_rate=1 * pq.kHz, name='spam',
+                                    description='eggs', file_origin='testfile.txt', arg1='test')
         self.signal1.segment = Segment()
         self.signal1.channel_index = ChannelIndex(index=[0])
 
@@ -329,10 +308,8 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
             self.assertEqual(result.size, 5)
             self.assertEqual(result.sampling_period, self.signal1.sampling_period)
             self.assertEqual(result.sampling_rate, self.signal1.sampling_rate)
-            self.assertEqual(result.t_start,
-                             self.signal1.t_start + 3 * result.sampling_period)
-            self.assertEqual(result.t_stop,
-                             result.t_start + 5 * result.sampling_period)
+            self.assertEqual(result.t_start, self.signal1.t_start + 3 * result.sampling_period)
+            self.assertEqual(result.t_stop, result.t_start + 5 * result.sampling_period)
             assert_array_equal(result.magnitude, self.data1[3:8].reshape(-1, 1))
 
             # Test other attributes were copied over (in this case, defaults)
@@ -373,10 +350,8 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.assertEqual(result3.annotations, {'arg1': 'test'})
 
         self.assertEqual(result1.sampling_period, self.signal1.sampling_period)
-        self.assertEqual(result2.sampling_period,
-                         self.signal1.sampling_period * 2)
-        self.assertEqual(result3.sampling_period,
-                         self.signal1.sampling_period * 2)
+        self.assertEqual(result2.sampling_period, self.signal1.sampling_period * 2)
+        self.assertEqual(result3.sampling_period, self.signal1.sampling_period * 2)
 
         assert_array_equal(result1.magnitude, self.data1[:2].reshape(-1, 1))
         assert_array_equal(result2.magnitude, self.data1[::2].reshape(-1, 1))
@@ -384,10 +359,8 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
 
     def test__slice_should_modify_linked_channelindex(self):
         n = 8  # number of channels
-        signal = AnalogSignal(np.arange(n * 100.0).reshape(100, n),
-                              sampling_rate=1 * pq.kHz,
-                              units="mV",
-                              name="test")
+        signal = AnalogSignal(np.arange(n * 100.0).reshape(100, n), sampling_rate=1 * pq.kHz,
+                              units="mV", name="test")
         self.assertEqual(signal.shape, (100, n))
         signal.channel_index = ChannelIndex(index=np.arange(n, dtype=int),
                                             channel_names=["channel{0}".format(i) for i in
@@ -396,10 +369,10 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         odd_channels = signal[:, 1::2]
         self.assertEqual(odd_channels.shape, (100, n // 2))
         assert_array_equal(odd_channels.channel_index.index, np.arange(n // 2, dtype=int))
-        assert_array_equal(odd_channels.channel_index.channel_names, [
-            "channel{0}".format(i) for i in range(1, n, 2)])
-        assert_array_equal(signal.channel_index.channel_names, [
-            "channel{0}".format(i) for i in range(n)])
+        assert_array_equal(odd_channels.channel_index.channel_names,
+                           ["channel{0}".format(i) for i in range(1, n, 2)])
+        assert_array_equal(signal.channel_index.channel_names,
+                           ["channel{0}".format(i) for i in range(n)])
         self.assertEqual(odd_channels.channel_index.analogsignals[0].name, signal.name)
 
     def test__copy_should_let_access_to_parents_objects(self):
@@ -437,21 +410,17 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.assertRaises(IndexError, self.signal1.__getitem__, (10, 0))
 
     def test_comparison_operators(self):
-        assert_array_equal(self.signal1 >= 5 * pq.nA,
-                           np.array([False, False, False, False, False,
-                                     True, True, True, True, True]).reshape(-1, 1))
-        assert_array_equal(self.signal1 >= 5 * pq.pA,
-                           np.array([False, True, True, True, True,
-                                     True, True, True, True, True]).reshape(-1, 1))
-        assert_array_equal(self.signal1 == 5 * pq.nA,
-                           np.array([False, False, False, False, False,
-                                     True, False, False, False, False]).reshape(-1, 1))
-        assert_array_equal(self.signal1 == self.signal1,
-                           np.array([True, True, True, True, True,
-                                     True, True, True, True, True]).reshape(-1, 1))
+        assert_array_equal(self.signal1 >= 5 * pq.nA, np.array(
+            [False, False, False, False, False, True, True, True, True, True]).reshape(-1, 1))
+        assert_array_equal(self.signal1 >= 5 * pq.pA, np.array(
+            [False, True, True, True, True, True, True, True, True, True]).reshape(-1, 1))
+        assert_array_equal(self.signal1 == 5 * pq.nA, np.array(
+            [False, False, False, False, False, True, False, False, False, False]).reshape(-1, 1))
+        assert_array_equal(self.signal1 == self.signal1, np.array(
+            [True, True, True, True, True, True, True, True, True, True]).reshape(-1, 1))
 
     def test__comparison_as_indexing(self):
-        self.assertEqual(self.signal1[self.signal1 == 5], [5*pq.mV])
+        self.assertEqual(self.signal1[self.signal1 == 5], [5 * pq.mV])
 
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.mV)
@@ -514,10 +483,8 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         assert_array_equal(self.data1, sig_as_q.magnitude.flat)
 
     def test_splice_1channel_inplace(self):
-        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1],
-                                           t_start=3 * pq.ms,
-                                           sampling_rate=self.signal1.sampling_rate,
-                                           units=pq.uA)
+        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1], t_start=3 * pq.ms,
+                                           sampling_rate=self.signal1.sampling_rate, units=pq.uA)
         result = self.signal1.splice(signal_for_splicing, copy=False)
         assert_array_equal(result.magnitude.flatten(),
                            np.array([0.0, 1.0, 2.0, 100.0, 100.0, 100.0, 6.0, 7.0, 8.0, 9.0]))
@@ -526,10 +493,8 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.assertEqual(result.channel_index, self.signal1.channel_index)
 
     def test_splice_1channel_with_copy(self):
-        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1],
-                                           t_start=3 * pq.ms,
-                                           sampling_rate=self.signal1.sampling_rate,
-                                           units=pq.uA)
+        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1], t_start=3 * pq.ms,
+                                           sampling_rate=self.signal1.sampling_rate, units=pq.uA)
         result = self.signal1.splice(signal_for_splicing, copy=True)
         assert_array_equal(result.magnitude.flatten(),
                            np.array([0.0, 1.0, 2.0, 100.0, 100.0, 100.0, 6.0, 7.0, 8.0, 9.0]))
@@ -539,62 +504,45 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.assertIs(result.channel_index, None)
 
     def test_splice_2channels_inplace(self):
-        signal = AnalogSignal(np.arange(20.0).reshape((10, 2)),
-                              sampling_rate=1 * pq.kHz,
+        signal = AnalogSignal(np.arange(20.0).reshape((10, 2)), sampling_rate=1 * pq.kHz,
                               units="mV")
         signal_for_splicing = AnalogSignal(np.array([[0.1, 0.0], [0.2, 0.0], [0.3, 0.0]]),
                                            t_start=3 * pq.ms,
-                                           sampling_rate=self.signal1.sampling_rate,
-                                           units=pq.V)
+                                           sampling_rate=self.signal1.sampling_rate, units=pq.V)
         result = signal.splice(signal_for_splicing, copy=False)
-        assert_array_equal(result.magnitude,
-                           np.array([[0.0, 1.0],
-                                     [2.0, 3.0],
-                                     [4.0, 5.0],
-                                     [100.0, 0.0],
-                                     [200.0, 0.0],
-                                     [300.0, 0.0],
-                                     [12.0, 13.0],
-                                     [14.0, 15.0],
-                                     [16.0, 17.0],
-                                     [18.0, 19.0]]))
+        assert_array_equal(result.magnitude, np.array(
+            [[0.0, 1.0], [2.0, 3.0], [4.0, 5.0], [100.0, 0.0], [200.0, 0.0], [300.0, 0.0],
+             [12.0, 13.0], [14.0, 15.0], [16.0, 17.0], [18.0, 19.0]]))
         assert_array_equal(signal, result)  # in-place
 
     def test_splice_1channel_invalid_t_start(self):
-        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1],
-                                           t_start=12 * pq.ms,  # after the end of the signal
-                                           sampling_rate=self.signal1.sampling_rate,
-                                           units=pq.uA)
+        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1], t_start=12 * pq.ms,
+                                           # after the end of the signal
+                                           sampling_rate=self.signal1.sampling_rate, units=pq.uA)
         self.assertRaises(ValueError, self.signal1.splice, signal_for_splicing, copy=False)
 
     def test_splice_1channel_invalid_t_stop(self):
-        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1],
-                                           t_start=8 * pq.ms,  # too close to the end of the signal
-                                           sampling_rate=self.signal1.sampling_rate,
-                                           units=pq.uA)
+        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1], t_start=8 * pq.ms,
+                                           # too close to the end of the signal
+                                           sampling_rate=self.signal1.sampling_rate, units=pq.uA)
         self.assertRaises(ValueError, self.signal1.splice, signal_for_splicing, copy=False)
 
     def test_splice_1channel_invalid_sampling_rate(self):
-        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1],
-                                           t_start=3 * pq.ms,
+        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1], t_start=3 * pq.ms,
                                            sampling_rate=2 * self.signal1.sampling_rate,
                                            units=pq.uA)
         self.assertRaises(ValueError, self.signal1.splice, signal_for_splicing, copy=False)
 
     def test_splice_1channel_invalid_units(self):
-        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1],
-                                           t_start=3 * pq.ms,
-                                           sampling_rate=self.signal1.sampling_rate,
-                                           units=pq.uV)
+        signal_for_splicing = AnalogSignal([0.1, 0.1, 0.1], t_start=3 * pq.ms,
+                                           sampling_rate=self.signal1.sampling_rate, units=pq.uV)
         self.assertRaises(ValueError, self.signal1.splice, signal_for_splicing, copy=False)
 
 
 class TestAnalogSignalEquality(unittest.TestCase):
     def test__signals_with_different_data_complement_should_be_not_equal(self):
-        signal1 = AnalogSignal(np.arange(10.0), units="mV",
-                               sampling_rate=1 * pq.kHz)
-        signal2 = AnalogSignal(np.arange(10.0), units="mV",
-                               sampling_rate=2 * pq.kHz)
+        signal1 = AnalogSignal(np.arange(10.0), units="mV", sampling_rate=1 * pq.kHz)
+        signal2 = AnalogSignal(np.arange(10.0), units="mV", sampling_rate=2 * pq.kHz)
         assert_neo_object_is_compliant(signal1)
         assert_neo_object_is_compliant(signal2)
         self.assertNotEqual(signal1, signal2)
@@ -604,11 +552,8 @@ class TestAnalogSignalCombination(unittest.TestCase):
     def setUp(self):
         self.data1 = np.arange(10.0)
         self.data1quant = self.data1 * pq.mV
-        self.signal1 = AnalogSignal(self.data1quant,
-                                    sampling_rate=1 * pq.kHz,
-                                    name='spam', description='eggs',
-                                    file_origin='testfile.txt',
-                                    arg1='test')
+        self.signal1 = AnalogSignal(self.data1quant, sampling_rate=1 * pq.kHz, name='spam',
+                                    description='eggs', file_origin='testfile.txt', arg1='test')
 
     def test__compliant(self):
         assert_neo_object_is_compliant(self.signal1)
@@ -644,10 +589,9 @@ class TestAnalogSignalCombination(unittest.TestCase):
         self.assertEqual(result.file_origin, 'testfile.txt')
         self.assertEqual(result.annotations, {'arg1': 'test'})
 
-        targ = AnalogSignal(np.arange(10.0, 30.0, 2.0), units="mV",
-                            sampling_rate=1 * pq.kHz,
-                            name='spam', description='eggs',
-                            file_origin='testfile.txt', arg1='test')
+        targ = AnalogSignal(np.arange(10.0, 30.0, 2.0), units="mV", sampling_rate=1 * pq.kHz,
+                            name='spam', description='eggs', file_origin='testfile.txt',
+                            arg1='test')
         assert_neo_object_is_compliant(targ)
 
         assert_array_equal(result, targ)
@@ -667,10 +611,9 @@ class TestAnalogSignalCombination(unittest.TestCase):
         self.assertEqual(result.file_origin, 'testfile.txt')
         self.assertEqual(result.annotations, {'arg1': 'test'})
 
-        targ = AnalogSignal(np.arange(10.0, 30.0, 2.0), units="mV",
-                            sampling_rate=1 * pq.kHz,
-                            name='spam', description='eggs',
-                            file_origin='testfile.txt', arg1='test')
+        targ = AnalogSignal(np.arange(10.0, 30.0, 2.0), units="mV", sampling_rate=1 * pq.kHz,
+                            name='spam', description='eggs', file_origin='testfile.txt',
+                            arg1='test')
         assert_neo_object_is_compliant(targ)
 
         assert_array_equal(result, targ)
@@ -680,8 +623,8 @@ class TestAnalogSignalCombination(unittest.TestCase):
         self.signal1.t_start = 0.0 * pq.ms
         assert_neo_object_is_compliant(self.signal1)
 
-        signal2 = AnalogSignal(np.arange(10.0), units="mV",
-                               t_start=100.0 * pq.ms, sampling_rate=0.5 * pq.kHz)
+        signal2 = AnalogSignal(np.arange(10.0), units="mV", t_start=100.0 * pq.ms,
+                               sampling_rate=0.5 * pq.kHz)
         assert_neo_object_is_compliant(signal2)
 
         self.assertRaises(ValueError, self.signal1.__add__, signal2)
@@ -745,8 +688,7 @@ class TestAnalogSignalCombination(unittest.TestCase):
 
 class TestAnalogSignalFunctions(unittest.TestCase):
     def test__pickle(self):
-        signal1 = AnalogSignal([1, 2, 3, 4], sampling_period=1 * pq.ms,
-                               units=pq.S)
+        signal1 = AnalogSignal([1, 2, 3, 4], sampling_period=1 * pq.ms, units=pq.S)
         signal1.annotations['index'] = 2
         signal1.channel_index = ChannelIndex(index=[0])
 
@@ -770,8 +712,7 @@ class TestAnalogSignalSampling(unittest.TestCase):
     def test___get_sampling_rate__period_none_rate_none_ValueError(self):
         sampling_rate = None
         sampling_period = None
-        self.assertRaises(ValueError, _get_sampling_rate,
-                          sampling_rate, sampling_period)
+        self.assertRaises(ValueError, _get_sampling_rate, sampling_rate, sampling_period)
 
     def test___get_sampling_rate__period_quant_rate_none(self):
         sampling_rate = None
@@ -797,20 +738,17 @@ class TestAnalogSignalSampling(unittest.TestCase):
     def test___get_sampling_rate__period_rate_not_equivalent_ValueError(self):
         sampling_rate = pq.Quantity(10., units=pq.Hz)
         sampling_period = pq.Quantity(10, units=pq.s)
-        self.assertRaises(ValueError, _get_sampling_rate,
-                          sampling_rate, sampling_period)
+        self.assertRaises(ValueError, _get_sampling_rate, sampling_rate, sampling_period)
 
     def test___get_sampling_rate__period_none_rate_float_TypeError(self):
         sampling_rate = 10.
         sampling_period = None
-        self.assertRaises(TypeError, _get_sampling_rate,
-                          sampling_rate, sampling_period)
+        self.assertRaises(TypeError, _get_sampling_rate, sampling_rate, sampling_period)
 
     def test___get_sampling_rate__period_array_rate_none_TypeError(self):
         sampling_rate = None
         sampling_period = np.array(10.)
-        self.assertRaises(TypeError, _get_sampling_rate,
-                          sampling_rate, sampling_period)
+        self.assertRaises(TypeError, _get_sampling_rate, sampling_rate, sampling_period)
 
 
 if __name__ == "__main__":

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -274,7 +274,7 @@ class TestAnalogSignalProperties(unittest.TestCase):
             prepr = pretty(signal)
             targ = (('AnalogSignal with %d channels of length %d; units %s; datatype %s \n'
                      '' % (signal.shape[1], signal.shape[0],
-                           signal.units.dimensionality.unicode,signal.dtype))
+                           signal.units.dimensionality.unicode, signal.dtype))
                     + ('annotations: %s\n' % signal.annotations)
                     + ('sampling rate: {}\n'.format(signal.sampling_rate))
                     + ('time: {} to {}'.format(signal.t_start, signal.t_stop)))

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -450,6 +450,9 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
                            np.array([True, True, True, True, True,
                                      True, True, True, True, True]).reshape(-1, 1))
 
+    def test__comparison_as_indexing(self):
+        self.assertEqual(self.signal1[self.signal1 == 5], [5*pq.mV])
+
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.mV)
 

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -420,8 +420,13 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         assert_array_equal(self.signal1 == self.signal1, np.array(
             [True, True, True, True, True, True, True, True, True, True]).reshape(-1, 1))
 
-    def test__comparison_as_indexing(self):
+    def test__comparison_as_indexing_single_trace(self):
         self.assertEqual(self.signal1[self.signal1 == 5], [5 * pq.mV])
+
+    def test__comparison_as_indexing_multi_trace(self):
+        signal = AnalogSignal(np.arange(20).reshape((-1, 2))*pq.V, sampling_rate=1*pq.Hz)
+        assert_array_equal(signal[signal < 10],
+                           np.array([[0, 2, 4, 6, 8], [1, 3, 5, 7, 9]]).T * pq.V)
 
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.mV)

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -263,20 +263,21 @@ class TestAnalogSignalProperties(unittest.TestCase):
     def test__repr(self):
         for i, signal in enumerate(self.signals):
             prepr = repr(signal)
-            targ = '<AnalogSignal(%s, [%s, %s], sampling rate: %s)>' % (
-            repr(self.data[i].reshape(-1, 1)), self.t_start[i],
-            self.t_start[i] + len(self.data[i]) / self.rates[i], self.rates[i])
+            targ = '<AnalogSignal(%s, [%s, %s], sampling rate: %s)>' \
+                   '' % (repr(self.data[i].reshape(-1, 1)), self.t_start[i],
+                         self.t_start[i] + len(self.data[i]) / self.rates[i], self.rates[i])
             self.assertEqual(prepr, targ)
 
     @unittest.skipUnless(HAVE_IPYTHON, "requires IPython")
     def test__pretty(self):
         for i, signal in enumerate(self.signals):
             prepr = pretty(signal)
-            targ = (('AnalogSignal with %d channels of length %d; units %s; datatype %s \n' % (
-            signal.shape[1], signal.shape[0], signal.units.dimensionality.unicode,
-            signal.dtype)) + ('annotations: %s\n' % signal.annotations) + (
-                        'sampling rate: {}\n'.format(signal.sampling_rate)) + (
-                        'time: {} to {}'.format(signal.t_start, signal.t_stop)))
+            targ = (('AnalogSignal with %d channels of length %d; units %s; datatype %s \n'
+                     '' % (signal.shape[1], signal.shape[0],
+                           signal.units.dimensionality.unicode,signal.dtype))
+                    + ('annotations: %s\n' % signal.annotations)
+                    + ('sampling rate: {}\n'.format(signal.sampling_rate))
+                    + ('time: {} to {}'.format(signal.t_start, signal.t_stop)))
             self.assertEqual(prepr, targ)
 
 

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -423,10 +423,34 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
     def test__comparison_as_indexing_single_trace(self):
         self.assertEqual(self.signal1[self.signal1 == 5], [5 * pq.mV])
 
-    def test__comparison_as_indexing_multi_trace(self):
+    def test__comparison_as_indexing_double_trace(self):
         signal = AnalogSignal(np.arange(20).reshape((-1, 2))*pq.V, sampling_rate=1*pq.Hz)
         assert_array_equal(signal[signal < 10],
                            np.array([[0, 2, 4, 6, 8], [1, 3, 5, 7, 9]]).T * pq.V)
+
+    def test__indexing_keeps_order_across_channels(self):
+        # AnalogSignals with 10 traces each having 5 samples (eg. data[0] = [0,10,20,30,40])
+        data = np.array([range(10), range(10,20), range(20,30), range(30,40), range(40,50)])
+        mask = np.full((5,10), fill_value=False)
+        # selecting one entry per trace
+        mask[[0, 1, 0, 3, 0, 2, 4, 3, 1, 4], range(10)] = True
+
+        signal = AnalogSignal(np.array(data)*pq.V, sampling_rate=1*pq.Hz)
+        assert_array_equal(signal[mask],
+                           np.array([0, 11, 2, 33, 4, 25, 46, 37, 18, 49]) * pq.V)
+
+    def test__indexing_keeps_order_across_time(self):
+        # AnalogSignals with 10 traces each having 5 samples (eg. data[0] = [0,10,20,30,40])
+        data = np.array([range(10), range(10,20), range(20,30), range(30,40), range(40,50)])
+        mask = np.full((5,10), fill_value=False)
+        # selecting two entries per trace
+        temporal_ids = [0, 1, 0, 3, 1, 2, 4, 2, 1, 4] + [4, 3, 2, 1, 0, 1, 2, 3, 2, 1]
+        mask[temporal_ids, list(range(10)) + list(range(10))] = True
+
+        signal = AnalogSignal(np.array(data)*pq.V, sampling_rate=1*pq.Hz)
+        assert_array_equal(signal[mask],
+                           np.array([[0, 11, 2, 13, 4, 15, 26, 27, 18, 19],
+                                    [40, 31, 22, 33, 14, 25, 46, 37, 28, 49]]) * pq.V)
 
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.mV)

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -443,6 +443,12 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         assert_array_equal(self.signal1 >= 5 * pq.pA,
                            np.array([False, True, True, True, True,
                                      True, True, True, True, True]).reshape(-1, 1))
+        assert_array_equal(self.signal1 == 5 * pq.nA,
+                           np.array([False, False, False, False, False,
+                                     True, False, False, False, False]).reshape(-1, 1))
+        assert_array_equal(self.signal1 == self.signal1,
+                           np.array([True, True, True, True, True,
+                                     True, True, True, True, True]).reshape(-1, 1))
 
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.mV)

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -430,27 +430,26 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
 
     def test__indexing_keeps_order_across_channels(self):
         # AnalogSignals with 10 traces each having 5 samples (eg. data[0] = [0,10,20,30,40])
-        data = np.array([range(10), range(10,20), range(20,30), range(30,40), range(40,50)])
-        mask = np.full((5,10), fill_value=False)
+        data = np.array([range(10), range(10, 20), range(20, 30), range(30, 40), range(40, 50)])
+        mask = np.full((5, 10), fill_value=False)
         # selecting one entry per trace
         mask[[0, 1, 0, 3, 0, 2, 4, 3, 1, 4], range(10)] = True
 
-        signal = AnalogSignal(np.array(data)*pq.V, sampling_rate=1*pq.Hz)
-        assert_array_equal(signal[mask],
-                           np.array([0, 11, 2, 33, 4, 25, 46, 37, 18, 49]) * pq.V)
+        signal = AnalogSignal(np.array(data) * pq.V, sampling_rate=1 * pq.Hz)
+        assert_array_equal(signal[mask], np.array([[0, 11, 2, 33, 4, 25, 46, 37, 18, 49]]) * pq.V)
 
     def test__indexing_keeps_order_across_time(self):
         # AnalogSignals with 10 traces each having 5 samples (eg. data[0] = [0,10,20,30,40])
-        data = np.array([range(10), range(10,20), range(20,30), range(30,40), range(40,50)])
-        mask = np.full((5,10), fill_value=False)
+        data = np.array([range(10), range(10, 20), range(20, 30), range(30, 40), range(40, 50)])
+        mask = np.full((5, 10), fill_value=False)
         # selecting two entries per trace
         temporal_ids = [0, 1, 0, 3, 1, 2, 4, 2, 1, 4] + [4, 3, 2, 1, 0, 1, 2, 3, 2, 1]
         mask[temporal_ids, list(range(10)) + list(range(10))] = True
 
-        signal = AnalogSignal(np.array(data)*pq.V, sampling_rate=1*pq.Hz)
-        assert_array_equal(signal[mask],
-                           np.array([[0, 11, 2, 13, 4, 15, 26, 27, 18, 19],
-                                    [40, 31, 22, 33, 14, 25, 46, 37, 28, 49]]) * pq.V)
+        signal = AnalogSignal(np.array(data) * pq.V, sampling_rate=1 * pq.Hz)
+        assert_array_equal(signal[mask], np.array([[0, 11, 2, 13, 4, 15, 26, 27, 18, 19],
+                                                   [40, 31, 22, 33, 14, 25, 46, 37, 28,
+                                                    49]]) * pq.V)
 
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.mV)

--- a/neo/test/coretest/test_analogsignalarray.py
+++ b/neo/test/coretest/test_analogsignalarray.py
@@ -378,6 +378,14 @@ class TestAnalogSignalArrayArrayMethods(unittest.TestCase):
                             np.array([[False, True, True],
                                       [True, True, True],
                                       [True, True, True]]))
+        assert_arrays_equal(self.signal1[0:3, 0:3] == 5 * pq.nA,
+                            np.array([[False, False, False],
+                                      [True, False, False],
+                                      [False, False, False]]))
+        assert_arrays_equal(self.signal1[0:3, 0:3] == self.signal1[0:3, 0:3],
+                            np.array([[True, True, True],
+                                      [True, True, True],
+                                      [True, True, True]]))
 
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.mV)

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -320,6 +320,12 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         assert_array_equal(self.signal1 >= 5 * pq.mV,
                            np.array([[False, False, False, False, False,
                                       True, True, True, True, True]]).T)
+        assert_array_equal(self.signal1 == 5 * pq.mV,
+                           np.array([[False, False, False, False, False,
+                                      True, False, False, False, False]]).T)
+        assert_array_equal(self.signal1 == self.signal1,
+                           np.array([[True, True, True, True, True,
+                                      True, True, True, True, True]]).T)
 
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.nA)

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -327,6 +327,9 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
                            np.array([[True, True, True, True, True,
                                       True, True, True, True, True]]).T)
 
+    def test__comparison_as_indexing(self):
+        self.assertEqual(self.signal1[self.signal1 == 5], [5*pq.mV])
+
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.nA)
 

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -658,13 +658,12 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
     def test__pretty(self):
         res = pretty(self.signal1)
         signal = self.signal1
-        targ = ((
-                        "IrregularlySampledSignal with %d channels of length %d; units %s; "
-                        "datatype %s \n" % (
-                    signal.shape[1], signal.shape[0], signal.units.dimensionality.unicode,
-                    signal.dtype)) + ("name: '%s'\ndescription: '%s'\n" % (
-        signal.name, signal.description)) + ("annotations: %s\n" % str(signal.annotations)) + (
-                            "sample times: %s" % (signal.times[:10],)))
+        targ = (("IrregularlySampledSignal with %d channels of length %d; units %s; datatype %s \n"
+                 "" % (signal.shape[1], signal.shape[0], signal.units.dimensionality.unicode,
+                       signal.dtype))
+                + ("name: '%s'\ndescription: '%s'\n" % (signal.name, signal.description))
+                + ("annotations: %s\n" % str(signal.annotations))
+                + ("sample times: %s" % (signal.times[:10],)))
         self.assertEqual(res, targ)
 
     def test__merge(self):

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -281,8 +281,13 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         assert_array_equal(self.signal1 == self.signal1, np.array(
             [[True, True, True, True, True, True, True, True, True, True]]).T)
 
-    def test__comparison_as_indexing(self):
+    def test__comparison_as_indexing_single_trace(self):
         self.assertEqual(self.signal1[self.signal1 == 5], [5 * pq.mV])
+
+    def test__comparison_as_indexing_multi_trace(self):
+        signal = IrregularlySampledSignal(self.time1quant, np.arange(20).reshape((-1, 2))*pq.V)
+        assert_array_equal(signal[signal < 10],
+                           np.array([[0, 2, 4, 6, 8], [1, 3, 5, 7, 9]]).T * pq.V)
 
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.nA)

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -22,41 +22,32 @@ from neo.core.irregularlysampledsignal import IrregularlySampledSignal
 from neo.core import Segment, ChannelIndex
 from neo.core.baseneo import MergeError
 from neo.test.tools import (assert_arrays_almost_equal, assert_arrays_equal,
-                            assert_neo_object_is_compliant,
-                            assert_same_sub_schema)
-from neo.test.generate_datasets import (get_fake_value, get_fake_values,
-                                        fake_neo, TEST_ANNOTATIONS)
+                            assert_neo_object_is_compliant, assert_same_sub_schema)
+from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_neo,
+                                        TEST_ANNOTATIONS)
 
 
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict([(str(x), TEST_ANNOTATIONS[x]) for x in
-                                 range(len(TEST_ANNOTATIONS))])
+        self.annotations = dict(
+            [(str(x), TEST_ANNOTATIONS[x]) for x in range(len(TEST_ANNOTATIONS))])
 
     def test__get_fake_values(self):
         self.annotations['seed'] = 0
         times = get_fake_value('times', pq.Quantity, seed=0, dim=1)
         signal = get_fake_value('signal', pq.Quantity, seed=1, dim=2)
-        name = get_fake_value('name', str, seed=2,
-                              obj=IrregularlySampledSignal)
-        description = get_fake_value('description', str, seed=3,
-                                     obj='IrregularlySampledSignal')
+        name = get_fake_value('name', str, seed=2, obj=IrregularlySampledSignal)
+        description = get_fake_value('description', str, seed=3, obj='IrregularlySampledSignal')
         file_origin = get_fake_value('file_origin', str)
-        attrs1 = {'name': name,
-                  'description': description,
-                  'file_origin': file_origin}
+        attrs1 = {'name': name, 'description': description, 'file_origin': file_origin}
         attrs2 = attrs1.copy()
         attrs2.update(self.annotations)
 
-        res11 = get_fake_values(IrregularlySampledSignal,
-                                annotate=False, seed=0)
-        res12 = get_fake_values('IrregularlySampledSignal',
-                                annotate=False, seed=0)
-        res21 = get_fake_values(IrregularlySampledSignal,
-                                annotate=True, seed=0)
-        res22 = get_fake_values('IrregularlySampledSignal',
-                                annotate=True, seed=0)
+        res11 = get_fake_values(IrregularlySampledSignal, annotate=False, seed=0)
+        res12 = get_fake_values('IrregularlySampledSignal', annotate=False, seed=0)
+        res21 = get_fake_values(IrregularlySampledSignal, annotate=True, seed=0)
+        res22 = get_fake_values('IrregularlySampledSignal', annotate=True, seed=0)
 
         assert_array_equal(res11.pop('times'), times)
         assert_array_equal(res12.pop('times'), times)
@@ -97,10 +88,8 @@ class Test__generate_datasets(unittest.TestCase):
 class TestIrregularlySampledSignalConstruction(unittest.TestCase):
     def test_IrregularlySampledSignal_creation_times_units_signal_units(self):
         params = {'test2': 'y1', 'test3': True}
-        sig = IrregularlySampledSignal([1.1, 1.5, 1.7] * pq.ms,
-                                       signal=[20., 40., 60.] * pq.mV,
-                                       name='test', description='tester',
-                                       file_origin='test.file',
+        sig = IrregularlySampledSignal([1.1, 1.5, 1.7] * pq.ms, signal=[20., 40., 60.] * pq.mV,
+                                       name='test', description='tester', file_origin='test.file',
                                        test1=1, **params)
         sig.annotate(test1=1.1, test0=[1, 2])
         assert_neo_object_is_compliant(sig)
@@ -118,12 +107,9 @@ class TestIrregularlySampledSignalConstruction(unittest.TestCase):
 
     def test_IrregularlySampledSignal_creation_units_arg(self):
         params = {'test2': 'y1', 'test3': True}
-        sig = IrregularlySampledSignal([1.1, 1.5, 1.7],
-                                       signal=[20., 40., 60.],
-                                       units=pq.V, time_units=pq.s,
-                                       name='test', description='tester',
-                                       file_origin='test.file',
-                                       test1=1, **params)
+        sig = IrregularlySampledSignal([1.1, 1.5, 1.7], signal=[20., 40., 60.], units=pq.V,
+                                       time_units=pq.s, name='test', description='tester',
+                                       file_origin='test.file', test1=1, **params)
         sig.annotate(test1=1.1, test0=[1, 2])
         assert_neo_object_is_compliant(sig)
 
@@ -140,12 +126,10 @@ class TestIrregularlySampledSignalConstruction(unittest.TestCase):
 
     def test_IrregularlySampledSignal_creation_units_rescale(self):
         params = {'test2': 'y1', 'test3': True}
-        sig = IrregularlySampledSignal([1.1, 1.5, 1.7] * pq.s,
-                                       signal=[2., 4., 6.] * pq.V,
-                                       units=pq.mV, time_units=pq.ms,
-                                       name='test', description='tester',
-                                       file_origin='test.file',
-                                       test1=1, **params)
+        sig = IrregularlySampledSignal([1.1, 1.5, 1.7] * pq.s, signal=[2., 4., 6.] * pq.V,
+                                       units=pq.mV, time_units=pq.ms, name='test',
+                                       description='tester', file_origin='test.file', test1=1,
+                                       **params)
         sig.annotate(test1=1.1, test0=[1, 2])
         assert_neo_object_is_compliant(sig)
 
@@ -178,15 +162,12 @@ class TestIrregularlySampledSignalConstruction(unittest.TestCase):
 
 class TestIrregularlySampledSignalProperties(unittest.TestCase):
     def setUp(self):
-        self.times = [np.arange(10.0) * pq.s,
-                      np.arange(-100.0, 100.0, 10.0) * pq.ms,
+        self.times = [np.arange(10.0) * pq.s, np.arange(-100.0, 100.0, 10.0) * pq.ms,
                       np.arange(100) * pq.ns]
-        self.data = [np.arange(10.0) * pq.nA,
-                     np.arange(-100.0, 100.0, 10.0) * pq.mV,
+        self.data = [np.arange(10.0) * pq.nA, np.arange(-100.0, 100.0, 10.0) * pq.mV,
                      np.random.uniform(size=100) * pq.uV]
-        self.signals = [IrregularlySampledSignal(t, signal=D,
-                                                 testattr='test')
-                        for D, t in zip(self.data, self.times)]
+        self.signals = [IrregularlySampledSignal(t, signal=D, testattr='test') for D, t in
+                        zip(self.data, self.times)]
 
     def test__compliant(self):
         for signal in self.signals:
@@ -194,75 +175,54 @@ class TestIrregularlySampledSignalProperties(unittest.TestCase):
 
     def test__t_start_getter(self):
         for signal, times in zip(self.signals, self.times):
-            self.assertAlmostEqual(signal.t_start,
-                                   times[0],
-                                   delta=1e-15)
+            self.assertAlmostEqual(signal.t_start, times[0], delta=1e-15)
 
     def test__t_stop_getter(self):
         for signal, times in zip(self.signals, self.times):
-            self.assertAlmostEqual(signal.t_stop,
-                                   times[-1],
-                                   delta=1e-15)
+            self.assertAlmostEqual(signal.t_stop, times[-1], delta=1e-15)
 
     def test__duration_getter(self):
         for signal, times in zip(self.signals, self.times):
-            self.assertAlmostEqual(signal.duration,
-                                   times[-1] - times[0],
-                                   delta=1e-15)
+            self.assertAlmostEqual(signal.duration, times[-1] - times[0], delta=1e-15)
 
     def test__sampling_intervals_getter(self):
         for signal, times in zip(self.signals, self.times):
-            assert_arrays_almost_equal(signal.sampling_intervals,
-                                       np.diff(times),
-                                       threshold=1e-15)
+            assert_arrays_almost_equal(signal.sampling_intervals, np.diff(times), threshold=1e-15)
 
     def test_IrregularlySampledSignal_repr(self):
-        sig = IrregularlySampledSignal([1.1, 1.5, 1.7] * pq.s,
-                                       signal=[2., 4., 6.] * pq.V,
-                                       name='test', description='tester',
-                                       file_origin='test.file',
+        sig = IrregularlySampledSignal([1.1, 1.5, 1.7] * pq.s, signal=[2., 4., 6.] * pq.V,
+                                       name='test', description='tester', file_origin='test.file',
                                        test1=1)
         assert_neo_object_is_compliant(sig)
 
         if np.__version__.split(".")[:2] > ['1', '13']:
-            # see https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst#many-changes-to-array-printing-disableable-with-the-new-legacy-printing-mode
-            targ = ('<IrregularlySampledSignal(array([[2.],\n       [4.],\n       [6.]]) * V ' +
-                    'at times [1.1 1.5 1.7] s)>')
+            # see https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst#many
+            # -changes-to-array-printing-disableable-with-the-new-legacy-printing-mode
+            targ = (
+                        '<IrregularlySampledSignal(array([[2.],\n       [4.],\n       [6.]]) * V '
+                        '' + 'at times [1.1 1.5 1.7] s)>')
         else:
-            targ = ('<IrregularlySampledSignal(array([[ 2.],\n       [ 4.],\n       [ 6.]]) * V ' +
-                    'at times [ 1.1  1.5  1.7] s)>')
+            targ = (
+                        '<IrregularlySampledSignal(array([[ 2.],\n       [ 4.],\n       [ 6.]]) '
+                        '* V ' + 'at times [ 1.1  1.5  1.7] s)>')
         res = repr(sig)
         self.assertEqual(targ, res)
 
-        # def test__children(self):
-        #     signal = self.signals[0]
-        #
-        #     segment = Segment(name='seg1')
-        #     segment.analogsignals = [signal]
-        #     segment.create_many_to_one_relationship()
-        #
-        #     rchan = RecordingChannel(name='rchan1')
-        #     rchan.analogsignals = [signal]
-        #     rchan.create_many_to_one_relationship()
-        #
-        #     self.assertEqual(signal._single_parent_objects,
-        #                      ('Segment', 'RecordingChannel'))
-        #     self.assertEqual(signal._multi_parent_objects, ())
-        #
-        #     self.assertEqual(signal._single_parent_containers,
-        #                      ('segment', 'recordingchannel'))
-        #     self.assertEqual(signal._multi_parent_containers, ())
-        #
-        #     self.assertEqual(signal._parent_objects,
-        #                      ('Segment', 'RecordingChannel'))
-        #     self.assertEqual(signal._parent_containers,
-        #                      ('segment', 'recordingchannel'))
-        #
-        #     self.assertEqual(len(signal.parents), 2)
-        #     self.assertEqual(signal.parents[0].name, 'seg1')
-        #     self.assertEqual(signal.parents[1].name, 'rchan1')
-        #
-        #     assert_neo_object_is_compliant(signal)
+        # def test__children(self):  #     signal = self.signals[0]  #  #     segment = Segment(
+        # name='seg1')  #     segment.analogsignals = [signal]  #
+        # segment.create_many_to_one_relationship()  #  #     rchan = RecordingChannel(
+        # name='rchan1')  #     rchan.analogsignals = [signal]  #
+        # rchan.create_many_to_one_relationship()  #  #     self.assertEqual(
+        # signal._single_parent_objects,  #                      ('Segment',
+        # 'RecordingChannel'))  #     self.assertEqual(signal._multi_parent_objects, ())  #  #
+        #    self.assertEqual(signal._single_parent_containers,  #                      (
+        # 'segment', 'recordingchannel'))  #     self.assertEqual(
+        # signal._multi_parent_containers, ())  #  #     self.assertEqual(
+        # signal._parent_objects,  #                      ('Segment', 'RecordingChannel'))  #
+        #   self.assertEqual(signal._parent_containers,  #                      ('segment',
+        # 'recordingchannel'))  #  #     self.assertEqual(len(signal.parents), 2)  #
+        # self.assertEqual(signal.parents[0].name, 'seg1')  #     self.assertEqual(
+        # signal.parents[1].name, 'rchan1')  #  #     assert_neo_object_is_compliant(signal)
 
 
 class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
@@ -271,12 +231,9 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         self.data1quant = self.data1 * pq.mV
         self.time1 = np.logspace(1, 5, 10)
         self.time1quant = self.time1 * pq.ms
-        self.signal1 = IrregularlySampledSignal(self.time1quant,
-                                                signal=self.data1quant,
-                                                name='spam',
-                                                description='eggs',
-                                                file_origin='testfile.txt',
-                                                arg1='test')
+        self.signal1 = IrregularlySampledSignal(self.time1quant, signal=self.data1quant,
+                                                name='spam', description='eggs',
+                                                file_origin='testfile.txt', arg1='test')
         self.signal1.segment = Segment()
         self.signal1.channel_index = ChannelIndex([0])
 
@@ -317,18 +274,15 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         self.assertRaises(IndexError, self.signal1.__getitem__, 10)
 
     def test_comparison_operators(self):
-        assert_array_equal(self.signal1 >= 5 * pq.mV,
-                           np.array([[False, False, False, False, False,
-                                      True, True, True, True, True]]).T)
-        assert_array_equal(self.signal1 == 5 * pq.mV,
-                           np.array([[False, False, False, False, False,
-                                      True, False, False, False, False]]).T)
-        assert_array_equal(self.signal1 == self.signal1,
-                           np.array([[True, True, True, True, True,
-                                      True, True, True, True, True]]).T)
+        assert_array_equal(self.signal1 >= 5 * pq.mV, np.array(
+            [[False, False, False, False, False, True, True, True, True, True]]).T)
+        assert_array_equal(self.signal1 == 5 * pq.mV, np.array(
+            [[False, False, False, False, False, True, False, False, False, False]]).T)
+        assert_array_equal(self.signal1 == self.signal1, np.array(
+            [[True, True, True, True, True, True, True, True, True, True]]).T)
 
     def test__comparison_as_indexing(self):
-        self.assertEqual(self.signal1[self.signal1 == 5], [5*pq.mV])
+        self.assertEqual(self.signal1[self.signal1 == 5], [5 * pq.mV])
 
     def test__comparison_with_inconsistent_units_should_raise_Exception(self):
         self.assertRaises(ValueError, self.signal1.__gt__, 5 * pq.nA)
@@ -394,11 +348,8 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         targdataquant = [[1.0], [2.0], [3.0]] * pq.mV
         targtime = np.logspace(1, 5, 10)
         targtimequant = targtime[1:4] * pq.ms
-        targ_signal = IrregularlySampledSignal(targtimequant,
-                                               signal=targdataquant,
-                                               name='spam',
-                                               description='eggs',
-                                               file_origin='testfile.txt',
+        targ_signal = IrregularlySampledSignal(targtimequant, signal=targdataquant, name='spam',
+                                               description='eggs', file_origin='testfile.txt',
                                                arg1='test')
 
         t_start = 15
@@ -418,11 +369,8 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
     def test_time_slice_out_of_boundries(self):
         targdataquant = self.data1quant
         targtimequant = self.time1quant
-        targ_signal = IrregularlySampledSignal(targtimequant,
-                                               signal=targdataquant,
-                                               name='spam',
-                                               description='eggs',
-                                               file_origin='testfile.txt',
+        targ_signal = IrregularlySampledSignal(targtimequant, signal=targdataquant, name='spam',
+                                               description='eggs', file_origin='testfile.txt',
                                                arg1='test')
 
         t_start = 0
@@ -442,11 +390,8 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
     def test_time_slice_empty(self):
         targdataquant = [] * pq.mV
         targtimequant = [] * pq.ms
-        targ_signal = IrregularlySampledSignal(targtimequant,
-                                               signal=targdataquant,
-                                               name='spam',
-                                               description='eggs',
-                                               file_origin='testfile.txt',
+        targ_signal = IrregularlySampledSignal(targtimequant, signal=targdataquant, name='spam',
+                                               description='eggs', file_origin='testfile.txt',
                                                arg1='test')
 
         t_start = 15
@@ -467,11 +412,8 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         targdataquant = [[1.0], [2.0], [3.0], [4.0], [5.0], [6.0], [7.0], [8.0], [9.0]] * pq.mV
         targtime = np.logspace(1, 5, 10)
         targtimequant = targtime[1:10] * pq.ms
-        targ_signal = IrregularlySampledSignal(targtimequant,
-                                               signal=targdataquant,
-                                               name='spam',
-                                               description='eggs',
-                                               file_origin='testfile.txt',
+        targ_signal = IrregularlySampledSignal(targtimequant, signal=targdataquant, name='spam',
+                                               description='eggs', file_origin='testfile.txt',
                                                arg1='test')
 
         t_start = 15
@@ -492,11 +434,8 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         targdataquant = [[0.0], [1.0], [2.0], [3.0]] * pq.mV
         targtime = np.logspace(1, 5, 10)
         targtimequant = targtime[0:4] * pq.ms
-        targ_signal = IrregularlySampledSignal(targtimequant,
-                                               signal=targdataquant,
-                                               name='spam',
-                                               description='eggs',
-                                               file_origin='testfile.txt',
+        targ_signal = IrregularlySampledSignal(targtimequant, signal=targdataquant, name='spam',
+                                               description='eggs', file_origin='testfile.txt',
                                                arg1='test')
 
         t_start = None
@@ -514,15 +453,12 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         self.assertEqual(result.annotations, {'arg1': 'test'})
 
     def test_time_slice_none_both(self):
-        targdataquant = [[0.0], [1.0], [2.0], [3.0], [4.0],
-                         [5.0], [6.0], [7.0], [8.0], [9.0]] * pq.mV
+        targdataquant = [[0.0], [1.0], [2.0], [3.0], [4.0], [5.0], [6.0], [7.0], [8.0],
+                         [9.0]] * pq.mV
         targtime = np.logspace(1, 5, 10)
         targtimequant = targtime[0:10] * pq.ms
-        targ_signal = IrregularlySampledSignal(targtimequant,
-                                               signal=targdataquant,
-                                               name='spam',
-                                               description='eggs',
-                                               file_origin='testfile.txt',
+        targ_signal = IrregularlySampledSignal(targtimequant, signal=targdataquant, name='spam',
+                                               description='eggs', file_origin='testfile.txt',
                                                arg1='test')
 
         t_start = None
@@ -543,11 +479,8 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         targdataquant = [[1.0], [2.0], [3.0]] * pq.mV
         targtime = np.logspace(1, 5, 10)
         targtimequant = targtime[1:4] * pq.ms
-        targ_signal = IrregularlySampledSignal(targtimequant,
-                                               signal=targdataquant,
-                                               name='spam',
-                                               description='eggs',
-                                               file_origin='testfile.txt',
+        targ_signal = IrregularlySampledSignal(targtimequant, signal=targdataquant, name='spam',
+                                               description='eggs', file_origin='testfile.txt',
                                                arg1='test')
 
         t_start = 15
@@ -590,12 +523,9 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         self.data1quant = self.data1 * pq.mV
         self.time1 = np.logspace(1, 5, 10)
         self.time1quant = self.time1 * pq.ms
-        self.signal1 = IrregularlySampledSignal(self.time1quant,
-                                                signal=self.data1quant,
-                                                name='spam',
-                                                description='eggs',
-                                                file_origin='testfile.txt',
-                                                arg1='test')
+        self.signal1 = IrregularlySampledSignal(self.time1quant, signal=self.data1quant,
+                                                name='spam', description='eggs',
+                                                file_origin='testfile.txt', arg1='test')
 
     def test__compliant(self):
         assert_neo_object_is_compliant(self.signal1)
@@ -632,12 +562,9 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         self.assertEqual(result.file_origin, 'testfile.txt')
         self.assertEqual(result.annotations, {'arg1': 'test'})
 
-        targ = IrregularlySampledSignal(self.time1quant,
-                                        signal=np.arange(10.0, 30.0, 2.0),
-                                        units="mV",
-                                        name='spam', description='eggs',
-                                        file_origin='testfile.txt',
-                                        arg1='test')
+        targ = IrregularlySampledSignal(self.time1quant, signal=np.arange(10.0, 30.0, 2.0),
+                                        units="mV", name='spam', description='eggs',
+                                        file_origin='testfile.txt', arg1='test')
         assert_neo_object_is_compliant(targ)
 
         assert_array_equal(result, targ)
@@ -646,8 +573,8 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         assert_same_sub_schema(result, targ)
 
     def test__add_signals_with_inconsistent_times_AssertionError(self):
-        signal2 = IrregularlySampledSignal(self.time1quant * 2.,
-                                           signal=np.arange(10.0), units="mV")
+        signal2 = IrregularlySampledSignal(self.time1quant * 2., signal=np.arange(10.0),
+                                           units="mV")
         assert_neo_object_is_compliant(signal2)
 
         self.assertRaises(ValueError, self.signal1.__add__, signal2)
@@ -732,12 +659,12 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         res = pretty(self.signal1)
         signal = self.signal1
         targ = ((
-                "IrregularlySampledSignal with %d channels of length %d; units %s; datatype %s \n" % (
-                signal.shape[1], signal.shape[0], signal.units.dimensionality.unicode,
-                signal.dtype)) +
-                ("name: '%s'\ndescription: '%s'\n" % (signal.name, signal.description)) +
-                ("annotations: %s\n" % str(signal.annotations)) +
-                ("sample times: %s" % (signal.times[:10],)))
+                        "IrregularlySampledSignal with %d channels of length %d; units %s; "
+                        "datatype %s \n" % (
+                    signal.shape[1], signal.shape[0], signal.units.dimensionality.unicode,
+                    signal.dtype)) + ("name: '%s'\ndescription: '%s'\n" % (
+        signal.name, signal.description)) + ("annotations: %s\n" % str(signal.annotations)) + (
+                            "sample times: %s" % (signal.times[:10],)))
         self.assertEqual(res, targ)
 
     def test__merge(self):
@@ -746,18 +673,12 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         times1 = np.arange(11.0) * pq.ms
         times2 = np.arange(1.0, 12.0) * pq.ms
 
-        signal1 = IrregularlySampledSignal(times1, data1,
-                                           name='signal1',
-                                           description='test signal',
-                                           file_origin='testfile.txt')
-        signal2 = IrregularlySampledSignal(times1, data2,
-                                           name='signal2',
-                                           description='test signal',
-                                           file_origin='testfile.txt')
-        signal3 = IrregularlySampledSignal(times2, data2,
-                                           name='signal3',
-                                           description='test signal',
-                                           file_origin='testfile.txt')
+        signal1 = IrregularlySampledSignal(times1, data1, name='signal1',
+                                           description='test signal', file_origin='testfile.txt')
+        signal2 = IrregularlySampledSignal(times1, data2, name='signal2',
+                                           description='test signal', file_origin='testfile.txt')
+        signal3 = IrregularlySampledSignal(times2, data2, name='signal3',
+                                           description='test signal', file_origin='testfile.txt')
 
         merged12 = signal1.merge(signal2)
 
@@ -780,8 +701,8 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
 
 class TestAnalogSignalFunctions(unittest.TestCase):
     def test__pickle(self):
-        signal1 = IrregularlySampledSignal(np.arange(10.0) / 100 * pq.s,
-                                           np.arange(10.0), units="mV")
+        signal1 = IrregularlySampledSignal(np.arange(10.0) / 100 * pq.s, np.arange(10.0),
+                                           units="mV")
 
         fobj = open('./pickle', 'wb')
         pickle.dump(signal1, fobj)
@@ -800,10 +721,10 @@ class TestAnalogSignalFunctions(unittest.TestCase):
 
 class TestIrregularlySampledSignalEquality(unittest.TestCase):
     def test__signals_with_different_times_should_be_not_equal(self):
-        signal1 = IrregularlySampledSignal(np.arange(10.0) / 100 * pq.s,
-                                           np.arange(10.0), units="mV")
-        signal2 = IrregularlySampledSignal(np.arange(10.0) / 100 * pq.ms,
-                                           np.arange(10.0), units="mV")
+        signal1 = IrregularlySampledSignal(np.arange(10.0) / 100 * pq.s, np.arange(10.0),
+                                           units="mV")
+        signal2 = IrregularlySampledSignal(np.arange(10.0) / 100 * pq.ms, np.arange(10.0),
+                                           units="mV")
         self.assertNotEqual(signal1, signal2)
 
 


### PR DESCRIPTION
This PR is based on #557. In addition to #557 it implements indexing of AnalogSignals and IrregularlySampledSignals via numpy arrays. The returned object is a quantity object, as the temporal information can not necessarily be captured by an AnalogSignal or IrregularlySampledSignal.
See also #556 for the discussion.