### PR TITLE
Revert implementation of Epoch and Event to not use array annotations machinery for label and duration

### DIFF
--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -117,7 +117,7 @@ class Epoch(DataObject):
             ValueError("Unit %s has dimensions %s, not [time]" % (units, dim.simplified))
 
         obj = pq.Quantity.__new__(cls, times, units=dim)
-        obj.labels = labels
+        obj.labels = np.array(labels)
         obj.durations = durations
         obj.segment = None
         return obj

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -95,8 +95,10 @@ class Epoch(DataObject):
                 raise ValueError("Durations array has different length to times")
         if labels is None:
             labels = np.array([], dtype='S')
-        elif len(labels) != times.size:
-            raise ValueError("Labels array has different length to times")
+        else:
+            labels = np.array(labels)
+            if labels.size != times.size and labels.size:
+                raise ValueError("Labels array has different length to times")
         if units is None:
             # No keyword units, so get from `times`
             try:
@@ -117,7 +119,7 @@ class Epoch(DataObject):
             ValueError("Unit %s has dimensions %s, not [time]" % (units, dim.simplified))
 
         obj = pq.Quantity.__new__(cls, times, units=dim)
-        obj._labels = np.array(labels)
+        obj._labels = labels
         obj._durations = durations
         obj.segment = None
         return obj

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -192,7 +192,10 @@ class Epoch(DataObject):
         obj = Epoch(times=super(Epoch, self).__getitem__(i))
         obj._copy_data_complement(self)
         obj._durations = self.durations[i]
-        obj._labels = self.labels[i]
+        if self._labels is not None and self._labels.size > 0:
+            obj._labels = self.labels[i]
+        else:
+            obj._labels = self.labels
         try:
             # Array annotations need to be sliced accordingly
             obj.array_annotate(**deepcopy(self.array_annotations_at_index(i)))

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -82,8 +82,10 @@ class Event(DataObject):
             times = np.array([]) * pq.s
         if labels is None:
             labels = np.array([], dtype='S')
-        elif len(labels) != times.size:
-            raise ValueError("Labels array has different length to times")
+        else:
+            labels = np.array(labels)
+            if labels.size != times.size and labels.size:
+                raise ValueError("Labels array has different length to times")
         if units is None:
             # No keyword units, so get from `times`
             try:
@@ -104,7 +106,7 @@ class Event(DataObject):
             ValueError("Unit %s has dimensions %s, not [time]" % (units, dim.simplified))
 
         obj = pq.Quantity(times, units=dim).view(cls)
-        obj._labels = np.array(labels)
+        obj._labels = labels
         obj.segment = None
         return obj
 

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -102,7 +102,7 @@ class Event(DataObject):
             ValueError("Unit %s has dimensions %s, not [time]" % (units, dim.simplified))
 
         obj = pq.Quantity(times, units=dim).view(cls)
-        obj.labels = labels
+        obj.labels = np.array(labels)
         obj.segment = None
         return obj
 

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -217,6 +217,10 @@ class Event(DataObject):
 
     def __getitem__(self, i):
         obj = super(Event, self).__getitem__(i)
+        if self._labels is not None and self._labels.size > 0:
+            obj.labels = self._labels[i]
+        else:
+            obj.labels = self._labels
         try:
             obj.array_annotate(**deepcopy(self.array_annotations_at_index(i)))
         except AttributeError:  # If Quantity was returned, not Event

--- a/neo/io/brainwaresrcio.py
+++ b/neo/io/brainwaresrcio.py
@@ -517,13 +517,6 @@ class BrainwareSrcIO(BaseIO):
         senders = []
         for event in events:
             times.append(event.times.magnitude)
-            # With the introduction of array annotations and the adaptation of labels to use
-            # this infrastructure, even single labels are wrapped into an array to ensure
-            # consistency.
-            # The following lines were 'labels.append(event.labels)' which assumed event.labels
-            # to be a scalar. Thus, I can safely assume the array to have length 1, because
-            # it only wraps this scalar. Now this scalar is accessed as the 0th element of
-            # event.labels
             if event.labels.shape == (1,):
                 labels.append(event.labels[0])
             else:
@@ -775,7 +768,7 @@ class BrainwareSrcIO(BaseIO):
         # char * numchars -- comment text
         text = self.__read_str(numchars2, utf=False)
 
-        comment = Event(times=pq.Quantity(time, units=pq.d), labels=text,
+        comment = Event(times=pq.Quantity(time, units=pq.d), labels=[text],
                         sender=sender, file_origin=self._file_origin)
 
         self._seg0.events.append(comment)

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -351,9 +351,6 @@ class TestEpoch(unittest.TestCase):
         self.assertEqual(result.annotations['test0'], targ.annotations['test0'])
         self.assertEqual(result.annotations['test1'], targ.annotations['test1'])
         self.assertEqual(result.annotations['test2'], targ.annotations['test2'])
-        assert_arrays_equal(result.array_annotations['durations'],
-                            np.array([], dtype='float64') * pq.ns)
-        assert_arrays_equal(result.array_annotations['labels'], np.array([], dtype='S'))
         self.assertIsInstance(result.array_annotations, ArrayDict)
 
     def test_time_slice_none_stop(self):
@@ -547,14 +544,14 @@ class TestDuplicateWithNewData(unittest.TestCase):
 
     def test_duplicate_with_new_data(self):
         signal1 = self.epoch
-        new_data = np.sort(np.random.uniform(0, 100, self.epoch.size)) * pq.ms
-        signal1b = signal1.duplicate_with_new_data(new_data)
-        # Note: Labels and Durations are NOT copied any more!!!
+        new_times = np.sort(np.random.uniform(0, 100, self.epoch.size)) * pq.ms
+        new_durations = np.ones_like(new_times)
+        new_labels = np.array(list("zyxwvutsrqponmlkjihgfedcba"[:self.epoch.size]))
+        signal1b = signal1.duplicate_with_new_data(new_times, new_durations, new_labels)
         # After duplicating, array annotations should always be empty,
         # because different length of data would cause inconsistencies
-        # Only labels and durations should be available
-        assert_arrays_equal(signal1b.labels, np.ndarray((0,), dtype='S'))
-        assert_arrays_equal(signal1b.durations.magnitude, np.ndarray((0,)))
+        assert_arrays_equal(signal1b.labels, new_labels)
+        assert_arrays_equal(signal1b.durations, new_durations)
         self.assertTrue('index' not in signal1b.array_annotations)
         self.assertTrue('test' not in signal1b.array_annotations)
         self.assertIsInstance(signal1b.array_annotations, ArrayDict)

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -130,6 +130,13 @@ class TestEpoch(unittest.TestCase):
         assert_arrays_equal(epc.array_annotations['index'], np.arange(10, 13))
         self.assertIsInstance(epc.array_annotations, ArrayDict)
 
+    def test_Epoch_creation_invalid_durations_labels(self):
+        self.assertRaises(ValueError, Epoch, [1.1, 1.5, 1.7] * pq.ms,
+                          durations=[20, 40, 60, 80] * pq.ns)
+        self.assertRaises(ValueError, Epoch, [1.1, 1.5, 1.7] * pq.ms,
+                          durations=[20, 40, 60] * pq.ns,
+                          labels=["A", "B"])
+
     def test_Epoch_creation_scalar_duration(self):
         # test with scalar for durations
         epc = Epoch([1.1, 1.5, 1.7] * pq.ms, durations=20 * pq.ns,
@@ -202,6 +209,20 @@ class TestEpoch(unittest.TestCase):
         assert_arrays_equal(epcres.array_annotations['index'], np.array([10, 11, 12, 0, 1, 2]))
         self.assertTrue('test' not in epcres.array_annotations)
         self.assertIsInstance(epcres.array_annotations, ArrayDict)
+
+    def test_set_labels_duration(self):
+        epc = Epoch([1.1, 1.5, 1.7] * pq.ms,
+                    durations=20 * pq.ns,
+                    labels=['A', 'B', 'C'])
+        assert_array_equal(epc.durations.magnitude, np.array([20, 20, 20]))
+        epc.durations = [20.0, 21.0, 22.0] * pq.ns
+        assert_array_equal(epc.durations.magnitude, np.array([20, 21, 22]))
+        self.assertRaises(ValueError, setattr, epc, "durations", [25.0, 26.0] * pq.ns)
+
+        assert_array_equal(epc.labels, np.array(['A', 'B', 'C']))
+        epc.labels = ['D', 'E', 'F']
+        assert_array_equal(epc.labels, np.array(['D', 'E', 'F']))
+        self.assertRaises(ValueError, setattr, epc, "labels", ['X', 'Y'])
 
     def test__children(self):
         params = {'test2': 'y1', 'test3': True}

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -125,6 +125,16 @@ class TestEvent(unittest.TestCase):
         assert_arrays_equal(evt.array_annotations['index'], np.arange(10, 13))
         self.assertIsInstance(evt.array_annotations, ArrayDict)
 
+    def test_Event_creation_invalid_labels(self):
+        self.assertRaises(ValueError, Event, [1.1, 1.5, 1.7] * pq.ms,
+                          labels=["A", "B"])
+
+    def test_Epoch_creation_scalar_duration(self):
+        # test with scalar for durations
+        epc = Epoch([1.1, 1.5, 1.7] * pq.ms, durations=20 * pq.ns,
+                    labels=np.array(['test epoch 1', 'test epoch 2', 'test epoch 3'], dtype='S'))
+        assert_neo_object_is_compliant(epc)
+
     def tests_time_slice(self):
         params = {'test2': 'y1', 'test3': True}
         arr_ann = {'index': np.arange(10), 'test': np.arange(100, 110)}
@@ -376,6 +386,14 @@ class TestEvent(unittest.TestCase):
         assert_arrays_equal(evtres.array_annotations['index'], np.array([10, 11, 12, 0, 1, 2]))
         self.assertTrue('test' not in evtres.array_annotations)
         self.assertIsInstance(evtres.array_annotations, ArrayDict)
+
+    def test_set_labels(self):
+        evt = Event([1.1, 1.5, 1.7] * pq.ms,
+                    labels=['A', 'B', 'C'])
+        assert_array_equal(evt.labels, np.array(['A', 'B', 'C']))
+        evt.labels = ['D', 'E', 'F']
+        assert_array_equal(evt.labels, np.array(['D', 'E', 'F']))
+        self.assertRaises(ValueError, setattr, evt, "labels", ['X', 'Y'])
 
     def test__children(self):
         params = {'test2': 'y1', 'test3': True}

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -493,18 +493,18 @@ class TestDuplicateWithNewData(unittest.TestCase):
         self.data = np.array([0.1, 0.5, 1.2, 3.3, 6.4, 7])
         self.dataquant = self.data * pq.ms
         self.arr_ann = {'index': np.arange(6), 'test': ['a', 'b', 'c', 'd', 'e', 'f']}
-        self.event = Event(self.dataquant, array_annotations=self.arr_ann)
+        self.event = Event(times=self.dataquant, labels=np.array(['a', 'b', 'c', 'd', 'e', 'f']),
+                           array_annotations=self.arr_ann)
 
     def test_duplicate_with_new_data(self):
         signal1 = self.event
-        new_data = np.sort(np.random.uniform(0, 100, (self.event.size))) * pq.ms
-        signal1b = signal1.duplicate_with_new_data(new_data)
-        assert_arrays_almost_equal(np.asarray(signal1b), np.asarray(new_data), 1e-12)
-        # Note: Labels and Durations are NOT copied any more!!!
+        new_times = np.sort(np.random.uniform(0, 100, (self.event.size))) * pq.ms
+        new_labels = np.array(list("zyxwvutsrqponmlkjihgfedcba"[:self.event.size]))
+        signal1b = signal1.duplicate_with_new_data(new_times, new_labels)
+        assert_arrays_almost_equal(np.asarray(signal1b), np.asarray(new_times), 1e-12)
+        assert_arrays_equal(signal1b.labels, new_labels)
         # After duplicating, array annotations should always be empty,
         # because different length of data would cause inconsistencies
-        # Only labels and durations should be available
-        assert_arrays_equal(signal1b.labels, np.ndarray((0,), dtype='S'))
         self.assertTrue('index' not in signal1b.array_annotations)
         self.assertTrue('test' not in signal1b.array_annotations)
         self.assertIsInstance(signal1b.array_annotations, ArrayDict)

--- a/neo/test/test_utils.py
+++ b/neo/test/test_utils.py
@@ -426,8 +426,10 @@ class TestUtilsWithoutProxyObjects(unittest.TestCase):
             assert_same_attributes(block.segments[epoch_idx].analogsignals[0], anasig_target)
             assert_same_attributes(block.segments[epoch_idx].events[0],
                                    event.duplicate_with_new_data(
-                                       event.times - epoch.times[epoch_idx]).time_slice(
-                                       t_start=0 * pq.s, t_stop=epoch.durations[epoch_idx]))
+                                       event.times - epoch.times[epoch_idx],
+                                       event.labels
+                                    ).time_slice(t_start=0 * pq.s,
+                                                 t_stop=epoch.durations[epoch_idx]))
 
         assert_same_attributes(block.segments[0].epochs[0],
                                epoch2.duplicate_with_new_data(epoch2.times - epoch.times[0],
@@ -515,7 +517,8 @@ class TestUtilsWithProxyObjects(BaseProxyTest):
 
         loaded_event = proxy_event.load()
 
-        regular_event = Event(times=loaded_event.times - 1 * loaded_event.units)
+        regular_event = Event(times=loaded_event.times - 1 * loaded_event.units,
+                              labels=np.array(['trigger_a', 'trigger_b'] * 3, dtype='U12'))
 
         seg = Segment()
         seg.events = [regular_event, proxy_event]

--- a/neo/utils.py
+++ b/neo/utils.py
@@ -229,9 +229,14 @@ def _event_epoch_slice_by_valid_ids(obj, valid_ids):
     sparse_array_annotations = {key: value[valid_ids]
                                 for key, value in obj.array_annotations.items() if len(value)}
 
+    if obj.labels is not None and obj.labels.size > 0:
+        labels = obj.labels[valid_ids]
+    else:
+        labels = obj.labels
     if type(obj) is neo.Event:
         sparse_obj = neo.Event(
             times=copy.deepcopy(obj.times[valid_ids]),
+            labels=copy.deepcopy(labels),
             units=copy.deepcopy(obj.units),
             name=copy.deepcopy(obj.name),
             description=copy.deepcopy(obj.description),
@@ -242,6 +247,7 @@ def _event_epoch_slice_by_valid_ids(obj, valid_ids):
         sparse_obj = neo.Epoch(
             times=copy.deepcopy(obj.times[valid_ids]),
             durations=copy.deepcopy(obj.durations[valid_ids]),
+            labels=copy.deepcopy(labels),
             units=copy.deepcopy(obj.units),
             name=copy.deepcopy(obj.name),
             description=copy.deepcopy(obj.description),
@@ -829,7 +835,8 @@ def shift_event(ev, t_shift):
         New instance of an Event object starting at t_shift later than the
         original Event (the original Event is not modified).
     """
-    return _shift_time_signal(ev, t_shift)
+    return ev.duplicate_with_new_data(times=ev.times + t_shift,
+                                      labels=ev.labels)
 
 
 def shift_epoch(epoch, t_shift):
@@ -862,5 +869,5 @@ def _shift_time_signal(sig, t_shift):
         raise AttributeError(
             'Can only shift signals, which have an attribute'
             ' "times", not %s' % type(sig))
-    new_sig = sig.duplicate_with_new_data(signal=sig.times + t_shift)
+    new_sig = sig.duplicate_with_new_data(times=sig.times + t_shift)
     return new_sig


### PR DESCRIPTION
I failed to notice during the review of #606 and #472 that the implementation of `Event.labels`, `Epoch.labels` and `Epoch.durations` had been changed to store these attributes as array annotations.

I think this change is a mistake, because (i) semantically labels and durations are not annotations, they are fundamental data attributes for these objects, so it is confusing to handle them as annotations; (ii) annotations are treated differently to data attributes during copying and merging, and this can lead to problems.

I encountered this specifically while trying to fix problems with the `Container.merge()` method; I suspect it is also related to https://github.com/NeuralEnsemble/elephant/pull/203



