### PR TITLE
[nixio] Support 1D coordinates for single ChannelIndex

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -24,7 +24,11 @@ from __future__ import absolute_import
 
 import time
 from datetime import datetime
-from collections import Iterable, OrderedDict
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+from collections import OrderedDict
 import itertools
 from uuid import uuid4
 

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -591,6 +591,11 @@ class NixIO(BaseIO):
             for k, v in chx.annotations.items():
                 self._write_property(metadata, k, v)
 
+        coordinates = chx.coordinates
+        if coordinates is not None and np.ndim(coordinates) == 1:
+            # support 1D coordinates for single ChannelIndex
+            coordinates = [coordinates]
+
         for idx, channel in enumerate(chx.index):
             channame = "{}.ChannelIndex{}".format(nix_name, idx)
             nixchan = nixsource.create_source(channame, "neo.channelindex")
@@ -606,8 +611,8 @@ class NixIO(BaseIO):
             if len(chx.channel_ids):
                 chanid = chx.channel_ids[idx]
                 chanmd["channel_id"] = chanid
-            if chx.coordinates is not None:
-                coords = chx.coordinates[idx]
+            if coordinates is not None:
+                coords = coordinates[idx]
                 coordunits = stringify(coords[0].dimensionality)
                 nixcoords = tuple(c.magnitude.item() for c in coords)
                 chanprop = chanmd.create_property("coordinates", nixcoords)

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -67,12 +67,19 @@ class NixIOTest(unittest.TestCase):
         nix_channels = list(src for src in nixsrc.sources
                             if src.type == "neo.channelindex")
         self.assertEqual(len(neochx.index), len(nix_channels))
-
         if len(neochx.channel_ids):
             nix_chanids = list(src.metadata["channel_id"] for src
                                in nixsrc.sources
                                if src.type == "neo.channelindex")
             self.assertEqual(len(neochx.channel_ids), len(nix_chanids))
+
+        # coordinates can be 1D if there's only one channel
+        if neochx.coordinates is not None:
+            neocoordinates = neochx.coordinates
+            if np.ndim(neocoordinates) == 1:
+                neocoordinates = [neocoordinates]
+        else:
+            neocoordinates = []
 
         for nixchan in nix_channels:
             nixchanidx = nixchan.metadata["index"]
@@ -93,6 +100,13 @@ class NixIOTest(unittest.TestCase):
                 self.assertEqual(neochanid, nixchanid)
             elif "channel_id" in nixchan.metadata:
                 self.fail("Channel ID not loaded")
+
+            if len(neocoordinates):
+                neocoord = neocoordinates[neochanpos]
+                nixcoord = nixchan.metadata.props["coordinates"]
+                nixcoord = create_quantity(nixcoord.values, nixcoord.unit)
+                self.assertTrue(all(neocoord == nixcoord),
+                                msg="{} != {}".format(neocoord, nixcoord))
         nix_units = list(src for src in nixsrc.sources
                          if src.type == "neo.unit")
         self.assertEqual(len(neochx.units), len(nix_units))
@@ -688,6 +702,27 @@ class NixIOWriteTest(NixIOTest):
                              "eight", "xiii"]
 
         chx.coordinates = self.rquant((6, 3), pq.um)
+        self.write_and_compare([block])
+
+        # add an empty channel index and check again
+        newchx = ChannelIndex(np.array([]))
+        block.channel_indexes.append(newchx)
+        self.write_and_compare([block])
+
+    def test_channel_index_coords(self):
+        block = Block(name=self.rword())
+        chxn = ChannelIndex(name=self.rword(),
+                            description=self.rsentence(),
+                            channel_ids=[10, 20, 30],
+                            index=[1, 2, 3])
+        chxn.coordinates = self.rquant((3, 3), pq.mm)
+        chx1 = ChannelIndex(name=self.rword(),
+                            description=self.rsentence(),
+                            channel_ids=[1],
+                            index=[0])
+        chx1.coordinates = self.rquant(2, pq.mm)
+        block.channel_indexes.append(chxn)
+        block.channel_indexes.append(chx1)
         self.write_and_compare([block])
 
         # add an empty channel index and check again

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -13,7 +13,10 @@ Tests for NixIO
 
 import os
 import shutil
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from datetime import datetime
 
 from tempfile import mkdtemp


### PR DESCRIPTION
This PR adds support 1-dimensional ChannelIndex coordinates.  1D coordinates in ChannelIndex can occur when there is only one channel and the coordinates are specified as a vector (see issue #666).  When 1D coordinates are found they are wrapped in a list and treated the same as the general case.