### PR TITLE
Fixed detection of warnings in test_blackrockio.py (#568)

### DIFF
--- a/neo/test/iotest/test_brainwaredamio.py
+++ b/neo/test/iotest/test_brainwaredamio.py
@@ -45,7 +45,7 @@ def proc_dam(filename):
              dam file name = 'file1.dam'
     '''
     with np.load(filename) as damobj:
-        damfile = damobj.items()[0][1].flatten()
+        damfile = list(damobj.items())[0][1].flatten()
 
     filename = os.path.basename(filename[:-12] + '.dam')
 

--- a/neo/test/iotest/test_brainwaref32io.py
+++ b/neo/test/iotest/test_brainwaref32io.py
@@ -59,7 +59,7 @@ def proc_f32(filename):
 
     try:
         with np.load(filename) as f32obj:
-            f32file = f32obj.items()[0][1].flatten()
+            f32file = list(f32obj.items())[0][1].flatten()
     except IOError as exc:
         if 'as a pickle' in exc.message:
             block.create_many_to_one_relationship()

--- a/neo/test/iotest/test_brainwaresrcio.py
+++ b/neo/test/iotest/test_brainwaresrcio.py
@@ -68,7 +68,7 @@ def proc_src(filename):
              src file name = 'file1.src'
     '''
     with np.load(filename) as srcobj:
-        srcfile = srcobj.items()[0][1]
+        srcfile = list(srcobj.items())[0][1]
 
     filename = os.path.basename(filename[:-12] + '.src')
 


### PR DESCRIPTION
See #568 
Now the position of the warning in the list of warnings is not assumed anymore. 
Instead the test checks if the warning is in the list of warnings.

Apart from that the warnings.simplefilter filter should only be changed within
the context of catch_warnings here in order to ensure it being set to its original
state afterwards. Alternatively it needs to be reset manually. This was done as well.