### PR TITLE
Nlx unique chan id fix

### DIFF
--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -148,11 +148,11 @@ class NeuralynxRawIO(BaseRawIO):
 
                     if (os.path.getsize(filename)<=HEADER_SIZE):
                         self._empty_nse_ntt.append(filename)
-                        data = dict(unit_id    = np.array([]), 
-                                    channel_id = np.array([]), 
-                                    timestamp  = np.array([]), 
-                                    features   = np.array([[]]), 
-                                    samples    = np.array([[]]))
+                        data = dict(unit_id    = np.zeros((0,), dtype=dtype), 
+                                    channel_id = np.zeros((0,), dtype=dtype), 
+                                    timestamp  = np.zeros((0,), dtype=dtype), 
+                                    features   = np.zeros((0,0), dtype=dtype), 
+                                    samples    = np.zeros((0,0), dtype=dtype))
                     else:
                         data = np.memmap(filename, dtype=dtype, mode='r', offset=HEADER_SIZE)
 

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -148,11 +148,7 @@ class NeuralynxRawIO(BaseRawIO):
 
                     if (os.path.getsize(filename)<=HEADER_SIZE):
                         self._empty_nse_ntt.append(filename)
-                        data = dict(unit_id    = np.zeros((0,), dtype=dtype), 
-                                    channel_id = np.zeros((0,), dtype=dtype), 
-                                    timestamp  = np.zeros((0,), dtype=dtype), 
-                                    features   = np.zeros((0,0), dtype=dtype), 
-                                    samples    = np.zeros((0,0), dtype=dtype))
+                        data = np.zeros((0,), dtype=dtype)
                     else:
                         data = np.memmap(filename, dtype=dtype, mode='r', offset=HEADER_SIZE)
 


### PR DESCRIPTION
@samuelgarcia 

This PR includes a fix for non-unique chan_id when there are several files for the same AD channel

see  #590,  #589

Now I can read mixed records without splitting folders, like this
![image](https://user-images.githubusercontent.com/4338049/47603586-b3693980-d9f6-11e8-9380-f7a2df0bcb0e.png)

These two channels are reading from one AD channel, but with different preprocessings:
![image](https://user-images.githubusercontent.com/4338049/47603594-dbf13380-d9f6-11e8-8de2-ec6b4033c6c2.png)





