### PR TITLE
Blackrock comments

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -220,6 +220,10 @@ class BlackrockRawIO(BaseRawIO):
             '2.1': self.__get_comment_evtypes_variant_a,
             '2.2': self.__get_comment_evtypes_variant_a,
             '2.3': self.__get_comment_evtypes_variant_a}
+        self.__get_evtypes = {
+            '2.1': self.__get_evtypes_variant_a,
+            '2.2': self.__get_evtypes_variant_a,
+            '2.3': self.__get_evtypes_variant_b}
 
     def _parse_header(self):
 
@@ -269,11 +273,8 @@ class BlackrockRawIO(BaseRawIO):
 
             # scan events
             # NonNeural: serial and digital input
-            events_data, event_segment_ids = self.nev_data['NonNeural']
-            ev_dict = self.__nonneural_evtypes[self.__nev_spec](events_data)
-            if 'Comments' in self.nev_data:
-                comments_data, comments_segment_ids = self.nev_data['Comments']
-                ev_dict.update(self.__comment_evtypes[self.__nev_spec](comments_data))
+            ev_dict = self.__get_evtypes[self.__nev_spec]('NonNeural')
+            ev_dict.update(self.__get_evtypes[self.__nev_spec]('Comments'))
             for ev_name in ev_dict:
                 event_channels.append((ev_name, '', 'event'))
             # TODO: TrackingEvents
@@ -550,11 +551,15 @@ class BlackrockRawIO(BaseRawIO):
                 st_ann['file_origin'] = self._filenames['nev'] + '.nev'
 
             if self._avail_files['nev']:
-                ev_dict = self.__nonneural_evtypes[self.__nev_spec](events_data)
-                if 'Comments' in self.nev_data:
-                    ev_dict.update(self.__comment_evtypes[self.__nev_spec](comments_data))
+                ev_dict = self.__get_evtypes[self.__nev_spec]('NonNeural')
+                ev_dict.update(self.__get_evtypes[self.__nev_spec]('Comments'))
+                # For comment events add color codes
+                try:
+                    comments_data, _ = self.nev_data['Comments']
                     color_codes = ["#{:08X}".format(code) for code in comments_data['color']]
                     color_codes = np.array(color_codes, dtype='S9')
+                except KeyError:
+                    pass
                 for c in range(event_channels.size):
                     # Next line makes ev_ann a reference to seg_ann['events'][c]
                     ev_ann = seg_ann['events'][c]
@@ -1916,6 +1921,35 @@ class BlackrockRawIO(BaseRawIO):
                 'desc': 'Comments'
             }
         }
+
+    # This is introduced only for compatibilty reasons
+    # It is used for supporting Blackrock filespec 2.1 and 2.2
+    def __get_evtypes_variant_a(self, name):
+        data = self.__get_nev_data(name)
+        if data is None:
+            return {}
+        # Not a problem to call this for unsupported evtypes, they will just be ignored
+        # In this case there should not be anything unsupported
+        return self.__nonneural_evtypes[self.__nev_spec](data)
+
+    def __get_evtypes_variant_b(self, name):
+        data = self.__get_nev_data(name)
+        if data is None:
+            return {}
+        if name == 'Comments':
+            return self.__comment_evtypes[self.__nev_spec](data)
+        # TODO: All the other event types belong here.
+        # Not a problem to call this for unsupported evtypes, they will just be ignored
+        else:
+            return self.__nonneural_evtypes[self.__nev_spec](data)
+
+    def __get_nev_data(self, name, default=None):
+        try:
+            data, _ = self.nev_data[name]
+            return data
+        except KeyError:
+            # Return default value if not found
+            return default
 
     def __is_set(self, flag, pos):
         """

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -553,7 +553,8 @@ class BlackrockRawIO(BaseRawIO):
                 ev_dict = self.__nonneural_evtypes[self.__nev_spec](events_data)
                 if 'Comments' in self.nev_data:
                     ev_dict.update(self.__comment_evtypes[self.__nev_spec](comments_data))
-                    color_codes = ["{:08X}".format(code) for code in comments_data['color']]
+                    color_codes = ["#{:08X}".format(code) for code in comments_data['color']]
+                    color_codes = np.array(color_codes, dtype='S9')
                 for c in range(event_channels.size):
                     # Next line makes ev_ann a reference to seg_ann['events'][c]
                     ev_ann = seg_ann['events'][c]

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -1772,7 +1772,8 @@ class BlackrockRawIO(BaseRawIO):
             'digital_input_port': {
                 'name': 'digital_input_port',
                 'field': 'digital_input',
-                'mask': self.__is_set(data['packet_insertion_reason'], 0),
+                'mask': self.__is_set(data['packet_insertion_reason'], 0) &
+                        ~self.__is_set(data['packet_insertion_reason'], 7),
                 'desc': "Events of the digital input port"},
             'serial_input_port': {
                 'name': 'serial_input_port',

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -212,14 +212,14 @@ class BlackrockRawIO(BaseRawIO):
             '2.1': self.__get_channel_labels_variant_a,
             '2.2': self.__get_channel_labels_variant_b,
             '2.3': self.__get_channel_labels_variant_b}
-        self.__nonneural_evtypes = {
-            '2.1': self.__get_nonneural_evtypes_variant_a,
-            '2.2': self.__get_nonneural_evtypes_variant_a,
-            '2.3': self.__get_nonneural_evtypes_variant_b}
-        self.__comment_evtypes = {
-            '2.1': self.__get_comment_evtypes_variant_a,
-            '2.2': self.__get_comment_evtypes_variant_a,
-            '2.3': self.__get_comment_evtypes_variant_a}
+        self.__nonneural_evdicts = {
+            '2.1': self.__get_nonneural_evdicts_variant_a,
+            '2.2': self.__get_nonneural_evdicts_variant_a,
+            '2.3': self.__get_nonneural_evdicts_variant_b}
+        self.__comment_evdict = {
+            '2.1': self.__get_comment_evdict_variant_a,
+            '2.2': self.__get_comment_evdict_variant_a,
+            '2.3': self.__get_comment_evdict_variant_a}
 
     def _parse_header(self):
 
@@ -270,10 +270,10 @@ class BlackrockRawIO(BaseRawIO):
             # scan events
             # NonNeural: serial and digital input
             events_data, event_segment_ids = self.nev_data['NonNeural']
-            ev_dict = self.__nonneural_evtypes[self.__nev_spec](events_data)
+            ev_dict = self.__nonneural_evdicts[self.__nev_spec](events_data)
             if 'Comments' in self.nev_data:
                 comments_data, comments_segment_ids = self.nev_data['Comments']
-                ev_dict.update(self.__comment_evtypes[self.__nev_spec](comments_data))
+                ev_dict.update(self.__comment_evdict[self.__nev_spec](comments_data))
             for ev_name in ev_dict:
                 event_channels.append((ev_name, '', 'event'))
             # TODO: TrackingEvents
@@ -550,9 +550,9 @@ class BlackrockRawIO(BaseRawIO):
                 st_ann['file_origin'] = self._filenames['nev'] + '.nev'
 
             if self._avail_files['nev']:
-                ev_dict = self.__nonneural_evtypes[self.__nev_spec](events_data)
+                ev_dict = self.__nonneural_evdicts[self.__nev_spec](events_data)
                 if 'Comments' in self.nev_data:
-                    ev_dict.update(self.__comment_evtypes[self.__nev_spec](comments_data))
+                    ev_dict.update(self.__comment_evdict[self.__nev_spec](comments_data))
                     color_codes = ["#{:08X}".format(code) for code in comments_data['color']]
                     color_codes = np.array(color_codes, dtype='S9')
                 for c in range(event_channels.size):
@@ -673,10 +673,10 @@ class BlackrockRawIO(BaseRawIO):
         name = self.header['event_channels']['name'][event_channel_index]
         if name == 'comments':
             events_data, event_segment_ids = self.nev_data['Comments']
-            ev_dict = self.__comment_evtypes[self.__nev_spec](events_data)[name]
+            ev_dict = self.__comment_evdict[self.__nev_spec](events_data)[name]
         else:
             events_data, event_segment_ids = self.nev_data['NonNeural']
-            ev_dict = self.__nonneural_evtypes[self.__nev_spec](events_data)[name]
+            ev_dict = self.__nonneural_evdicts[self.__nev_spec](events_data)[name]
         mask = ev_dict['mask'] & (event_segment_ids == seg_index)
         if self._nb_segment == 1:
             # very fast
@@ -693,7 +693,7 @@ class BlackrockRawIO(BaseRawIO):
         name = self.header['event_channels']['name'][event_channel_index]
         if name == 'comments':
             events_data, event_segment_ids = self.nev_data['Comments']
-            ev_dict = self.__comment_evtypes[self.__nev_spec](events_data)[name]
+            ev_dict = self.__comment_evdict[self.__nev_spec](events_data)[name]
             # If immediate decoding is desired:
             encoding = {0: 'latin_1', 1: 'utf_16', 255: 'latin_1'}
             labels = [data[ev_dict['field']].decode(
@@ -705,7 +705,7 @@ class BlackrockRawIO(BaseRawIO):
             labels = np.array([data.encode('ASCII', errors='ignore') for data in labels])
         else:
             events_data, event_segment_ids = self.nev_data['NonNeural']
-            ev_dict = self.__nonneural_evtypes[self.__nev_spec](events_data)[name]
+            ev_dict = self.__nonneural_evdicts[self.__nev_spec](events_data)[name]
             labels = events_data[ev_dict['field']]
 
         mask = ev_dict['mask'] & (event_segment_ids == seg_index)
@@ -1796,7 +1796,7 @@ class BlackrockRawIO(BaseRawIO):
 
         return nsx_parameters[param_name]
 
-    def __get_nonneural_evtypes_variant_a(self, data):
+    def __get_nonneural_evdicts_variant_a(self, data):
         """
         Defines event types and the necessary parameters to extract them from
         a 2.1 and 2.2 nev file.
@@ -1885,7 +1885,7 @@ class BlackrockRawIO(BaseRawIO):
         # Empty segments were discarded, thus there may be less segments now
         self._nb_segment -= nb_empty_segments
 
-    def __get_nonneural_evtypes_variant_b(self, data):
+    def __get_nonneural_evdicts_variant_b(self, data):
         """
         Defines event types and the necessary parameters to extract them from
         a 2.3 nev file.
@@ -1907,7 +1907,7 @@ class BlackrockRawIO(BaseRawIO):
 
         return event_types
 
-    def __get_comment_evtypes_variant_a(self, data):
+    def __get_comment_evdict_variant_a(self, data):
         return {
             'comments': {
                 'name': 'comments',

--- a/neo/rawio/tests/test_blackrockrawio.py
+++ b/neo/rawio/tests/test_blackrockrawio.py
@@ -101,15 +101,16 @@ class TestBlackrockRawIO(BaseTestRawIO, unittest.TestCase, ):
         for ev_chan in range(nb_ev_chan):
             name = reader.header['event_channels']['name'][ev_chan]
             # ~ print(name)
+            all_timestamps, _, labels = reader.get_event_timestamps(
+                event_channel_index=ev_chan)
             if name == 'digital_input_port':
-
-                all_timestamps, _, labels = reader.get_event_timestamps(
-                    event_channel_index=ev_chan)
-
                 for label in np.unique(labels):
                     python_digievents = all_timestamps[labels == label]
                     matlab_digievents = mts_ml[mid_ml == int(label)]
                     assert_equal(python_digievents, matlab_digievents)
+            elif name == 'comments':
+                pass
+                # TODO: Save comments to Matlab file.
 
     @unittest.skipUnless(HAVE_SCIPY, "requires scipy")
     def test_compare_blackrockio_with_matlabloader_v21(self):


### PR DESCRIPTION
After having a close look at @cboulay 's code from #561 I could not find a solution that I think fits better at the moment. I tried a few things, like wrapping __nonneural_evtypes and __comment_evtypes into a common method that works for both (see commit c18475d), but I noticed this creates too much unnecessary code. Thus for now I would prefer not to do this. Once somebody implements another event type, however, I think a bit of restructuring will be justified.


The original code has not changed much but I introduced a few changes as discussed in #561.

- Strings are decoded according to the charset and reencoded to bytes that are human readable.
- Comment colors are parsed to 8-digit hex values as read from the file. If anybody (@cboulay ?) has more information on how they are encoded, please let me know. These hex strings are then placed into an array that is presented to the user as an annotation to the comment event object.
- I also renamed __nonneural_evtypes to __nonneural_evdicts aand __comment_evtypes to __comment_evdict.


I might, of course, have missed something, so if anybody sees a better way of implementing this, please also let me know.