### PR TITLE
Update docs to reflect correct URL for test files

### DIFF
--- a/doc/source/core.rst
+++ b/doc/source/core.rst
@@ -114,7 +114,7 @@ Here is an example showing these relationships in use::
 
     from neo.io import AxonIO
     import urllib
-    url = "https://portal.g-node.org/neo/axon/File_axon_3.abf"
+    url = "https://web.gin.g-node.org/NeuralEnsemble/ephy_testing_data/raw/master/axon/File_axon_3.abf"
     filename = './test.abf'
     urllib.urlretrieve(url, filename)
 


### PR DESCRIPTION
The URL for test files changed at some point but the docs did not reflect that in the example for AxonIO.  That example fails with the old URL and works with the new one.  