### PR TITLE
Fix some bugs which I see on my laptop, although apparently they are not caught by Travis or CircleCI?

### DIFF
--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -179,6 +179,14 @@ class Epoch(BaseNeo, pq.Quantity):
         obj.labels = self.labels[i]
         return obj
 
+    def __getslice__(self, i, j):
+        '''
+        Get a slice from :attr:`i` to :attr:`j`.attr[0]
+
+        Doesn't get called in Python 3, :meth:`__getitem__` is called instead
+        '''
+        return self.__getitem__(slice(i, j))
+
     @property
     def times(self):
         return pq.Quantity(self)

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -431,7 +431,7 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
     def test__indexing_keeps_order_across_channels(self):
         # AnalogSignals with 10 traces each having 5 samples (eg. data[0] = [0,10,20,30,40])
         data = np.array([range(10), range(10, 20), range(20, 30), range(30, 40), range(40, 50)])
-        mask = np.full((5, 10), fill_value=False)
+        mask = np.full((5, 10), fill_value=False, dtype=bool)
         # selecting one entry per trace
         mask[[0, 1, 0, 3, 0, 2, 4, 3, 1, 4], range(10)] = True
 
@@ -441,7 +441,7 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
     def test__indexing_keeps_order_across_time(self):
         # AnalogSignals with 10 traces each having 5 samples (eg. data[0] = [0,10,20,30,40])
         data = np.array([range(10), range(10, 20), range(20, 30), range(30, 40), range(40, 50)])
-        mask = np.full((5, 10), fill_value=False)
+        mask = np.full((5, 10), fill_value=False, dtype=bool)
         # selecting two entries per trace
         temporal_ids = [0, 1, 0, 3, 1, 2, 4, 2, 1, 4] + [4, 3, 2, 1, 0, 1, 2, 3, 2, 1]
         mask[temporal_ids, list(range(10)) + list(range(10))] = True

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -292,7 +292,7 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
     def test__indexing_keeps_order_across_channels(self):
         # AnalogSignals with 10 traces each having 5 samples (eg. data[0] = [0,10,20,30,40])
         data = np.array([range(10), range(10, 20), range(20, 30), range(30, 40), range(40, 50)])
-        mask = np.full((5, 10), fill_value=False)
+        mask = np.full((5, 10), fill_value=False, dtype=bool)
         # selecting one entry per trace
         mask[[0, 1, 0, 3, 0, 2, 4, 3, 1, 4], range(10)] = True
 
@@ -302,7 +302,7 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
     def test__indexing_keeps_order_across_time(self):
         # AnalogSignals with 10 traces each having 5 samples (eg. data[0] = [0,10,20,30,40])
         data = np.array([range(10), range(10, 20), range(20, 30), range(30, 40), range(40, 50)])
-        mask = np.full((5, 10), fill_value=False)
+        mask = np.full((5, 10), fill_value=False, dtype=bool)
         # selecting two entries per trace
         temporal_ids = [0, 1, 0, 3, 1, 2, 4, 2, 1, 4] + [4, 3, 2, 1, 0, 1, 2, 3, 2, 1]
         mask[temporal_ids, list(range(10)) + list(range(10))] = True


### PR DESCRIPTION

My env:
```
$ conda list
# packages in environment at /Users/andrew/anaconda/envs/neo:
#
alabaster                 0.7.6                    py27_0    http://repo.continuum.io/pkgs/free/osx-64/alabaster-0.7.6-py27_0.tar.bz2
allensdk                  0.12.0                    <pip>
babel                     2.1.1                    py27_0    http://repo.continuum.io/pkgs/free/osx-64/babel-2.1.1-py27_0.tar.bz2
certifi                   2016.2.28                py27_0    defaults
chardet                   3.0.4                     <pip>
coverage                  3.7.1                    py27_0    http://repo.continuum.io/pkgs/free/osx-64/coverage-3.7.1-py27_0.tar.bz2
cython                    0.27                      <pip>
dateutil                  2.1                      py27_2    <unknown>
docutils                  0.12                     py27_0    http://repo.continuum.io/pkgs/free/osx-64/docutils-0.12-py27_0.tar.bz2
enum34                    1.1.6                     <pip>
freetype                  2.4.10                        1    <unknown>
funcsigs                  1.0.2                    py27_0    defaults
future                    0.16.0                    <pip>
h5py                      2.5.0               np110py27_4    http://repo.continuum.io/pkgs/free/osx-64/h5py-2.5.0-np110py27_4.tar.bz2
hdf5                      1.8.15.1                      2    http://repo.continuum.io/pkgs/free/osx-64/hdf5-1.8.15.1-2.tar.bz2
idna                      2.7                       <pip>
igor                      0.2                       <pip>
ipython                   2.3.0                    py27_0    http://repo.continuum.io/pkgs/free/osx-64/ipython-2.3.0-py27_0.tar.bz2
jinja2                    2.8                      py27_0    http://repo.continuum.io/pkgs/free/osx-64/jinja2-2.8-py27_0.tar.bz2
klusta                    3.0.16                    <pip>
libpng                    1.5.13                        1    <unknown>
markupsafe                0.23                     py27_0    http://repo.continuum.io/pkgs/free/osx-64/markupsafe-0.23-py27_0.tar.bz2
matplotlib                1.4.2                np19py27_0    http://repo.continuum.io/pkgs/free/osx-64/matplotlib-1.4.2-np19py27_0.tar.bz2
mkl                       11.3.1                        0    http://repo.continuum.io/pkgs/free/osx-64/mkl-11.3.1-0.tar.bz2
mock                      2.0.0                    py27_0    defaults
neo (/Users/andrew/dev/analysis/neo) 0.7.0.dev0                <pip>
neurom                    1.4.8                     <pip>
nixio                     1.4.2                     <pip>
nose                      1.3.4                    py27_0    http://repo.continuum.io/pkgs/free/osx-64/nose-1.3.4-py27_0.tar.bz2
nsdf                      0.1                       <pip>
numexpr                   2.3.1                np19py27_0    http://repo.continuum.io/pkgs/free/osx-64/numexpr-2.3.1-np19py27_0.tar.bz2
numpy                     1.10.4                   py27_0    http://repo.continuum.io/pkgs/free/osx-64/numpy-1.10.4-py27_0.tar.bz2
nwb (/Users/andrew/packages/nwb_api-python) 1.0.4b0                   <pip>
openssl                   1.0.2l                        0    defaults
pandas                    0.18.1                    <pip>
pbr                       1.10.0                   py27_0    defaults
pip                       9.0.1                    py27_1    defaults
pkginfo                   1.4.2                     <pip>
pygments                  2.0.2                    py27_0    http://repo.continuum.io/pkgs/free/osx-64/pygments-2.0.2-py27_0.tar.bz2
pylru                     1.1.0                     <pip>
pynrrd                    0.2.1                     <pip>
pyparsing                 2.0.1                    py27_0    <unknown>
pytables                  3.1.1                np19py27_0    http://repo.continuum.io/pkgs/free/osx-64/pytables-3.1.1-np19py27_0.tar.bz2
python                    2.7.13                        0    defaults
python-dateutil           1.5                       <pip>
python.app                1.2                      py27_3    http://repo.continuum.io/pkgs/free/osx-64/python.app-1.2-py27_3.tar.bz2
pytz                      2015.7                   py27_0    http://repo.continuum.io/pkgs/free/osx-64/pytz-2015.7-py27_0.tar.bz2
pyyaml                    3.12                      <pip>
quantities (/Users/andrew/anaconda/envs/neo/lib/python2.7/site-packages) 0.12.1                    <pip>
readline                  6.2                           2    <unknown>
requests                  2.19.1                    <pip>
requests-toolbelt         0.8.0                     <pip>
scipy                     0.14.0               np19py27_0    http://repo.continuum.io/pkgs/free/osx-64/scipy-0.14.0-np19py27_0.tar.bz2
setuptools                36.4.0                   py27_0    defaults
six                       1.10.0                   py27_0    http://repo.continuum.io/pkgs/free/osx-64/six-1.10.0-py27_0.tar.bz2
snowballstemmer           1.2.0                    py27_0    http://repo.continuum.io/pkgs/free/osx-64/snowballstemmer-1.2.0-py27_0.tar.bz2
sphinx                    1.3.1                    py27_0    http://repo.continuum.io/pkgs/free/osx-64/sphinx-1.3.1-py27_0.tar.bz2
sphinx-rtd-theme          0.1.7                     <pip>
sphinx_rtd_theme          0.1.7                    py27_0    http://repo.continuum.io/pkgs/free/osx-64/sphinx_rtd_theme-0.1.7-py27_0.tar.bz2
sqlite                    3.13.0                        0    defaults
tables                    3.1.1                     <pip>
tk                        8.5.18                        0    http://repo.continuum.io/pkgs/free/osx-64/tk-8.5.18-0.tar.bz2
tqdm                      4.19.5                    <pip>
twine                     1.11.0                    <pip>
urllib3                   1.23                      <pip>
wheel                     0.29.0                   py27_0    http://repo.continuum.io/pkgs/free/osx-64/wheel-0.29.0-py27_0.tar.bz2
zlib                      1.2.11                        0    defaults
```