### PR TITLE
Fix Nix Ignoring Array Annotations

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -406,23 +406,15 @@ class NixIO(BaseIO):
             sig_length = 1
 
         array_annotations = {}
-
         if sig_length > 1:
             for attr_key, attr_val in neo_attrs.items():
                 if isinstance(attr_val, (list, np.ndarray, pq.Quantity)):
                     if isinstance(attr_val, (np.ndarray, pq.Quantity)) and attr_val.shape == ():
                         attr_val = attr_val.flatten()
                     if len(attr_val) == sig_length:
-                        if isinstance(attr_val, list) or (isinstance(attr_val, np.ndarray) and not (
-                                isinstance(attr_val, pq.Quantity) and (
-                                attr_val.shape == () or attr_val.shape == (1,)))):
-                            # Array annotations should only be 1-dimensional
-                            continue
-                        if isinstance(attr_val, dict):
-                            # Dictionaries are not supported as array annotations
-                            continue
                         array_annotations[attr_key] = attr_val
-                        del neo_attrs[attr_key]
+        for key in array_annotations:
+            del neo_attrs[key]
 
         neo_signal = AnalogSignal(
             signal=signaldata, sampling_period=sampling_period,
@@ -465,23 +457,15 @@ class NixIO(BaseIO):
             sig_length = 1
 
         array_annotations = {}
-
         if sig_length > 1:
             for attr_key, attr_val in neo_attrs.items():
                 if isinstance(attr_val, (list, np.ndarray, pq.Quantity)):
                     if isinstance(attr_val, (np.ndarray, pq.Quantity)) and attr_val.shape == ():
                         attr_val = attr_val.flatten()
                     if len(attr_val) == sig_length:
-                        if isinstance(attr_val, list) or (isinstance(attr_val, np.ndarray) and not (
-                                isinstance(attr_val, pq.Quantity) and (
-                                attr_val.shape == () or attr_val.shape == (1,)))):
-                            # Array annotations should only be 1-dimensional
-                            continue
-                        if isinstance(attr_val, dict):
-                            # Dictionaries are not supported as array annotations
-                            continue
                         array_annotations[attr_key] = attr_val
-                        del neo_attrs[attr_key]
+        for key in array_annotations:
+            del neo_attrs[key]
 
         neo_signal = IrregularlySampledSignal(
             signal=signaldata, times=times, array_annotations=array_annotations, **neo_attrs
@@ -511,23 +495,15 @@ class NixIO(BaseIO):
             sig_length = 1
 
         array_annotations = {}
-
         if sig_length > 1:
             for attr_key, attr_val in neo_attrs.items():
                 if isinstance(attr_val, (list, np.ndarray, pq.Quantity)):
                     if isinstance(attr_val, (np.ndarray, pq.Quantity)) and attr_val.shape == ():
                         attr_val = attr_val.flatten()
                     if len(attr_val) == sig_length:
-                        if isinstance(attr_val, list) or (isinstance(attr_val, np.ndarray) and not (
-                                isinstance(attr_val, pq.Quantity) and (
-                                attr_val.shape == () or attr_val.shape == (1,)))):
-                            # Array annotations should only be 1-dimensional
-                            continue
-                        if isinstance(attr_val, dict):
-                            # Dictionaries are not supported as array annotations
-                            continue
                         array_annotations[attr_key] = attr_val
-                        del neo_attrs[attr_key]
+        for key in array_annotations:
+            del neo_attrs[key]
 
         neo_event = Event(times=times, labels=labels, array_annotations=array_annotations,
                           **neo_attrs)
@@ -550,23 +526,15 @@ class NixIO(BaseIO):
             sig_length = 1
 
         array_annotations = {}
-
         if sig_length > 1:
             for attr_key, attr_val in neo_attrs.items():
                 if isinstance(attr_val, (list, np.ndarray, pq.Quantity)):
                     if isinstance(attr_val, (np.ndarray, pq.Quantity)) and attr_val.shape == ():
                         attr_val = attr_val.flatten()
                     if len(attr_val) == sig_length:
-                        if isinstance(attr_val, list) or (isinstance(attr_val, np.ndarray) and not (
-                                isinstance(attr_val, pq.Quantity) and (
-                                attr_val.shape == () or attr_val.shape == (1,)))):
-                            # Array annotations should only be 1-dimensional
-                            continue
-                        if isinstance(attr_val, dict):
-                            # Dictionaries are not supported as array annotations
-                            continue
                         array_annotations[attr_key] = attr_val
-                        del neo_attrs[attr_key]
+        for key in array_annotations:
+            del neo_attrs[key]
 
         if len(nix_mtag.positions.dimensions[0].labels) > 0:
             labels = np.array(nix_mtag.positions.dimensions[0].labels,
@@ -592,23 +560,15 @@ class NixIO(BaseIO):
             sig_length = 1
 
         array_annotations = {}
-
         if sig_length > 1:
             for attr_key, attr_val in neo_attrs.items():
                 if isinstance(attr_val, (list, np.ndarray, pq.Quantity)):
                     if isinstance(attr_val, (np.ndarray, pq.Quantity)) and attr_val.shape == ():
                         attr_val = attr_val.flatten()
                     if len(attr_val) == sig_length:
-                        if isinstance(attr_val, list) or (isinstance(attr_val, np.ndarray) and not (
-                                isinstance(attr_val, pq.Quantity) and (
-                                attr_val.shape == () or attr_val.shape == (1,)))):
-                            # Array annotations should only be 1-dimensional
-                            continue
-                        if isinstance(attr_val, dict):
-                            # Dictionaries are not supported as array annotations
-                            continue
                         array_annotations[attr_key] = attr_val
-                        del neo_attrs[attr_key]
+        for key in array_annotations:
+            del neo_attrs[key]
 
         neo_spiketrain = SpikeTrain(times=times, array_annotations=array_annotations, **neo_attrs)
         if nix_mtag.features:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -848,9 +848,8 @@ class NixIO(BaseIO):
                 self._write_property(metadata, k, v)
         if event.array_annotations:
             for k, v in event.array_annotations.items():
-                if k != 'labels':
-                    p = self._write_property(metadata, k, v)
-                    p.definition = ARRAYANNOTATION
+                p = self._write_property(metadata, k, v)
+                p.definition = ARRAYANNOTATION
 
         nixgroup.multi_tags.append(nixmt)
 
@@ -915,9 +914,8 @@ class NixIO(BaseIO):
                 self._write_property(metadata, k, v)
         if epoch.array_annotations:
             for k, v in epoch.array_annotations.items():
-                if k not in ['durations', 'labels']:
-                    p = self._write_property(metadata, k, v)
-                    p.definition = ARRAYANNOTATION
+                p = self._write_property(metadata, k, v)
+                p.definition = ARRAYANNOTATION
 
         nixgroup.multi_tags.append(nixmt)
 

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -409,8 +409,9 @@ class NixIO(BaseIO):
 
         if sig_length > 1:
             for attr_key, attr_val in neo_attrs.items():
-                if isinstance(attr_val, (list, np.ndarray)) or (
-                        isinstance(attr_val, pq.Quantity) and attr_val.shape == ()):
+                if isinstance(attr_val, (list, np.ndarray, pq.Quantity)):
+                    if isinstance(attr_val, (np.ndarray, pq.Quantity)) and attr_val.shape == ():
+                        attr_val = attr_val.flatten()
                     if len(attr_val) == sig_length:
                         if isinstance(attr_val, list) or (isinstance(attr_val, np.ndarray) and not (
                                 isinstance(attr_val, pq.Quantity) and (
@@ -467,8 +468,9 @@ class NixIO(BaseIO):
 
         if sig_length > 1:
             for attr_key, attr_val in neo_attrs.items():
-                if isinstance(attr_val, (list, np.ndarray)) or (
-                        isinstance(attr_val, pq.Quantity) and attr_val.shape == ()):
+                if isinstance(attr_val, (list, np.ndarray, pq.Quantity)):
+                    if isinstance(attr_val, (np.ndarray, pq.Quantity)) and attr_val.shape == ():
+                        attr_val = attr_val.flatten()
                     if len(attr_val) == sig_length:
                         if isinstance(attr_val, list) or (isinstance(attr_val, np.ndarray) and not (
                                 isinstance(attr_val, pq.Quantity) and (
@@ -512,8 +514,9 @@ class NixIO(BaseIO):
 
         if sig_length > 1:
             for attr_key, attr_val in neo_attrs.items():
-                if isinstance(attr_val, (list, np.ndarray)) or (
-                        isinstance(attr_val, pq.Quantity) and attr_val.shape == ()):
+                if isinstance(attr_val, (list, np.ndarray, pq.Quantity)):
+                    if isinstance(attr_val, (np.ndarray, pq.Quantity)) and attr_val.shape == ():
+                        attr_val = attr_val.flatten()
                     if len(attr_val) == sig_length:
                         if isinstance(attr_val, list) or (isinstance(attr_val, np.ndarray) and not (
                                 isinstance(attr_val, pq.Quantity) and (
@@ -550,8 +553,9 @@ class NixIO(BaseIO):
 
         if sig_length > 1:
             for attr_key, attr_val in neo_attrs.items():
-                if isinstance(attr_val, (list, np.ndarray)) or (
-                        isinstance(attr_val, pq.Quantity) and attr_val.shape == ()):
+                if isinstance(attr_val, (list, np.ndarray, pq.Quantity)):
+                    if isinstance(attr_val, (np.ndarray, pq.Quantity)) and attr_val.shape == ():
+                        attr_val = attr_val.flatten()
                     if len(attr_val) == sig_length:
                         if isinstance(attr_val, list) or (isinstance(attr_val, np.ndarray) and not (
                                 isinstance(attr_val, pq.Quantity) and (
@@ -591,8 +595,9 @@ class NixIO(BaseIO):
 
         if sig_length > 1:
             for attr_key, attr_val in neo_attrs.items():
-                if isinstance(attr_val, (list, np.ndarray)) or (
-                        isinstance(attr_val, pq.Quantity) and attr_val.shape == ()):
+                if isinstance(attr_val, (list, np.ndarray, pq.Quantity)):
+                    if isinstance(attr_val, (np.ndarray, pq.Quantity)) and attr_val.shape == ():
+                        attr_val = attr_val.flatten()
                     if len(attr_val) == sig_length:
                         if isinstance(attr_val, list) or (isinstance(attr_val, np.ndarray) and not (
                                 isinstance(attr_val, pq.Quantity) and (

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -1263,7 +1263,7 @@ class NixIO(BaseIO):
         neo_attrs["description"] = stringify(nix_obj.definition)
         if nix_obj.metadata:
             for prop in nix_obj.metadata.inherited_properties():
-                values = prop.values
+                values = list(prop.values)
                 if prop.unit:
                     units = prop.unit
                     values = create_quantity(values, units)
@@ -1274,8 +1274,6 @@ class NixIO(BaseIO):
                         values = ""
                 elif len(values) == 1:
                     values = values[0]
-                else:
-                    values = list(values)
                 neo_attrs[prop.name] = values
         neo_attrs["name"] = stringify(neo_attrs.get("neo_name"))
 

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -982,7 +982,8 @@ class NixIO(BaseIO):
                 self._write_property(metadata, k, v)
         if event.array_annotations:
             for k, v in event.array_annotations.items():
-                self._write_property(metadata, k, v)
+                if k != 'labels':
+                    self._write_property(metadata, k, v)
 
         nixgroup.multi_tags.append(nixmt)
 
@@ -1047,7 +1048,8 @@ class NixIO(BaseIO):
                 self._write_property(metadata, k, v)
         if epoch.array_annotations:
             for k, v in epoch.array_annotations.items():
-                self._write_property(metadata, k, v)
+                if k not in ['durations', 'labels']:
+                    self._write_property(metadata, k, v)
 
         nixgroup.multi_tags.append(nixmt)
 

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -378,6 +378,7 @@ class NixIOTest(unittest.TestCase):
             arr_ann_name, arr_ann_val = 'anasig_arr_ann', cls.rquant(10, pq.uV)
             asig_md.create_property(arr_ann_name, arr_ann_val.magnitude.flatten())
             asig_md.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
+            asig_md.props[arr_ann_name].definition = 'ARRAYANNOTATION'
 
             for idx in range(10):
                 da_asig = blk.create_data_array(
@@ -411,6 +412,7 @@ class NixIOTest(unittest.TestCase):
             arr_ann_name, arr_ann_val = 'irrsig_arr_ann', cls.rquant(7, pq.uV)
             isig_md.create_property(arr_ann_name, arr_ann_val.magnitude.flatten())
             isig_md.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
+            isig_md.props[arr_ann_name].definition = 'ARRAYANNOTATION'
             for idx in range(7):
                 da_isig = blk.create_data_array(
                     "{}.{}".format(isig_name, idx),
@@ -452,6 +454,7 @@ class NixIOTest(unittest.TestCase):
             arr_ann_name, arr_ann_val = 'st_arr_ann', cls.rquant(40, pq.uV)
             mtag_st_md.create_property(arr_ann_name, arr_ann_val.magnitude.flatten())
             mtag_st_md.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
+            mtag_st_md.props[arr_ann_name].definition = 'ARRAYANNOTATION'
 
             waveforms = cls.rquant((10, 8, 5), 1)
             wfname = "{}.waveforms".format(mtag_st.name)
@@ -503,6 +506,7 @@ class NixIOTest(unittest.TestCase):
             arr_ann_name, arr_ann_val = 'ep_arr_ann', cls.rquant(5, pq.uV)
             mtag_ep.metadata.create_property(arr_ann_name, arr_ann_val.magnitude.flatten())
             mtag_ep.metadata.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
+            mtag_ep.metadata.props[arr_ann_name].definition = 'ARRAYANNOTATION'
 
             label_dim = mtag_ep.positions.append_set_dimension()
             label_dim.labels = cls.rsentence(5).split(" ")
@@ -533,6 +537,7 @@ class NixIOTest(unittest.TestCase):
             arr_ann_name, arr_ann_val = 'ev_arr_ann', cls.rquant(5, pq.uV)
             mtag_ev.metadata.create_property(arr_ann_name, arr_ann_val.magnitude.flatten())
             mtag_ev.metadata.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
+            mtag_ev.metadata.props[arr_ann_name].definition = 'ARRAYANNOTATION'
 
             label_dim = mtag_ev.positions.append_set_dimension()
             label_dim.labels = cls.rsentence(5).split(" ")

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -326,7 +326,7 @@ class NixIOTest(unittest.TestCase):
                             nixvalue = np.array(nixvalue)
                         np.testing.assert_almost_equal(nixvalue, v.magnitude)
                     if isinstance(v, np.ndarray):
-                        self.assertTrue(np.all(v==nixmd[str(k)]))
+                        self.assertTrue(np.all(v == nixmd[str(k)]))
                     else:
                         self.assertEqual(nixmd[str(k)], v,
                                          "Property value mismatch: {}".format(k))
@@ -1408,54 +1408,50 @@ class NixIOReadTest(NixIOTest):
             nix_block = self.nixfile.blocks[bl.annotations['nix_name']]
             for seg in bl.segments:
                 for anasig in seg.analogsignals:
-                    da = nix_block.data_arrays[anasig.annotations['nix_name']+'.0']
+                    da = nix_block.data_arrays[anasig.annotations['nix_name'] + '.0']
                     self.assertIn('anasig_arr_ann', da.metadata)
                     self.assertIn('anasig_arr_ann', anasig.array_annotations)
-                    self.assertTrue(np.all(da.metadata['anasig_arr_ann'] ==
-                                           anasig.array_annotations['anasig_arr_ann'].magnitude))
+                    nix_ann = da.metadata['anasig_arr_ann']
+                    neo_ann = anasig.array_annotations['anasig_arr_ann']
+                    self.assertTrue(np.all(nix_ann == neo_ann.magnitude))
                     self.assertEqual(da.metadata.props['anasig_arr_ann'].unit,
-                                     units_to_string(
-                                         anasig.array_annotations['anasig_arr_ann'].units))
+                                     units_to_string(neo_ann.units))
                 for irrsig in seg.irregularlysampledsignals:
                     da = nix_block.data_arrays[irrsig.annotations['nix_name'] + '.0']
                     self.assertIn('irrsig_arr_ann', da.metadata)
                     self.assertIn('irrsig_arr_ann', irrsig.array_annotations)
-                    self.assertTrue(np.all(da.metadata['irrsig_arr_ann'] ==
-                                           irrsig.array_annotations[
-                                               'irrsig_arr_ann'].magnitude))
+                    nix_ann = da.metadata['irrsig_arr_ann']
+                    neo_ann = irrsig.array_annotations['irrsig_arr_ann']
+                    self.assertTrue(np.all(nix_ann == neo_ann.magnitude))
                     self.assertEqual(da.metadata.props['irrsig_arr_ann'].unit,
-                                     units_to_string(
-                                         irrsig.array_annotations['irrsig_arr_ann'].units))
+                                     units_to_string(neo_ann.units))
                 for ev in seg.events:
                     da = nix_block.multi_tags[ev.annotations['nix_name']]
                     self.assertIn('ev_arr_ann', da.metadata)
                     self.assertIn('ev_arr_ann', ev.array_annotations)
-                    self.assertTrue(np.all(da.metadata['ev_arr_ann'] ==
-                                           ev.array_annotations[
-                                               'ev_arr_ann'].magnitude))
+                    nix_ann = da.metadata['ev_arr_ann']
+                    neo_ann = ev.array_annotations['ev_arr_ann']
+                    self.assertTrue(np.all(nix_ann == neo_ann.magnitude))
                     self.assertEqual(da.metadata.props['ev_arr_ann'].unit,
-                                     units_to_string(
-                                         ev.array_annotations['ev_arr_ann'].units))
+                                     units_to_string(neo_ann.units))
                 for ep in seg.epochs:
                     da = nix_block.multi_tags[ep.annotations['nix_name']]
                     self.assertIn('ep_arr_ann', da.metadata)
                     self.assertIn('ep_arr_ann', ep.array_annotations)
-                    self.assertTrue(np.all(da.metadata['ep_arr_ann'] ==
-                                           ep.array_annotations[
-                                               'ep_arr_ann'].magnitude))
+                    nix_ann = da.metadata['ep_arr_ann']
+                    neo_ann = ep.array_annotations['ep_arr_ann']
+                    self.assertTrue(np.all(nix_ann == neo_ann.magnitude))
                     self.assertEqual(da.metadata.props['ep_arr_ann'].unit,
-                                     units_to_string(
-                                         ep.array_annotations['ep_arr_ann'].units))
+                                     units_to_string(neo_ann.units))
                 for st in seg.spiketrains:
                     da = nix_block.multi_tags[st.annotations['nix_name']]
                     self.assertIn('st_arr_ann', da.metadata)
                     self.assertIn('st_arr_ann', st.array_annotations)
-                    self.assertTrue(np.all(da.metadata['st_arr_ann'] ==
-                                           st.array_annotations[
-                                               'st_arr_ann'].magnitude))
+                    nix_ann = da.metadata['st_arr_ann']
+                    neo_ann = st.array_annotations['st_arr_ann']
+                    self.assertTrue(np.all(nix_ann == neo_ann.magnitude))
                     self.assertEqual(da.metadata.props['st_arr_ann'].unit,
-                                     units_to_string(
-                                         st.array_annotations['st_arr_ann'].units))
+                                     units_to_string(neo_ann.units))
 
 
 @unittest.skipUnless(HAVE_NIX, "Requires NIX")


### PR DESCRIPTION
The NixIO currently just ignores array annotations. I went through it with @achilleas-k and added them analogously to annotations. For writing this is straightforward, when reading I check the shape of all annotations and turn them into array annotations if it matches.