### PR TITLE
[nixio] Fix in read_block() auto indexing

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -214,9 +214,8 @@ class NixIO(BaseIO):
             if index >= len(self.nix_file.blocks):
                 return None
             nix_block = self.nix_file.blocks[index]
+            self._block_read_counter += 1
 
-        nix_block = self.nix_file.blocks[self._block_read_counter]
-        self._block_read_counter += 1
         return self._nix_to_neo_block(nix_block)
 
     def iter_blocks(self):

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -1337,6 +1337,8 @@ class NixIOReadTest(NixIOTest):
         for idx, nixblock in enumerate(self.nixfile.blocks):
             neoblock = self.io.read_block(index=idx)
             self.assertEqual(neoblock.annotations["nix_name"], nixblock.name)
+            self.assertEqual(neoblock.annotations["nix_name"],
+                             self.nixfile.blocks[idx].name)
 
     def test_auto_index_read(self):
         for nixblock in self.nixfile.blocks:
@@ -1347,6 +1349,15 @@ class NixIOReadTest(NixIOTest):
         self.assertIs(self.io.read_block(), None)
         self.assertIs(self.io.read_block(), None)
         self.assertIs(self.io.read_block(), None)
+
+        with NixIO(self.filename, "ro") as nf:
+            neoblock = nf.read_block(index=1)
+            self.assertEqual(self.nixfile.blocks[1].name,
+                             neoblock.annotations["nix_name"])
+
+            neoblock = nf.read_block()  # should start again from 0
+            self.assertEqual(self.nixfile.blocks[0].name,
+                             neoblock.annotations["nix_name"])
 
     def test_neo_name_read(self):
         for nixblock in self.nixfile.blocks:


### PR DESCRIPTION
There was a bug in read_block() when multiple calls both with and
without arguments. The automatic indexing was buggy and would increment
even when it didn't have to.

Test added to catch regressions.