### PR TITLE
[WIP] Test data generation fixes for array_annotations

### DIFF
--- a/neo/test/generate_datasets.py
+++ b/neo/test/generate_datasets.py
@@ -225,7 +225,7 @@ def get_fake_value(name, datatype, dim=0, dtype='float', seed=None, units=None, 
             if shape is None:
                 # To ensure consistency, times, labels and durations need to have the same size
                 if name in ["times", "labels", "durations"]:
-                    size.append(n if n else 5)
+                    size.append(5)
                 else:
                     size.append(np.random.randint(5) + 1)
             else:

--- a/neo/test/generate_datasets.py
+++ b/neo/test/generate_datasets.py
@@ -225,7 +225,7 @@ def get_fake_value(name, datatype, dim=0, dtype='float', seed=None, units=None, 
             if shape is None:
                 # To ensure consistency, times, labels and durations need to have the same size
                 if name in ["times", "labels", "durations"]:
-                    size.append(5)
+                    size.append(n if n else 5)
                 else:
                     size.append(np.random.randint(5) + 1)
             else:
@@ -286,6 +286,9 @@ def get_fake_values(cls, annotate=True, seed=None, n=None):
     for i, attr in enumerate(cls._necessary_attrs + cls._recommended_attrs):
         if seed is not None:
             iseed = seed + i
+        #if cls == Epoch and attr in ['durations', 'labels', 'array_annotations']:
+        #    kwargs[attr[0]] = get_fake_value(*attr, seed=iseed, obj=cls, shape=n)
+        #else:
         kwargs[attr[0]] = get_fake_value(*attr, seed=iseed, obj=cls, n=n)
 
     if 'waveforms' in kwargs:  # everything here is to force the kwargs to have len(time) ==
@@ -381,11 +384,11 @@ def fake_neo(obj_type="Block", cascade=True, seed=None, n=1):
         cls = obj_type
         obj_type = obj_type.__name__
 
-    if cls is Epoch:
-        obj = fake_epoch(seed=seed, n=n)
-    else:
-        kwargs = get_fake_values(obj_type, annotate=True, seed=seed, n=n)
-        obj = cls(**kwargs)
+    #if cls is Epoch:
+    #    obj = fake_epoch(seed=seed, n=n)
+    #else:
+    kwargs = get_fake_values(obj_type, annotate=True, seed=seed, n=n)
+    obj = cls(**kwargs)
 
     # if not cascading, we don't need to do any of the stuff after this
     if not cascade:


### PR DESCRIPTION
With the introduction of array_annotations in neo 0.7 the generation of test data (`fake_neo`, `get_fake_values`) has changed a bit. The resulting data are not consistent (in length) any more causing tests in Elephant to fail (see Neuralensemble/elephant#192).
So far this PR is a quick and dirty fix to solve those problems by hardcoding the length of every object that has array_annotations. 

Of course, this is not the desired behavior. Instead it would be good to make random generation consistent again. When I looked into this, I found out that Epoch is handled separately causing quite a few difficulties. By hardcoding the length I could trivially remove this special case. But since there is no such function for Events I assume this consistency can be accomplished without any special cases or hardcoding.
When I tried to do this, however, I noticed some pieces of code I could not understand. I also didn't find any documentation regarding the desired behavior. So before implementing any changes I wanted to check what the parameters `n`, `dim` and `shape` in `fake_neo` and `get_fake_value`/`get_fake_values` are supposed to do. It seems to me that sometimes `n` is actually used to define shape, and `shape` might be appended to the final shape `dim` times etc. If anybody knows this, I could try to restore consistent output in a general way that can handle any objects.