### PR TITLE
fix bug for bool key type in neuralynxrawio.py

### DIFF
--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -497,7 +497,7 @@ def _to_bool(txt):
     elif txt=='False': 
         return False
     else: 
-        raise Exception('Connot convert %s to bool' %(txt))
+        raise Exception('Can not convert %s to bool' %(txt))
 
 # keys in
 txt_header_keys = [

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -490,6 +490,15 @@ class NeuralynxRawIO(BaseRawIO):
                     self._sigs_length.append(length)
 
 
+### Keys funcitons
+def _to_bool(txt):
+    if txt=='True': 
+        return True
+    elif txt=='False': 
+        return False
+    else: 
+        raise Exception('Connot convert %s to bool' %(txt))
+
 # keys in
 txt_header_keys = [
     ('AcqEntName', 'channel_names', None),  # used
@@ -504,7 +513,7 @@ txt_header_keys = [
     ('NumADChannels', '', None),
     ('ADChannel', 'channel_ids', None),  # used
     ('InputRange', '', None),
-    ('InputInverted', 'input_inverted', bool),  # used
+    ('InputInverted', 'input_inverted', _to_bool),  # used
     ('DSPLowCutFilterEnabled', '', None),
     ('DspLowCutFrequency', '', None),
     ('DspLowCutNumTaps', '', None),
@@ -559,15 +568,7 @@ def read_txt_header(filename):
                 name = k2
             value = match[1].rstrip(' ')
             if type_ is not None:
-                if type_==bool:
-                     if value=='True': 
-                         value=True
-                     elif value=='False': 
-                         value=False
-                     else: 
-                         raise Exception('Unknown value %s for k1=%s, k2=%s' %(value, k1, k2))
-                else:
-                     value = type_(value)
+                value = type_(value)
             info[name] = value
 
     # if channel_ids or s not in info then the filename is used

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -559,7 +559,15 @@ def read_txt_header(filename):
                 name = k2
             value = match[1].rstrip(' ')
             if type_ is not None:
-                value = type_(value)
+                if type_==bool:
+                     if value=='True': 
+                         value=True
+                     elif value=='False': 
+                         value=False
+                     else: 
+                         raise Exception('Unknown value %s for k1=%s, k2=%s' %(value, k1, k2))
+                else:
+                     value = type_(value)
             info[name] = value
 
     # if channel_ids or s not in info then the filename is used


### PR DESCRIPTION
in header there is a key:

```
-InputInverted False
```

which is interpreted as True when you use `bool('False')`