### PR TITLE
Add support for reading IrregularlySampledSignals in AsciiSignalIO

### DIFF
--- a/neo/io/asciisignalio.py
+++ b/neo/io/asciisignalio.py
@@ -225,15 +225,13 @@ class AsciiSignalIO(BaseIO):
             sampling_rate = self.sampling_rate
             t_start = self.t_start
         else:
-            # todo: if the values in timecolumn are not equally spaced
-            #       (within float representation tolerances)
-            #       we should produce an IrregularlySampledSignal
             delta_t = np.diff(sig[:, self.timecolumn])
             mean_delta_t = np.mean(delta_t)
             if (delta_t.max() - delta_t.min()) / mean_delta_t < 1e-6:
-                # equally spaced
+                # equally spaced --> AnalogSignal
                 sampling_rate = 1.0 / np.mean(np.diff(sig[:, self.timecolumn])) / self.time_units
             else:
+                # not equally spaced --> IrregularlySampledSignal
                 sampling_rate = None
             t_start = sig[0, self.timecolumn] * self.time_units
 

--- a/neo/io/asciisignalio.py
+++ b/neo/io/asciisignalio.py
@@ -18,7 +18,7 @@ import numpy as np
 import quantities as pq
 
 from neo.io.baseio import BaseIO
-from neo.core import AnalogSignal, Segment, Block
+from neo.core import AnalogSignal, IrregularlySampledSignal, Segment, Block
 
 
 class AsciiSignalIO(BaseIO):
@@ -228,7 +228,13 @@ class AsciiSignalIO(BaseIO):
             # todo: if the values in timecolumn are not equally spaced
             #       (within float representation tolerances)
             #       we should produce an IrregularlySampledSignal
-            sampling_rate = 1.0 / np.mean(np.diff(sig[:, self.timecolumn])) / self.time_units
+            delta_t = np.diff(sig[:, self.timecolumn])
+            mean_delta_t = np.mean(delta_t)
+            if (delta_t.max() - delta_t.min())/mean_delta_t < 1e-6:
+                # equally spaced
+                sampling_rate = 1.0 / np.mean(np.diff(sig[:, self.timecolumn])) / self.time_units
+            else:
+                sampling_rate = None
             t_start = sig[0, self.timecolumn] * self.time_units
 
         if self.signal_group_mode == 'all-in-one':
@@ -241,11 +247,17 @@ class AsciiSignalIO(BaseIO):
                 signal = sig[:, mask]
             else:
                 signal = sig
-            anaSig = AnalogSignal(signal * self.units, sampling_rate=sampling_rate,
-                                  t_start=t_start,
-                                  channel_index=self.usecols or np.arange(signal.shape[1]),
-                                  name='multichannel')
-            seg.analogsignals.append(anaSig)
+            if sampling_rate is None:
+                irr_sig = IrregularlySampledSignal(signal[:, self.timecolumn] * self.time_units,
+                                                   signal * self.units,
+                                                   name='multichannel')
+                seg.irregularlysampledsignals.append(irr_sig)
+            else:
+                ana_sig = AnalogSignal(signal * self.units, sampling_rate=sampling_rate,
+                                       t_start=t_start,
+                                       channel_index=self.usecols or np.arange(signal.shape[1]),
+                                       name='multichannel')
+                seg.analogsignals.append(ana_sig)
         else:
             if self.timecolumn is not None and self.timecolumn < 0:
                 time_col = sig.shape[1] + self.timecolumn
@@ -255,10 +267,17 @@ class AsciiSignalIO(BaseIO):
                 if time_col == i:
                     continue
                 signal = sig[:, i] * self.units
-                anaSig = AnalogSignal(signal, sampling_rate=sampling_rate,
-                                      t_start=t_start, channel_index=i,
-                                      name='Column %d' % i)
-                seg.analogsignals.append(anaSig)
+                if sampling_rate is None:
+                    irr_sig = IrregularlySampledSignal(sig[:, time_col] * self.time_units,
+                                                       signal,
+                                                       t_start=t_start, channel_index=i,
+                                                       name='Column %d' % i)
+                    seg.irregularlysampledsignals.append(irr_sig)
+                else:
+                    ana_sig = AnalogSignal(signal, sampling_rate=sampling_rate,
+                                           t_start=t_start, channel_index=i,
+                                           name='Column %d' % i)
+                    seg.analogsignals.append(ana_sig)
 
         seg.create_many_to_one_relationship()
         return seg

--- a/neo/io/asciisignalio.py
+++ b/neo/io/asciisignalio.py
@@ -230,7 +230,7 @@ class AsciiSignalIO(BaseIO):
             #       we should produce an IrregularlySampledSignal
             delta_t = np.diff(sig[:, self.timecolumn])
             mean_delta_t = np.mean(delta_t)
-            if (delta_t.max() - delta_t.min())/mean_delta_t < 1e-6:
+            if (delta_t.max() - delta_t.min()) / mean_delta_t < 1e-6:
                 # equally spaced
                 sampling_rate = 1.0 / np.mean(np.diff(sig[:, self.timecolumn])) / self.time_units
             else:

--- a/neo/test/iotest/test_asciisignalio.py
+++ b/neo/test/iotest/test_asciisignalio.py
@@ -64,13 +64,15 @@ class TestAsciiSignalIO(unittest.TestCase):
                 writer.writerow(row)
 
         io = AsciiSignalIO(filename, usecols=(0, 1, 3), timecolumn=2,
-                           # note that timecolumn applies to the remaining columns after applying usecols
+                           # note that timecolumn applies to the remaining columns
+                           # after applying usecols
                            time_units="ms", delimiter=',', units="mV", method='csv',
                            signal_group_mode='all-in-one', t_start=0.5)
 
         block = io.read_block()
         signal = block.segments[0].analogsignals[0]
-        self.assertEqual(signal.shape, (4, 2))  # two columns remaining after usecols and timecolumn applied
+        self.assertEqual(signal.shape, (4, 2))  # two columns remaining after usecols
+                                                # and timecolumn applied
         assert_array_almost_equal(signal[:, 1].reshape(-1).magnitude,
                                   np.array(sample_data)[:, 1],
                                   decimal=5)
@@ -99,7 +101,8 @@ class TestAsciiSignalIO(unittest.TestCase):
 
         block = io.read_block()
         signal = block.segments[0].analogsignals[0]
-        self.assertEqual(signal.shape, (4, 2))  # two columns remaining after usecols and timecolumn applied
+        self.assertEqual(signal.shape, (4, 2))  # two columns remaining after usecols
+                                                # and timecolumn applied
         assert_array_almost_equal(signal[:, 1].reshape(-1).magnitude,
                                   np.array(sample_data)[:, 1],
                                   decimal=5)
@@ -283,7 +286,8 @@ class TestAsciiSignalIO(unittest.TestCase):
         assert len(block2.segments[0].analogsignals) == 3
         signal2 = block2.segments[0].analogsignals[1]
 
-        assert_array_almost_equal(signal1.magnitude[:, 1], signal2.magnitude.reshape(-1), decimal=7)
+        assert_array_almost_equal(signal1.magnitude[:, 1], signal2.magnitude.reshape(-1),
+                                  decimal=7)
         self.assertEqual(signal1.units, signal2.units)
         self.assertEqual(signal1.sampling_rate, signal2.sampling_rate)
         assert_array_equal(signal1.times, signal2.times)
@@ -309,7 +313,6 @@ class TestAsciiSignalIO(unittest.TestCase):
         self.assertEqual(signal1.units, pq.mV)
 
         os.remove(filename)
-
 
     def test_irregular_multichannel(self):
         sample_data = np.random.uniform(size=(200, 3))


### PR DESCRIPTION
(cf #649)

Not implemented: write support for IrregularlySampledSignals