### PR TITLE
Fix import crash with VHDR files that have no channel coordinates

### DIFF
--- a/neo/rawio/brainvisionrawio.py
+++ b/neo/rawio/brainvisionrawio.py
@@ -116,12 +116,13 @@ class BrainVisionRawIO(BaseRawIO):
         self.header['event_channels'] = event_channels
 
         self._generate_minimal_annotations()
-        for c in range(sig_channels.size):
-            coords = vhdr_header['Coordinates']['Ch{}'.format(c + 1)]
-            coords = [float(v) for v in coords.split(',')]
-            if coords[0] > 0.:
-                # if radius is 0 we do not have coordinates.
-                self.raw_annotations['signal_channels'][c]['coordinates'] = coords
+        if 'Coordinates' in vhdr_header:
+            for c in range(sig_channels.size):
+                coords = vhdr_header['Coordinates']['Ch{}'.format(c + 1)]
+                coords = [float(v) for v in coords.split(',')]
+                if coords[0] > 0.:
+                    # if radius is 0 we do not have coordinates.
+                    self.raw_annotations['signal_channels'][c]['coordinates'] = coords
 
     def _source_name(self):
         return self.filename


### PR DESCRIPTION
Currently the BrainVision importer will crash when a file is missing the `[Coordinates]` section, which appears to be quite common (we have many of those). [Here](https://github.com/NeuralEnsemble/python-neo/files/3234457/cog-test2.zip) is a small sample file that exhibits this issue (note I hand-edited the file so that it doesn't also trigger an unrelated problem, which is fixed by a [separate](https://github.com/NeuralEnsemble/python-neo/pull/673) PR).