### PR TITLE
 Blackrock - separate dig input and serial input

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -1862,12 +1862,14 @@ class BlackrockRawIO(BaseRawIO):
             'digital_input_port': {
                 'name': 'digital_input_port',
                 'field': 'digital_input',
-                'mask': data['packet_insertion_reason'] == 1,
+                'mask': self.__is_set(data['packet_insertion_reason'], 0) &
+                        ~self.__is_set(data['packet_insertion_reason'], 7),
                 'desc': "Events of the digital input port"},
             'serial_input_port': {
                 'name': 'serial_input_port',
                 'field': 'digital_input',
-                'mask': data['packet_insertion_reason'] == 129,
+                'mask': self.__is_set(data['packet_insertion_reason'], 0) &
+                        self.__is_set(data['packet_insertion_reason'], 7),
                 'desc': "Events of the serial input port"}}
 
         return event_types

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -1772,7 +1772,8 @@ class BlackrockRawIO(BaseRawIO):
             'digital_input_port': {
                 'name': 'digital_input_port',
                 'field': 'digital_input',
-                'mask': self.__is_set(data['packet_insertion_reason'], 0),
+                'mask': self.__is_set(data['packet_insertion_reason'], 0) &
+                        ~self.__is_set(data['packet_insertion_reason'], 7),
                 'desc': "Events of the digital input port"},
             'serial_input_port': {
                 'name': 'serial_input_port',


### PR DESCRIPTION
This is a rebase of #570.

I also changed __get_nonneural_evtypes_variant_b to match @cboulay  's implementation which is cleaner and in line with the Blackrock manual.