### PR TITLE
Add an alias for `duplicate_with_new_data`, for backwards compatibility.

### DIFF
--- a/neo/core/dataobject.py
+++ b/neo/core/dataobject.py
@@ -331,6 +331,12 @@ class DataObject(BaseNeo, pq.Quantity):
             length = 1
         return length
 
+    def duplicate_with_new_array(self, signal, units=None):
+        warnings.warn("Use of the `duplicate_with_new_array function is deprecated. "
+                      "Please use `duplicate_with_new_data` instead.",
+                      DeprecationWarning)
+        return self.duplicate_with_new_data(signal, units=units)
+
 
 class ArrayDict(dict):
     """Dictionary subclass to handle array annotations


### PR DESCRIPTION
See #621 

I propose to make a release with version 0.7.1 as soon as this is merged, so that we can reduce the impact of updating Neo on downstream projects. What do you think @samuelgarcia ?