### PR TITLE
Stop pushing coverage information to Coveralls from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
-  - "3.6"  
+  - "3.6"
 
 # command to install dependencies
 install:
   - pip install -r requirements.txt
   - pip install coveralls
-  - pip install . 
+  - pip install .
 # command to run tests, e.g. python setup.py test
 script:
   nosetests --with-coverage --cover-package=neo
-after_success:
-  coveralls


### PR DESCRIPTION
as we don't test the `io` modules there.

Now Coveralls gets coverage information only from CircleCI

cf #506 