### PR TITLE
Fix for #661

### DIFF
--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -8,6 +8,10 @@ object inherit from.  It provides shared methods for all container types.
 
 # needed for python 3 compatibility
 from __future__ import absolute_import, division, print_function
+try:
+    basestring
+except NameError:
+    basestring = str
 
 from neo.core.baseneo import BaseNeo, _reference_name, _container_name
 
@@ -404,6 +408,11 @@ class Container(BaseNeo):
             >>> obj.filter(objects=neo.SpikeTrain)
             >>> obj.filter(targdict={'myannotation':3})
         """
+
+        if isinstance(targdict, basestring):
+            raise TypeError("filtering is based on key-value pairs."
+                            " Only a single string was provided.")
+
         # if objects are specified, get the classes
         if objects:
             data = True

--- a/neo/test/coretest/test_container.py
+++ b/neo/test/coretest/test_container.py
@@ -101,6 +101,10 @@ class TestContainerNeo(unittest.TestCase):
         container.create_many_to_many_relationship()
         container.create_relationship()
 
+    def test_filter(self):
+        container = Container()
+        self.assertRaises(TypeError, container.filter, "foo")
+
 
 class Test_Container_merge(unittest.TestCase):
     '''


### PR DESCRIPTION
Raise a meaningful error if `filter()` is called with a single string rather than dict/kwargs

Fixes #661