### PR TITLE
Some improvements to AsciiSignalIO

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           keys:
           - v1-dependencies-{{ checksum "requirements.txt" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          #- v1-dependencies-
 
       - restore-cache:
           keys:
@@ -87,7 +87,7 @@ jobs:
           keys:
           - v1-py2-dependencies-{{ checksum "requirements.txt" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-py2-dependencies-
+          #- v1-py2-dependencies-
 
       - restore-cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,11 @@ jobs:
       - checkout
 
       # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          #- v1-dependencies-
+      #- restore_cache:
+      #    keys:
+      #    - v1-dependencies-{{ checksum "requirements.txt" }}
+      #    # fallback to using the latest cache if no exact match is found
+      #    #- v1-dependencies-
 
       - restore-cache:
           keys:
@@ -83,11 +83,11 @@ jobs:
       - checkout
 
       # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-py2-dependencies-{{ checksum "requirements.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          #- v1-py2-dependencies-
+      #- restore_cache:
+      #    keys:
+      #    - v1-py2-dependencies-{{ checksum "requirements.txt" }}
+      #    # fallback to using the latest cache if no exact match is found
+      #    #- v1-py2-dependencies-
 
       - restore-cache:
           keys:

--- a/neo/io/asciisignalio.py
+++ b/neo/io/asciisignalio.py
@@ -45,13 +45,13 @@ class AsciiSignalIO(BaseIO):
         skiprows : skip n first lines in case they contains header informations
         sampling_rate : the sampling rate of signals. Ignored if timecolumn is not None
         t_start : time of the first sample (Quantity). Ignored if timecolumn is not None
-        multichannel : if True, load data as a single, multi-channel AnalogSignal, 
-                       otherwise (default for backwards compatibility) load data as 
+        multichannel : if True, load data as a single, multi-channel AnalogSignal,
+                       otherwise (default for backwards compatibility) load data as
                        separate, single-channel AnalogSignals
         method : 'genfromtxt', 'csv', 'homemade' or a user-defined function which takes a filename
                  and usecolumns as argument and returns a 2D NumPy array.
-        
-        If specifying both usecols and timecolumn, the latter should identify 
+
+        If specifying both usecols and timecolumn, the latter should identify
         the column index _after_ removing the unused columns.
 
         The methods are as follows:
@@ -66,7 +66,8 @@ class AsciiSignalIO(BaseIO):
 
     supported_objects = [Block, Segment, AnalogSignal]
     readable_objects = [Block, Segment]
-    writeable_objects = [Segment]  # can write a Block with a single segment, but not the general case
+    # can write a Block with a single segment, but not the general case
+    writeable_objects = [Segment]
 
     has_header = False
     is_streameable = False
@@ -128,7 +129,8 @@ class AsciiSignalIO(BaseIO):
         self.units = pq.Quantity(1, units)
 
         if not(method in ('genfromtxt', 'csv', 'homemade') or callable(method)):
-            raise ValueError("method must be one of 'genfromtxt', 'csv', 'homemade', or a function")
+            raise ValueError(
+                "method must be one of 'genfromtxt', 'csv', 'homemade', or a function")
         self.method = method
         self.multichannel = multichannel
 
@@ -141,7 +143,7 @@ class AsciiSignalIO(BaseIO):
 
     def read_segment(self, lazy=False):
         """
-        
+
         """
         if lazy:
             raise NotImplementedError("lazy mode not supported")
@@ -193,7 +195,7 @@ class AsciiSignalIO(BaseIO):
             sampling_rate = self.sampling_rate
             t_start = self.t_start
         else:
-            # todo: if the values in timecolumn are not equally spaced 
+            # todo: if the values in timecolumn are not equally spaced
             #       (within float representation tolerances)
             #       we should produce an IrregularlySampledSignal
             sampling_rate = 1.0 / np.mean(np.diff(sig[:, self.timecolumn])) / self.time_units
@@ -210,13 +212,13 @@ class AsciiSignalIO(BaseIO):
             else:
                 signal = sig
             anaSig = AnalogSignal(signal * self.units, sampling_rate=sampling_rate,
-                                  t_start=t_start, 
+                                  t_start=t_start,
                                   channel_index=self.usecols or np.arange(signal.shape[1]),
                                   name='multichannel')
             seg.analogsignals.append(anaSig)
         else:
             if self.timecolumn is not None and self.timecolumn < 0:
-                time_col  = sig.shape[1] + self.timecolumn
+                time_col = sig.shape[1] + self.timecolumn
             else:
                 time_col = self.timecolumn
             for i in range(sig.shape[1]):
@@ -235,13 +237,15 @@ class AsciiSignalIO(BaseIO):
         """
         Write a segment and AnalogSignal in a text file.
         """
-        # todo: check all analog signals have the same length, physical dimensions and sampling rates
+        # todo: check all analog signals have the same length, physical dimensions
+        # and sampling rates
         l = []
         if self.timecolumn is not None:
             if self.timecolumn != 0:
                 raise NotImplementedError("Only column 0 currently supported for writing times")
             l.append(segment.analogsignals[0].times[:, np.newaxis].rescale(self.time_units))
-        # todo: check signals are compatible (size, sampling rate), otherwise we can't/shouldn't concatenate them
+        # todo: check signals are compatible (size, sampling rate), otherwise we
+        # can't/shouldn't concatenate them
         for anaSig in segment.analogsignals:
             l.append(anaSig.rescale(self.units).magnitude)
         sigs = np.concatenate(l, axis=1)

--- a/neo/io/asciisignalio.py
+++ b/neo/io/asciisignalio.py
@@ -2,7 +2,7 @@
 """
 Class for reading/writing analog signals in a text file.
 Each column represents an AnalogSignal. All AnalogSignals have the same sampling rate.
-Covers many case when part of a file can be viewed as a CSV format.
+Covers many cases when parts of a file can be viewed as a CSV format.
 
 Supported : Read/Write
 
@@ -17,16 +17,15 @@ import numpy as np
 import quantities as pq
 
 from neo.io.baseio import BaseIO
-from neo.core import AnalogSignal, Segment
+from neo.core import AnalogSignal, Segment, Block
 
 
 class AsciiSignalIO(BaseIO):
     """
 
-    Class for reading signal in generic ascii format.
-    Columns respresents signals. They all share the same sampling rate.
-    The sampling rate is externally known or the first columns could hold the time
-    vector.
+    Class for reading signals in generic ascii format.
+    Columns represent signals. They all share the same sampling rate.
+    The sampling rate is externally known or the first column could hold the time vector.
 
     Usage:
         >>> from neo import io
@@ -35,14 +34,39 @@ class AsciiSignalIO(BaseIO):
         >>> print seg.analogsignals
         [<AnalogSignal(array([ 39.0625    ,   0.        ,   0.        , ..., -26.85546875 ...
 
+    Arguments relevant for reading and writing:
+        delimiter : column delimiter in file, e.g. '\t', one space, two spaces, ',', ';'
+        timecolumn :  None or a valid integer that identifies which column contains the time vector (counting from zero)
+        units : units of AnalogSignal can be a str or directly a Quantity
+        time_units : where timecolumn is specified, the time units must be specified as a string or Quantity
+
+    Arguments relevant only for reading:
+        usecols : if None take all columns otherwise a list for selected columns (counting from zero)
+        skiprows : skip n first lines in case they contains header informations
+        sampling_rate : the sampling rate of signals. Ignored if timecolumn is not None
+        t_start : time of the first sample (Quantity). Ignored if timecolumn is not None
+        multichannel : if True, load data as a single, multi-channel AnalogSignal, 
+                       otherwise (default for backwards compatibility) load data as 
+                       separate, single-channel AnalogSignals
+        method : 'genfromtxt', 'csv', 'homemade' or a user-defined function which takes a filename
+                 and usecolumns as argument and returns a 2D NumPy array.
+        
+        If specifying both usecols and timecolumn, the latter should identify 
+        the column index _after_ removing the unused columns.
+
+        The methods are as follows:
+            - 'genfromtxt' use numpy.genfromtxt
+            - 'csv' use csv module
+            - 'homemade' use an intuitive, more robust but slow method
+
     """
 
     is_readable = True
     is_writable = True
 
-    supported_objects = [Segment, AnalogSignal]
-    readable_objects = [Segment]
-    writeable_objects = [Segment]
+    supported_objects = [Block, Segment, AnalogSignal]
+    readable_objects = [Block, Segment]
+    writeable_objects = [Segment]  # can write a Block with a single segment, but not the general case
 
     has_header = False
     is_streameable = False
@@ -53,10 +77,12 @@ class AsciiSignalIO(BaseIO):
             ('usecols', {'value': None, 'type': int}),
             ('skiprows', {'value': 0}),
             ('timecolumn', {'value': None, 'type': int}),
-            ('unit', {'value': 'V', }),
-            ('sampling_rate', {'value': 1000., }),
-            ('t_start', {'value': 0., }),
+            ('units', {'value': 'V', }),
+            ('time_units', {'value': pq.s, }),
+            ('sampling_rate', {'value': 1.0 * pq.Hz, }),
+            ('t_start', {'value': 0.0 * pq.s, }),
             ('method', {'value': 'homemade', 'possible': ['genfromtxt', 'csv', 'homemade']}),
+            ('multichannel', {'value': False})
         ]
     }
     write_params = {
@@ -71,135 +97,163 @@ class AsciiSignalIO(BaseIO):
 
     mode = 'file'
 
-    def __init__(self, filename=None):
+    def __init__(self, filename=None, delimiter='\t', usecols=None, skiprows=0, timecolumn=None,
+                 sampling_rate=1.0 * pq.Hz, t_start=0.0 * pq.s, units=pq.V, time_units=pq.s,
+                 method='genfromtxt', multichannel=False):
         """
         This class read/write AnalogSignal in a text file.
         Each signal is a column.
-        One of the column can be the time vector
+        One of the columns can be the time vector.
 
         Arguments:
             filename : the filename to read/write
         """
+        # todo: allow units to be a list/array (e.g. current and voltage in the same file)
         BaseIO.__init__(self)
         self.filename = filename
+        self.delimiter = delimiter
+        self.usecols = usecols
+        self.skiprows = skiprows
+        self.timecolumn = timecolumn
+        self.sampling_rate = sampling_rate
+        self.time_units = time_units
+        if time_units is not None:
+            self.time_units = pq.Quantity(1, time_units)
+        if isinstance(t_start, pq.Quantity):
+            self.t_start = t_start
+        else:
+            if not isinstance(self.time_units, pq.Quantity):
+                raise ValueError("Units of t_start not specified")
+            self.t_start = t_start * self.time_units
+        self.units = pq.Quantity(1, units)
 
-    def read_segment(self,
-                     lazy=False,
-                     delimiter='\t',
-                     usecols=None,
-                     skiprows=0,
+        if not(method in ('genfromtxt', 'csv', 'homemade') or callable(method)):
+            raise ValueError("method must be one of 'genfromtxt', 'csv', 'homemade', or a function")
+        self.method = method
+        self.multichannel = multichannel
 
-                     timecolumn=None,
-                     sampling_rate=1. * pq.Hz,
-                     t_start=0. * pq.s,
+    def read_block(self, lazy=False):
+        block = Block(file_origin=os.path.basename(self.filename))
+        segment = self.read_segment(lazy=lazy)
+        segment.block = block
+        block.segments.append(segment)
+        return block
 
-                     unit=pq.V,
-
-                     method='genfromtxt',
-
-                     ):
+    def read_segment(self, lazy=False):
         """
-        Arguments:
-            delimiter  :  columns delimiter in file  '\t' or one space or two space or ',' or ';'
-            usecols : if None take all columns otherwise a list for selected columns
-            skiprows : skip n first lines in case they contains header informations
-            timecolumn :  None or a valid int that point the time vector
-            samplerate : the samplerate of signals if timecolumn is not None this is not take in account
-            t_start : time of the first sample
-            unit : unit of AnalogSignal can be a str or directly a Quantities
-
-            method :  'genfromtxt' or 'csv' or 'homemade'
-                        in case of bugs you can try one of this methods
-
-                        'genfromtxt' use numpy.genfromtxt
-                        'csv' use cvs module
-                        'homemade' use a intuitive more robust but slow method
-
+        
         """
-        assert not lazy, 'Do not support lazy'
+        if lazy:
+            raise NotImplementedError("lazy mode not supported")
 
         seg = Segment(file_origin=os.path.basename(self.filename))
 
-        if type(sampling_rate) == float or type(sampling_rate) == int:
-            # if not quantitities Hz by default
-            sampling_rate = sampling_rate * pq.Hz
-
-        if type(t_start) == float or type(t_start) == int:
-            # if not quantitities s by default
-            t_start = t_start * pq.s
-
-        unit = pq.Quantity(1, unit)
-
         # loadtxt
-        if method == 'genfromtxt':
+        if self.method == 'genfromtxt':
             sig = np.genfromtxt(self.filename,
-                                delimiter=delimiter,
-                                usecols=usecols,
-                                skip_header=skiprows,
+                                delimiter=self.delimiter,
+                                usecols=self.usecols,
+                                skip_header=self.skiprows,
                                 dtype='f')
             if len(sig.shape) == 1:
                 sig = sig[:, np.newaxis]
-        elif method == 'csv':
-            tab = [l for l in csv.reader(file(self.filename, 'rU'), delimiter=delimiter)]
-            tab = tab[skiprows:]
+        elif self.method == 'csv':
+            tab = [l for l in csv.reader(file(self.filename, 'rU'), delimiter=self.delimiter)]
+            tab = tab[self.skiprows:]
             sig = np.array(tab, dtype='f')
-        elif method == 'homemade':
+            if self.usecols is not None:
+                mask = np.array(self.usecols)
+                sig = sig[:, mask]
+        elif self.method == 'homemade':
             fid = open(self.filename, 'rU')
-            for l in range(skiprows):
+            for l in range(self.skiprows):
                 fid.readline()
             tab = []
             for line in fid.readlines():
                 line = line.replace('\r', '')
                 line = line.replace('\n', '')
-                l = line.split(delimiter)
+                l = line.split(self.delimiter)
                 while '' in l:
                     l.remove('')
                 tab.append(l)
             sig = np.array(tab, dtype='f')
+            if self.usecols is not None:
+                mask = np.array(self.usecols)
+                sig = sig[:, mask]
+        else:
+            sig = self.method(self.filename, self.usecols)
+            if not isinstance(sig, np.ndarray):
+                raise TypeError("method function must return a NumPy array")
+            if len(sig.shape) == 1:
+                sig = sig[:, np.newaxis]
+            elif sig.shape != 2:
+                raise ValueError("method function must return a 1D or 2D NumPy array")
 
-        if timecolumn is not None:
-            sampling_rate = 1. / np.mean(np.diff(sig[:, timecolumn])) * pq.Hz
-            t_start = sig[0, timecolumn] * pq.s
+        if self.timecolumn is None:
+            sampling_rate = self.sampling_rate
+            t_start = self.t_start
+        else:
+            # todo: if the values in timecolumn are not equally spaced 
+            #       (within float representation tolerances)
+            #       we should produce an IrregularlySampledSignal
+            sampling_rate = 1.0 / np.mean(np.diff(sig[:, self.timecolumn])) / self.time_units
+            t_start = sig[0, self.timecolumn] * self.time_units
 
-        for i in range(sig.shape[1]):
-            if timecolumn == i:
-                continue
-            if usecols is not None and i not in usecols:
-                continue
-
-            signal = sig[:, i] * unit
-
-            anaSig = AnalogSignal(signal, sampling_rate=sampling_rate,
-                                  t_start=t_start, channel_index=i,
-                                  name='Column %d' % i)
-
+        if self.multichannel:
+            if self.timecolumn is not None:
+                mask = list(range(sig.shape[1]))
+                if self.timecolumn >= 0:
+                    mask.remove(self.timecolumn)
+                else:  # allow negative column index
+                    mask.remove(sig.shape[1] + self.timecolumn)
+                signal = sig[:, mask]
+            else:
+                signal = sig
+            anaSig = AnalogSignal(signal * self.units, sampling_rate=sampling_rate,
+                                  t_start=t_start, 
+                                  channel_index=self.usecols or np.arange(signal.shape[1]),
+                                  name='multichannel')
             seg.analogsignals.append(anaSig)
+        else:
+            if self.timecolumn is not None and self.timecolumn < 0:
+                time_col  = sig.shape[1] + self.timecolumn
+            else:
+                time_col = self.timecolumn
+            for i in range(sig.shape[1]):
+                if time_col == i:
+                    continue
+                signal = sig[:, i] * self.units
+                anaSig = AnalogSignal(signal, sampling_rate=sampling_rate,
+                                      t_start=t_start, channel_index=i,
+                                      name='Column %d' % i)
+                seg.analogsignals.append(anaSig)
 
         seg.create_many_to_one_relationship()
         return seg
 
-    def write_segment(self, segment,
-                      delimiter='\t',
-
-                      skiprows=0,
-                      writetimecolumn=True,
-
-                      ):
+    def write_segment(self, segment):
         """
         Write a segment and AnalogSignal in a text file.
-
-         **Arguments**
-            delimiter  :  columns delimiter in file  '\t' or one space or two space or ',' or ';'
-            writetimecolumn :  True or Flase write time vector as first column
         """
-        if skiprows:
-            raise NotImplementedError('skiprows values other than 0 are not ' +
-                                      'supported')
+        # todo: check all analog signals have the same length, physical dimensions and sampling rates
         l = []
-        if writetimecolumn is not None:
-            l.append(segment.analogsignals[0].times[:, np.newaxis])
+        if self.timecolumn is not None:
+            if self.timecolumn != 0:
+                raise NotImplementedError("Only column 0 currently supported for writing times")
+            l.append(segment.analogsignals[0].times[:, np.newaxis].rescale(self.time_units))
+        # todo: check signals are compatible (size, sampling rate), otherwise we can't/shouldn't concatenate them
         for anaSig in segment.analogsignals:
-            l.append(anaSig.magnitude[:, np.newaxis])
+            l.append(anaSig.rescale(self.units).magnitude)
         sigs = np.concatenate(l, axis=1)
         # print sigs.shape
-        np.savetxt(self.filename, sigs, delimiter=delimiter)
+        np.savetxt(self.filename, sigs, delimiter=self.delimiter)
+
+    def write_block(self, block):
+        """
+        Can only write blocks containing a single segment.
+        """
+        # in future, maybe separate segments by a blank link, or a "magic" comment
+        if len(block.segments) > 1:
+            raise ValueError("Can only write blocks containing a single segment."
+                             " This block contains {} segments.".format(len(block.segments)))
+        self.write_segment(block.segments[0])

--- a/neo/io/asciisignalio.py
+++ b/neo/io/asciisignalio.py
@@ -36,20 +36,23 @@ class AsciiSignalIO(BaseIO):
 
     Arguments relevant for reading and writing:
         delimiter : column delimiter in file, e.g. '\t', one space, two spaces, ',', ';'
-        timecolumn :  None or a valid integer that identifies which column contains the time vector (counting from zero)
+        timecolumn :  None or a valid integer that identifies which column contains
+                      the time vector (counting from zero)
         units : units of AnalogSignal can be a str or directly a Quantity
-        time_units : where timecolumn is specified, the time units must be specified as a string or Quantity
+        time_units : where timecolumn is specified, the time units must be specified
+                     as a string or Quantity
 
     Arguments relevant only for reading:
-        usecols : if None take all columns otherwise a list for selected columns (counting from zero)
+        usecols : if None take all columns otherwise a list for selected columns
+                  (counting from zero)
         skiprows : skip n first lines in case they contains header informations
         sampling_rate : the sampling rate of signals. Ignored if timecolumn is not None
         t_start : time of the first sample (Quantity). Ignored if timecolumn is not None
         multichannel : if True, load data as a single, multi-channel AnalogSignal,
                        otherwise (default for backwards compatibility) load data as
                        separate, single-channel AnalogSignals
-        method : 'genfromtxt', 'csv', 'homemade' or a user-defined function which takes a filename
-                 and usecolumns as argument and returns a 2D NumPy array.
+        method : 'genfromtxt', 'csv', 'homemade' or a user-defined function which takes a
+                 filename and usecolumns as argument and returns a 2D NumPy array.
 
         If specifying both usecols and timecolumn, the latter should identify
         the column index _after_ removing the unused columns.
@@ -174,10 +177,10 @@ class AsciiSignalIO(BaseIO):
             for line in fid.readlines():
                 line = line.replace('\r', '')
                 line = line.replace('\n', '')
-                l = line.split(self.delimiter)
-                while '' in l:
-                    l.remove('')
-                tab.append(l)
+                parts = line.split(self.delimiter)
+                while '' in parts:
+                    parts.remove('')
+                tab.append(parts)
             sig = np.array(tab, dtype='f')
             if self.usecols is not None:
                 mask = np.array(self.usecols)

--- a/neo/rawio/examplerawio.py
+++ b/neo/rawio/examplerawio.py
@@ -27,7 +27,7 @@ Rules for creating a new class:
 
   3. Step 3 : Create the neo.io class with the wrapper
     * Create a file in neo/io/ that endith with "io.py"
-    * Create a that hinerits bot yrou RawIO class and BaseFromRaw class
+    * Create a that inherits both your RawIO class and BaseFromRaw class
     * copy/paste from neo/io/exampleio.py
 
   4.Step 4 : IO test

--- a/neo/test/iotest/test_asciisignalio.py
+++ b/neo/test/iotest/test_asciisignalio.py
@@ -30,16 +30,16 @@ class TestAsciiSignalIO(unittest.TestCase):
         sample_data = np.random.uniform(size=(200, 3))
         filename = "test_genfromtxt_expect_success.txt"
         np.savetxt(filename, sample_data, delimiter=' ')
-        sampling_rate = 1*pq.kHz
+        sampling_rate = 1 * pq.kHz
         io = AsciiSignalIO(filename, sampling_rate=sampling_rate, delimiter=' ',
                            units='mV', method='genfromtxt')
         block = io.read_block()
-        
+
         signal1 = block.segments[0].analogsignals[1]
         assert_array_almost_equal(signal1.reshape(-1).magnitude, sample_data[:, 1],
                                   decimal=6)
         self.assertEqual(len(block.segments[0].analogsignals), 3)
-        self.assertEqual(signal1.t_stop, sample_data.shape[0]/sampling_rate)
+        self.assertEqual(signal1.t_stop, sample_data.shape[0] / sampling_rate)
         self.assertEqual(signal1.units, pq.mV)
 
         os.remove(filename)
@@ -62,7 +62,7 @@ class TestAsciiSignalIO(unittest.TestCase):
                            units='mV', method='genfromtxt', timecolumn=-1,
                            time_units='ms', multichannel=False)
         block = io.read_block()
-        
+
         signal1 = block.segments[0].analogsignals[1]
         assert_array_almost_equal(signal1.reshape(-1).magnitude, sample_data[:, 1],
                                   decimal=6)
@@ -77,17 +77,17 @@ class TestAsciiSignalIO(unittest.TestCase):
         sample_data = np.random.uniform(size=(200, 3))
         filename = "test_multichannel.txt"
         np.savetxt(filename, sample_data, delimiter=' ')
-        sampling_rate = 1*pq.kHz
+        sampling_rate = 1 * pq.kHz
         io = AsciiSignalIO(filename, sampling_rate=sampling_rate, delimiter=' ',
                            units='mV', method='genfromtxt',
                            multichannel=True)
         block = io.read_block()
-        
+
         signal = block.segments[0].analogsignals[0]
         assert_array_almost_equal(signal.magnitude, sample_data,
                                   decimal=6)
         self.assertEqual(len(block.segments[0].analogsignals), 1)
-        self.assertEqual(signal.t_stop, sample_data.shape[0]/sampling_rate)
+        self.assertEqual(signal.t_stop, sample_data.shape[0] / sampling_rate)
         self.assertEqual(signal.units, pq.mV)
 
         os.remove(filename)
@@ -104,7 +104,7 @@ class TestAsciiSignalIO(unittest.TestCase):
                            time_units='ms',
                            multichannel=True)
         block = io.read_block()
-        
+
         signal = block.segments[0].analogsignals[0]
         assert_array_almost_equal(signal.magnitude, sample_data,
                                   decimal=6)
@@ -127,7 +127,7 @@ class TestAsciiSignalIO(unittest.TestCase):
                            time_units='ms',
                            multichannel=True)
         block = io.read_block()
-        
+
         signal = block.segments[0].analogsignals[0]
         assert_array_almost_equal(signal.magnitude, sample_data,
                                   decimal=6)
@@ -141,7 +141,6 @@ class TestAsciiSignalIO(unittest.TestCase):
     # test write without timecolumn
     # test write with timecolumn
     # test write with units/timeunits different from those of signal
-
 
 
 if __name__ == "__main__":

--- a/neo/test/iotest/test_asciisignalio.py
+++ b/neo/test/iotest/test_asciisignalio.py
@@ -60,7 +60,7 @@ class TestAsciiSignalIO(unittest.TestCase):
         np.savetxt(filename, combined_data, delimiter=' ')
         io = AsciiSignalIO(filename, delimiter=' ',
                            units='mV', method='genfromtxt', timecolumn=-1,
-                           time_units='ms', multichannel=False)
+                           time_units='ms', signal_group_mode='split-all')
         block = io.read_block()
 
         signal1 = block.segments[0].analogsignals[1]
@@ -80,7 +80,7 @@ class TestAsciiSignalIO(unittest.TestCase):
         sampling_rate = 1 * pq.kHz
         io = AsciiSignalIO(filename, sampling_rate=sampling_rate, delimiter=' ',
                            units='mV', method='genfromtxt',
-                           multichannel=True)
+                           signal_group_mode='all-in-one')
         block = io.read_block()
 
         signal = block.segments[0].analogsignals[0]
@@ -102,7 +102,7 @@ class TestAsciiSignalIO(unittest.TestCase):
         io = AsciiSignalIO(filename, delimiter=' ',
                            units='mV', method='genfromtxt', timecolumn=0,
                            time_units='ms',
-                           multichannel=True)
+                           signal_group_mode='all-in-one')
         block = io.read_block()
 
         signal = block.segments[0].analogsignals[0]
@@ -125,7 +125,7 @@ class TestAsciiSignalIO(unittest.TestCase):
         io = AsciiSignalIO(filename, delimiter=' ',
                            units='mV', method='genfromtxt', timecolumn=-1,
                            time_units='ms',
-                           multichannel=True)
+                           signal_group_mode='all-in-one')
         block = io.read_block()
 
         signal = block.segments[0].analogsignals[0]

--- a/neo/test/iotest/test_asciisignalio.py
+++ b/neo/test/iotest/test_asciisignalio.py
@@ -6,19 +6,142 @@ Tests of neo.io.asciisignalio
 # needed for python 3 compatibility
 from __future__ import absolute_import, division
 
+import os
 import unittest
-
+import numpy as np
+import quantities as pq
+from numpy.testing import assert_array_almost_equal
 from neo.io import AsciiSignalIO
 from neo.test.iotest.common_io_test import BaseTestIO
 
 
-class TestAsciiSignalIO(BaseTestIO, unittest.TestCase, ):
+class TestAsciiSignalIOWithTestFiles(BaseTestIO, unittest.TestCase):
     ioclass = AsciiSignalIO
     files_to_download = [  # 'File_asciisignal_1.asc',
         'File_asciisignal_2.txt',
         'File_asciisignal_3.txt',
     ]
     files_to_test = files_to_download
+
+
+class TestAsciiSignalIO(unittest.TestCase):
+
+    def test_genfromtxt_expect_success(self):
+        sample_data = np.random.uniform(size=(200, 3))
+        filename = "test_genfromtxt_expect_success.txt"
+        np.savetxt(filename, sample_data, delimiter=' ')
+        sampling_rate = 1*pq.kHz
+        io = AsciiSignalIO(filename, sampling_rate=sampling_rate, delimiter=' ',
+                           units='mV', method='genfromtxt')
+        block = io.read_block()
+        
+        signal1 = block.segments[0].analogsignals[1]
+        assert_array_almost_equal(signal1.reshape(-1).magnitude, sample_data[:, 1],
+                                  decimal=6)
+        self.assertEqual(len(block.segments[0].analogsignals), 3)
+        self.assertEqual(signal1.t_stop, sample_data.shape[0]/sampling_rate)
+        self.assertEqual(signal1.units, pq.mV)
+
+        os.remove(filename)
+
+    # test_genfromtxt_expect_failure
+    # test_csv_expect_success
+    # test_csv_expect_failure
+    # test_homemade_expect_success
+    # test_homemade_expect_failure
+    # test usecols
+    # test skiprows
+    def test_timecolumn(self):
+        sample_data = np.random.uniform(size=(200, 3))
+        sampling_period = 0.5
+        time_data = sampling_period * np.arange(sample_data.shape[0])
+        combined_data = np.hstack((sample_data, time_data[:, np.newaxis]))
+        filename = "test_multichannel.txt"
+        np.savetxt(filename, combined_data, delimiter=' ')
+        io = AsciiSignalIO(filename, delimiter=' ',
+                           units='mV', method='genfromtxt', timecolumn=-1,
+                           time_units='ms', multichannel=False)
+        block = io.read_block()
+        
+        signal1 = block.segments[0].analogsignals[1]
+        assert_array_almost_equal(signal1.reshape(-1).magnitude, sample_data[:, 1],
+                                  decimal=6)
+        self.assertEqual(signal1.sampling_period, sampling_period * pq.ms)
+        self.assertEqual(len(block.segments[0].analogsignals), 3)
+        self.assertEqual(signal1.t_stop, sample_data.shape[0] * sampling_period * pq.ms)
+        self.assertEqual(signal1.units, pq.mV)
+
+        os.remove(filename)
+
+    def test_multichannel(self):
+        sample_data = np.random.uniform(size=(200, 3))
+        filename = "test_multichannel.txt"
+        np.savetxt(filename, sample_data, delimiter=' ')
+        sampling_rate = 1*pq.kHz
+        io = AsciiSignalIO(filename, sampling_rate=sampling_rate, delimiter=' ',
+                           units='mV', method='genfromtxt',
+                           multichannel=True)
+        block = io.read_block()
+        
+        signal = block.segments[0].analogsignals[0]
+        assert_array_almost_equal(signal.magnitude, sample_data,
+                                  decimal=6)
+        self.assertEqual(len(block.segments[0].analogsignals), 1)
+        self.assertEqual(signal.t_stop, sample_data.shape[0]/sampling_rate)
+        self.assertEqual(signal.units, pq.mV)
+
+        os.remove(filename)
+
+    def test_multichannel_with_timecolumn(self):
+        sample_data = np.random.uniform(size=(200, 3))
+        sampling_period = 0.5
+        time_data = sampling_period * np.arange(sample_data.shape[0])
+        combined_data = np.hstack((time_data[:, np.newaxis], sample_data))
+        filename = "test_multichannel.txt"
+        np.savetxt(filename, combined_data, delimiter=' ')
+        io = AsciiSignalIO(filename, delimiter=' ',
+                           units='mV', method='genfromtxt', timecolumn=0,
+                           time_units='ms',
+                           multichannel=True)
+        block = io.read_block()
+        
+        signal = block.segments[0].analogsignals[0]
+        assert_array_almost_equal(signal.magnitude, sample_data,
+                                  decimal=6)
+        self.assertEqual(signal.sampling_period, sampling_period * pq.ms)
+        self.assertEqual(len(block.segments[0].analogsignals), 1)
+        self.assertEqual(signal.t_stop, sample_data.shape[0] * sampling_period * pq.ms)
+        self.assertEqual(signal.units, pq.mV)
+
+        os.remove(filename)
+
+    def test_multichannel_with_negative_timecolumn(self):
+        sample_data = np.random.uniform(size=(200, 3))
+        sampling_period = 0.5
+        time_data = sampling_period * np.arange(sample_data.shape[0])
+        combined_data = np.hstack((sample_data, time_data[:, np.newaxis]))
+        filename = "test_multichannel.txt"
+        np.savetxt(filename, combined_data, delimiter=' ')
+        io = AsciiSignalIO(filename, delimiter=' ',
+                           units='mV', method='genfromtxt', timecolumn=-1,
+                           time_units='ms',
+                           multichannel=True)
+        block = io.read_block()
+        
+        signal = block.segments[0].analogsignals[0]
+        assert_array_almost_equal(signal.magnitude, sample_data,
+                                  decimal=6)
+        self.assertEqual(signal.sampling_period, sampling_period * pq.ms)
+        self.assertEqual(len(block.segments[0].analogsignals), 1)
+        self.assertEqual(signal.t_stop, sample_data.shape[0] * sampling_period * pq.ms)
+        self.assertEqual(signal.units, pq.mV)
+
+        os.remove(filename)
+
+    # test write without timecolumn
+    # test write with timecolumn
+    # test write with units/timeunits different from those of signal
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
in preparation for working on #579. Main changes:

(1) moved most arguments from `read_segment()` method to the IO class constructor, and added a `read_block()` method. This makes AsciiSignalIO more consistent with other Neo IOs.
(2) added an argument "multichannel", to control whether to create a multi-channel AnalogSignal or a list of single-channel signals. The default is the latter, for backwards compatibility.
(3) more consistency checks on argument values
(4) fixed a bug with "genfromtxt" where usecols would be applied twice.