### PR TITLE
[nixio] Use OrderedDict to group signals

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 
 import time
 from datetime import datetime
-from collections import Iterable
+from collections import Iterable, OrderedDict
 import itertools
 from uuid import uuid4
 
@@ -1174,7 +1174,7 @@ class NixIO(BaseIO):
         belong to the same Signal
         """
         # now start grouping
-        groups = dict()
+        groups = OrderedDict()
         for da in dataarrays:
             basename = ".".join(da.name.split(".")[:-1])
             if basename not in groups:

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -351,7 +351,7 @@ class NixIOTest(unittest.TestCase):
         allsignalgroups = list()
 
         # analogsignals
-        for n in range(3):
+        for n in range(5):
             siggroup = list()
             asig_name = "{}_asig{}".format(cls.rword(10), n)
             asig_definition = cls.rsentence(5, 5)


### PR DESCRIPTION
In older versions of Python (< 3.6) the builtin dict isn't ordered, so
signal grouping during read can get randomised.

Switch to using OrderedDict to support older versions as well.