### PR TITLE
account for empty nse in rawio.neuralynxrawio

### DIFF
--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -148,11 +148,11 @@ class NeuralynxRawIO(BaseRawIO):
 
                     if (os.path.getsize(filename)<=HEADER_SIZE):
                         self._empty_nse_ntt.append(filename)
-                        data = dict(unit_id    = np.array([]), 
-                                    channel_id = np.array([]), 
-                                    timestamp  = np.array([]), 
-                                    features   = np.array([[]]), 
-                                    samples    = np.array([[]]))
+                        data = dict(unit_id    = np.zeros((0,), dtype=dtype), 
+                                    channel_id = np.zeros((0,), dtype=dtype), 
+                                    timestamp  = np.zeros((0,), dtype=dtype), 
+                                    features   = np.zeros((0,0), dtype=dtype), 
+                                    samples    = np.zeros((0,0), dtype=dtype))
                     else:
                         data = np.memmap(filename, dtype=dtype, mode='r', offset=HEADER_SIZE)
 

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -148,11 +148,7 @@ class NeuralynxRawIO(BaseRawIO):
 
                     if (os.path.getsize(filename)<=HEADER_SIZE):
                         self._empty_nse_ntt.append(filename)
-                        data = dict(unit_id    = np.zeros((0,), dtype=dtype), 
-                                    channel_id = np.zeros((0,), dtype=dtype), 
-                                    timestamp  = np.zeros((0,), dtype=dtype), 
-                                    features   = np.zeros((0,0), dtype=dtype), 
-                                    samples    = np.zeros((0,0), dtype=dtype))
+                        data = np.zeros((0,), dtype=dtype)
                     else:
                         data = np.memmap(filename, dtype=dtype, mode='r', offset=HEADER_SIZE)
 


### PR DESCRIPTION
Guys, I've made an update for a workaround with the empty nse files
There still will be info in self._spike_memmap, but it will be just empty numpy arrays