### PR TITLE
Fix crash with some VHDR files that spell channel records in lowercase

### DIFF
--- a/neo/rawio/brainvisionrawio.py
+++ b/neo/rawio/brainvisionrawio.py
@@ -61,9 +61,13 @@ class BrainVisionRawIO(BaseRawIO):
         self._raw_signals = sigs.reshape(-1, nb_channel)
 
         sig_channels = []
+        channel_infos = vhdr_header['Channel Infos']
         for c in range(nb_channel):
-            name, ref, res, units = vhdr_header['Channel Infos'][
-                'Ch%d' % (c + 1,)].split(',')
+            try:
+                channel_desc = channel_infos['Ch%d' % (c + 1,)]
+            except KeyError:
+                channel_desc = channel_infos['ch%d' % (c + 1,)]
+            name, ref, res, units = channel_desc.split(',')
             units = units.replace('µ', 'u')
             chan_id = c + 1
             if sig_dtype == np.int16 or sig_dtype == np.int32:


### PR DESCRIPTION
This patch allows importing VHDR files in which the per-channel metadata (under "Channel Infos") uses lowercase field names (e.g., `ch1=...` instead of `Ch1=...`). That affects files from at least [one](https://www.cognionics.net/) vendor. 

A sample file that reproduces the issue is [here](https://github.com/NeuralEnsemble/python-neo/files/3234417/cog-test.zip). Note that this file also happens to trigger an unrelated bug later into the import (related to no channel coordinates being present, which is quite common), which is not fixed by this PR, but you can verify that with the fix it will make it further through the file than without.