### PR TITLE
Blackrock - separate dig input and serial input.

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -1772,7 +1772,8 @@ class BlackrockRawIO(BaseRawIO):
             'digital_input_port': {
                 'name': 'digital_input_port',
                 'field': 'digital_input',
-                'mask': self.__is_set(data['packet_insertion_reason'], 0),
+                'mask': self.__is_set(data['packet_insertion_reason'], 0) &
+                        ~self.__is_set(data['packet_insertion_reason'], 7),
                 'desc': "Events of the digital input port"},
             'serial_input_port': {
                 'name': 'serial_input_port',


### PR DESCRIPTION
Prior to this merge, all serial input events are also showing up as digital input events. But maybe that's desired?