### PR TITLE
BlackrockRawIO: Fixed thresholds not being multiplied by the digitisation factor

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -320,7 +320,8 @@ class BlackrockRawIO(BaseRawIO):
         all_spec = [self.__nsx_spec[nsx_nb] for nsx in self.nsx_to_load]
         if self._avail_files['nev']:
             all_spec.append(self.__nev_spec)
-        assert all(all_spec[0] == spec for spec in all_spec), "Files don't have the same internal version"
+        assert all(all_spec[0] == spec for spec in all_spec), \
+            "Files don't have the same internal version"
 
         if len(self.nsx_to_load) > 0 and \
                 self.__nsx_spec[self.nsx_to_load[0]] == '2.1' and \
@@ -1919,7 +1920,7 @@ class BlackrockRawIO(BaseRawIO):
                 # remap nsx seg index
                 for nsx_nb in self.nsx_to_load:
                     data = self.nsx_datas[nsx_nb].pop(j)
-                    self.nsx_datas[nsx_nb][j-1] = data
+                    self.nsx_datas[nsx_nb][j - 1] = data
 
                     data_header = self.__nsx_data_header[nsx_nb].pop(j)
                     self.__nsx_data_header[nsx_nb][j - 1] = data_header

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -509,9 +509,11 @@ class BlackrockRawIO(BaseRawIO):
                     chidx_ann['connector_pinID'] = neuevwav['connector_pin'][get_idx]
                     chidx_ann['nev_dig_factor'] = neuevwav['digitization_factor'][get_idx]
                     chidx_ann['nev_energy_threshold'] = neuevwav['energy_threshold'][
-                        get_idx] * pq.uV
-                    chidx_ann['nev_hi_threshold'] = neuevwav['hi_threshold'][get_idx] * pq.uV
-                    chidx_ann['nev_lo_threshold'] = neuevwav['lo_threshold'][get_idx] * pq.uV
+                        get_idx] * chidx_ann['nev_dig_factor'] / 1000 * pq.uV
+                    chidx_ann['nev_hi_threshold'] = neuevwav['hi_threshold'][get_idx] * chidx_ann[
+                        'nev_dig_factor'] / 1000 * pq.uV
+                    chidx_ann['nev_lo_threshold'] = neuevwav['lo_threshold'][get_idx] * chidx_ann[
+                        'nev_dig_factor'] / 1000 * pq.uV
                     chidx_ann['nb_sorted_units'] = neuevwav['nb_sorted_units'][get_idx]
                     chidx_ann['waveform_size'] = self.__waveform_size[self.__nev_spec](
                     )[sig_channels[c]['id']] * self.__nev_params('waveform_time_unit')


### PR DESCRIPTION
The thresholds are applied to the digitised signal in the Blackrock software, to use them with the converted analog signal we need to multiply them by the digitisation factor.