### PR TITLE
Turn time-slicing and -shifting utilities into methods of the corresponding classes

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -483,6 +483,26 @@ class AnalogSignal(BaseSignal):
 
         return obj
 
+    def time_shift(self, t_shift):
+        """
+        Shifts a :class:`AnalogSignal` to start at a new time.
+
+        Parameters:
+        -----------
+        t_shift: Quantity (time)
+            Amount of time by which to shift the :class:`AnalogSignal`.
+
+        Returns:
+        --------
+        new_sig: :class:`AnalogSignal`
+            New instance of a :class:`AnalogSignal` object starting at t_shift later than the
+            original :class:`AnalogSignal` (the original :class:`AnalogSignal` is not modified).
+        """
+        new_sig = deepcopy(self)
+        new_sig.t_start = new_sig.t_start + t_shift
+
+        return new_sig
+
     def splice(self, signal, copy=False):
         """
         Replace part of the current signal by a new piece of signal.

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -293,18 +293,18 @@ class Epoch(DataObject):
 
     def time_shift(self, t_shift):
         """
-        Shifts an Epoch by an amount of time.
+        Shifts an :class:`Epoch` by an amount of time.
 
         Parameters:
         -----------
         t_shift: Quantity (time)
-            Amount of time by which to shift the Epoch.
+            Amount of time by which to shift the :class:`Epoch`.
 
         Returns:
         --------
-        epoch: Epoch
-            New instance of an Epoch object starting at t_shift later than the
-            original Epoch (the original Epoch is not modified).
+        epoch: :class:`Epoch`
+            New instance of an :class:`Epoch` object starting at t_shift later than the
+            original :class:`Epoch` (the original :class:`Epoch` is not modified).
         """
         new_epc = self.duplicate_with_new_data(times=self.times + t_shift,
                                                durations=self.durations,

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -291,6 +291,31 @@ class Epoch(DataObject):
 
         return new_epc
 
+    def time_shift(self, t_shift):
+        """
+        Shifts an Epoch by an amount of time.
+
+        Parameters:
+        -----------
+        t_shift: Quantity (time)
+            Amount of time by which to shift the Epoch.
+
+        Returns:
+        --------
+        epoch: Epoch
+            New instance of an Epoch object starting at t_shift later than the
+            original Epoch (the original Epoch is not modified).
+        """
+        new_epc = self.duplicate_with_new_data(times=self.times + t_shift,
+                                               durations=self.durations,
+                                               labels=self.labels)
+
+        # Here we can safely copy the array annotations since we know that
+        # the length of the Epoch does not change.
+        new_epc.array_annotate(**self.array_annotations)
+
+        return new_epc
+
     def set_labels(self, labels):
         self.array_annotate(labels=labels)
 

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -254,6 +254,29 @@ class Event(DataObject):
 
         return new_evt
 
+    def time_shift(self, t_shift):
+        """
+        Shifts an Event by an amount of time.
+
+        Parameters:
+        -----------
+        t_shift: Quantity (time)
+            Amount of time by which to shift the Event.
+
+        Returns:
+        --------
+        epoch: Event
+            New instance of an Event object starting at t_shift later than the
+            original Event (the original Event is not modified).
+        """
+        new_evt = self.duplicate_with_new_data(self.times + t_shift)
+
+        # Here we can safely copy the array annotations since we know that
+        # the length of the Event does not change.
+        new_evt.array_annotate(**self.array_annotations)
+
+        return new_evt
+
     def set_labels(self, labels):
         self.array_annotate(labels=labels)
 

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -256,18 +256,18 @@ class Event(DataObject):
 
     def time_shift(self, t_shift):
         """
-        Shifts an Event by an amount of time.
+        Shifts an :class:`Event` by an amount of time.
 
         Parameters:
         -----------
         t_shift: Quantity (time)
-            Amount of time by which to shift the Event.
+            Amount of time by which to shift the :class:`Event`.
 
         Returns:
         --------
         epoch: Event
-            New instance of an Event object starting at t_shift later than the
-            original Event (the original Event is not modified).
+            New instance of an :class:`Event` object starting at t_shift later than the
+            original :class:`Event` (the original :class:`Event` is not modified).
         """
         new_evt = self.duplicate_with_new_data(self.times + t_shift)
 

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -395,6 +395,28 @@ class IrregularlySampledSignal(BaseSignal):
 
         return new_st
 
+    def time_shift(self, t_shift):
+        """
+        Shifts a :class:`IrregularlySampledSignal` to start at a new time.
+
+        Parameters:
+        -----------
+        t_shift: Quantity (time)
+            Amount of time by which to shift the :class:`IrregularlySampledSignal`.
+
+        Returns:
+        --------
+        new_sig: :class:`SpikeTrain`
+            New instance of a :class:`IrregularlySampledSignal` object
+            starting at t_shift later than the original :class:`IrregularlySampledSignal`
+            (the original :class:`IrregularlySampledSignal` is not modified).
+        """
+        new_sig = deepcopy(self)
+
+        new_sig.times += t_shift
+
+        return new_sig
+
     def merge(self, other):
         '''
         Merge another signal into this one.

--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -14,6 +14,8 @@ from datetime import datetime
 
 import numpy as np
 
+from copy import deepcopy
+
 from neo.core.container import Container
 
 
@@ -251,3 +253,88 @@ class Segment(Container):
             self.take_slice_of_analogsignalarray_by_unit(unit_list)
         # TODO copy others attributes
         return seg
+
+    def time_slice(self, t_start=None, t_stop=None, reset_time=False, **kwargs):
+        """
+        Creates a time slice of a Segment containing slices of all child
+        objects.
+
+        Parameters:
+        -----------
+        t_start: Quantity
+            Starting time of the sliced time window.
+        t_stop: Quantity
+            Stop time of the sliced time window.
+        reset_time: bool
+            If True the time stamps of all sliced objects are set to fall
+            in the range from t_start to t_stop.
+            If False, original time stamps are retained.
+            Default is False.
+
+        Keyword Arguments:
+        ------------------
+            Additional keyword arguments used for initialization of the sliced
+            Segment object.
+
+        Returns:
+        --------
+        subseg: Segment
+            Temporal slice of the original Segment from t_start to t_stop.
+        """
+        subseg = Segment(**kwargs)
+
+        for attr in ['file_datetime', 'rec_datetime', 'index',
+                     'name', 'description', 'file_origin']:
+            setattr(subseg, attr, getattr(self, attr))
+
+        subseg.annotations = deepcopy(self.annotations)
+
+        t_shift = - t_start
+
+        # cut analogsignals and analogsignalarrays
+        for ana_id in range(len(self.analogsignals)):
+            if hasattr(self.analogsignals[ana_id], '_rawio'):
+                ana_time_slice = self.analogsignals[ana_id].load(time_slice=(t_start, t_stop))
+            else:
+                ana_time_slice = self.analogsignals[ana_id].time_slice(t_start, t_stop)
+            if reset_time:
+                ana_time_slice = ana_time_slice.time_shift(t_shift)
+            subseg.analogsignals.append(ana_time_slice)
+
+        # cut spiketrains
+        for st_id in range(len(self.spiketrains)):
+            if hasattr(self.spiketrains[st_id], '_rawio'):
+                st_time_slice = self.spiketrains[st_id].load(time_slice=(t_start, t_stop))
+            else:
+                st_time_slice = self.spiketrains[st_id].time_slice(t_start, t_stop)
+            if reset_time:
+                st_time_slice = st_time_slice.time_shift(t_shift)
+            subseg.spiketrains.append(st_time_slice)
+
+        # cut events
+        for ev_id in range(len(self.events)):
+            if hasattr(self.events[ev_id], '_rawio'):
+                ev_time_slice = self.events[ev_id].load(time_slice=(t_start, t_stop))
+            else:
+                ev_time_slice = self.events[ev_id].time_slice(t_start, t_stop)
+            if reset_time:
+                ev_time_slice = ev_time_slice.time_shift(t_shift)
+            # appending only non-empty events
+            if len(ev_time_slice):
+                subseg.events.append(ev_time_slice)
+
+        # cut epochs
+        for ep_id in range(len(self.epochs)):
+            if hasattr(self.epochs[ep_id], '_rawio'):
+                ep_time_slice = self.epochs[ep_id].load(time_slice=(t_start, t_stop))
+            else:
+                ep_time_slice = self.epochs[ep_id].time_slice(t_start, t_stop)
+            if reset_time:
+                ep_time_slice = ep_time_slice.time_shift(t_shift)
+            # appending only non-empty epochs
+            if len(ep_time_slice):
+                subseg.epochs.append(ep_time_slice)
+
+        subseg.create_relationship()
+
+        return subseg

--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -301,6 +301,17 @@ class Segment(Container):
                 ana_time_slice = ana_time_slice.time_shift(t_shift)
             subseg.analogsignals.append(ana_time_slice)
 
+        # cut irregularly sampled signals
+        for irr_id in range(len(self.irregularlysampledsignals)):
+            if hasattr(self.irregularlysampledsignals[irr_id], '_rawio'):
+                ana_time_slice = self.irregularlysampledsignals[irr_id].load(
+                    time_slice=(t_start, t_stop))
+            else:
+                ana_time_slice = self.irregularlysampledsignals[irr_id].time_slice(t_start, t_stop)
+            if reset_time:
+                ana_time_slice = ana_time_slice.time_shift(t_shift)
+            subseg.irregularlysampledsignals.append(ana_time_slice)
+
         # cut spiketrains
         for st_id in range(len(self.spiketrains)):
             if hasattr(self.spiketrains[st_id], '_rawio'):

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -606,6 +606,32 @@ class SpikeTrain(DataObject):
 
         return new_st
 
+    def time_shift(self, t_shift):
+        """
+        Shifts a :class:`SpikeTrain` to start at a new time.
+
+        Parameters:
+        -----------
+        t_shift: Quantity (time)
+            Amount of time by which to shift the :class:`SpikeTrain`.
+
+        Returns:
+        --------
+        spiketrain: :class:`SpikeTrain`
+            New instance of a :class:`SpikeTrain` object starting at t_start (the original
+            :class:`SpikeTrain` is not modified).
+        """
+        new_st = self.duplicate_with_new_data(
+            signal=self.times.view(pq.Quantity) + t_shift,
+            t_start=self.t_start + t_shift,
+            t_stop=self.t_stop + t_shift)
+
+        # Here we can safely copy the array annotations since we know that
+        # the length of the SpikeTrain does not change.
+        new_st.array_annotate(**self.array_annotations)
+
+        return new_st
+
     def merge(self, other):
         '''
         Merge another :class:`SpikeTrain` into this one.

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -618,8 +618,8 @@ class SpikeTrain(DataObject):
         Returns:
         --------
         spiketrain: :class:`SpikeTrain`
-            New instance of a :class:`SpikeTrain` object starting at t_start (the original
-            :class:`SpikeTrain` is not modified).
+            New instance of a :class:`SpikeTrain` object starting at t_shift later than the
+            original :class:`SpikeTrain` (the original :class:`SpikeTrain` is not modified).
         """
         new_st = self.duplicate_with_new_data(
             signal=self.times.view(pq.Quantity) + t_shift,

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -31,7 +31,8 @@ from neo.core import Segment
 
 from neo.test.tools import (assert_arrays_almost_equal, assert_neo_object_is_compliant,
                             assert_same_sub_schema, assert_objects_equivalent,
-                            assert_same_attributes, assert_same_sub_schema, assert_arrays_equal)
+                            assert_same_attributes, assert_same_sub_schema, assert_arrays_equal,
+                            assert_same_annotations, assert_same_array_annotations)
 from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_neo,
                                         TEST_ANNOTATIONS)
 
@@ -357,27 +358,35 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
 
     def test__time_slice_deepcopy_array_annotations(self):
         length = self.signal1.shape[-1]
-        params1 = {'test0': ['y{}'.format(i) for i in range(length)], 'test1': ['deeptest' for i in range(length)],
+        params1 = {'test0': ['y{}'.format(i) for i in range(length)],
+                   'test1': ['deeptest' for i in range(length)],
                    'test2': [(-1)**i > 0 for i in range(length)]}
         self.signal1.array_annotate(**params1)
         result = self.signal1.time_slice(None, None)
 
         # Change annotations of original
-        params2 = {'test0': ['x{}'.format(i) for i in range(length)], 'test2': [(-1)**(i+1) > 0 for i in range(length)]}
+        params2 = {'test0': ['x{}'.format(i) for i in range(length)],
+                   'test2': [(-1)**(i+1) > 0 for i in range(length)]}
         self.signal1.array_annotate(**params2)
         self.signal1.array_annotations['test1'][0] = 'shallowtest'
 
-        self.assertFalse(all(self.signal1.array_annotations['test0'] == result.array_annotations['test0']))
-        self.assertFalse(all(self.signal1.array_annotations['test1'] == result.array_annotations['test1']))
-        self.assertFalse(all(self.signal1.array_annotations['test2'] == result.array_annotations['test2']))
+        self.assertFalse(all(self.signal1.array_annotations['test0']
+                             == result.array_annotations['test0']))
+        self.assertFalse(all(self.signal1.array_annotations['test1']
+                             == result.array_annotations['test1']))
+        self.assertFalse(all(self.signal1.array_annotations['test2']
+                             == result.array_annotations['test2']))
 
         # Change annotations of result
         params3 = {'test0': ['z{}'.format(i) for i in range(1, result.shape[-1]+1)]}
         result.array_annotate(**params3)
         result.array_annotations['test1'][0] = 'shallow2'
-        self.assertFalse(all(self.signal1.array_annotations['test0'] == result.array_annotations['test0']))
-        self.assertFalse(all(self.signal1.array_annotations['test1'] == result.array_annotations['test1']))
-        self.assertFalse(all(self.signal1.array_annotations['test2'] == result.array_annotations['test2']))
+        self.assertFalse(all(self.signal1.array_annotations['test0']
+                             == result.array_annotations['test0']))
+        self.assertFalse(all(self.signal1.array_annotations['test1']
+                             == result.array_annotations['test1']))
+        self.assertFalse(all(self.signal1.array_annotations['test2']
+                             == result.array_annotations['test2']))
 
     def test__time_slice_deepcopy_data(self):
         result = self.signal1.time_slice(None, None)
@@ -457,6 +466,37 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.assertEqual(result.segment, None)
         self.assertEqual(result.channel_index, None)
 
+    def test__time_shift_same_attributes(self):
+        result = self.signal1.time_shift(1 * pq.ms)
+        assert_same_attributes(result, self.signal1, exclude=['times', 't_start', 't_stop'])
+
+    def test__time_shift_same_annotations(self):
+        result = self.signal1.time_shift(1 * pq.ms)
+        assert_same_annotations(result, self.signal1)
+
+    def test__time_shift_same_array_annotations(self):
+        result = self.signal1.time_shift(1 * pq.ms)
+        assert_same_array_annotations(result, self.signal1)
+
+    def test__time_shift_should_set_parents_to_None(self):
+        # When time-shifting, a deep copy is made,
+        # thus the reference to parent objects should be destroyed
+        result = self.signal1.time_shift(1 * pq.ms)
+        self.assertEqual(result.segment, None)
+        self.assertEqual(result.channel_index, None)
+
+    def test__time_shift_by_zero(self):
+        shifted = self.signal1.time_shift(0*pq.ms)
+        assert_arrays_equal(shifted.times, self.signal1.times)
+
+    def test__time_shift_same_units(self):
+        shifted = self.signal1.time_shift(10 * pq.ms)
+        assert_arrays_equal(shifted.times, self.signal1.times + 10*pq.ms)
+
+    def test__time_shift_different_units(self):
+        shifted = self.signal1.time_shift(1 * pq.s)
+        assert_arrays_equal(shifted.times, self.signal1.times + 1000 * pq.ms)
+
     # TODO: XXX ???
     def test__copy_should_let_access_to_parents_objects(self):
         result = self.signal1.copy()
@@ -465,9 +505,9 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
 
     def test__deepcopy_should_set_parents_objects_to_None(self):
         # Deepcopy should destroy references to parents
-         result = copy.deepcopy(self.signal1)
-         self.assertEqual(result.segment, None)
-         self.assertEqual(result.channel_index, None)
+        result = copy.deepcopy(self.signal1)
+        self.assertEqual(result.segment, None)
+        self.assertEqual(result.channel_index, None)
 
     def test__getitem_should_return_single_quantity(self):
         result1 = self.signal1[0, 0]

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -366,7 +366,7 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
 
         # Change annotations of original
         params2 = {'test0': ['x{}'.format(i) for i in range(length)],
-                   'test2': [(-1)**(i+1) > 0 for i in range(length)]}
+                   'test2': [(-1) ** (i + 1) > 0 for i in range(length)]}
         self.signal1.array_annotate(**params2)
         self.signal1.array_annotations['test1'][0] = 'shallowtest'
 
@@ -486,12 +486,12 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.assertEqual(result.channel_index, None)
 
     def test__time_shift_by_zero(self):
-        shifted = self.signal1.time_shift(0*pq.ms)
+        shifted = self.signal1.time_shift(0 * pq.ms)
         assert_arrays_equal(shifted.times, self.signal1.times)
 
     def test__time_shift_same_units(self):
         shifted = self.signal1.time_shift(10 * pq.ms)
-        assert_arrays_equal(shifted.times, self.signal1.times + 10*pq.ms)
+        assert_arrays_equal(shifted.times, self.signal1.times + 10 * pq.ms)
 
     def test__time_shift_different_units(self):
         shifted = self.signal1.time_shift(1 * pq.s)

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -343,7 +343,7 @@ class TestEpoch(unittest.TestCase):
 
         # Change annotations of original
         params2 = {'test0': ['x{}'.format(i) for i in range(length)],
-                   'test2': [(-1)**(i+1) > 0 for i in range(length)]}
+                   'test2': [(-1) ** (i + 1) > 0 for i in range(length)]}
         self.epc.array_annotate(**params2)
         self.epc.array_annotations['test1'][2] = 'shallowtest'
 
@@ -589,7 +589,7 @@ class TestEpoch(unittest.TestCase):
         # Deepcopy should destroy references to parents
         result = deepcopy(self.epc)
         self.assertEqual(result.segment, None)
-    
+
     def test__time_shift_same_attributes(self):
         result = self.epc.time_shift(1 * pq.ms)
         assert_same_attributes(result, self.epc, exclude=['times'])
@@ -609,12 +609,12 @@ class TestEpoch(unittest.TestCase):
         self.assertEqual(result.segment, None)
 
     def test__time_shift_by_zero(self):
-        shifted = self.epc.time_shift(0*pq.ms)
+        shifted = self.epc.time_shift(0 * pq.ms)
         assert_arrays_equal(shifted.times, self.epc.times)
 
     def test__time_shift_same_units(self):
         shifted = self.epc.time_shift(10 * pq.ms)
-        assert_arrays_equal(shifted.times, self.epc.times + 10*pq.ms)
+        assert_arrays_equal(shifted.times, self.epc.times + 10 * pq.ms)
 
     def test__time_shift_different_units(self):
         shifted = self.epc.time_shift(1 * pq.s)

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -25,7 +25,9 @@ else:
 from neo.core.epoch import Epoch
 from neo.core import Segment
 from neo.test.tools import (assert_neo_object_is_compliant, assert_arrays_equal,
-                            assert_arrays_almost_equal, assert_same_sub_schema)
+                            assert_arrays_almost_equal, assert_same_sub_schema,
+                            assert_same_attributes, assert_same_annotations,
+                            assert_same_array_annotations)
 from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_neo,
                                         TEST_ANNOTATIONS)
 
@@ -109,8 +111,11 @@ class TestEpoch(unittest.TestCase):
 
     def setUp(self):
         self.params = {'test0': 'y1', 'test1': ['deeptest'], 'test2': True}
+        self.seg = Segment()
         self.epc = Epoch(times=[10, 20, 30, 40, 50] * pq.s, durations=[10, 5, 7, 14, 9] * pq.ms,
-                    labels=np.array(['btn0', 'btn1', 'btn2', 'btn0', 'btn3'], dtype='S'), **self.params)
+                    labels=np.array(['btn0', 'btn1', 'btn2', 'btn0', 'btn3'], dtype='S'),
+                         **self.params)
+        self.epc.segment = self.seg
 
     def test_Epoch_creation(self):
         params = {'test2': 'y1', 'test3': True}
@@ -327,7 +332,8 @@ class TestEpoch(unittest.TestCase):
 
     def test__time_slice_deepcopy_array_annotations(self):
         length = self.epc.shape[-1]
-        params1 = {'test0': ['y{}'.format(i) for i in range(length)], 'test1': ['deeptest' for i in range(length)],
+        params1 = {'test0': ['y{}'.format(i) for i in range(length)],
+                   'test1': ['deeptest' for i in range(length)],
                    'test2': [(-1)**i > 0 for i in range(length)]}
         self.epc.array_annotate(**params1)
         # time_slice spike train, keep sliced spike times
@@ -336,22 +342,29 @@ class TestEpoch(unittest.TestCase):
         result = self.epc.time_slice(t_start, t_stop)
 
         # Change annotations of original
-        params2 = {'test0': ['x{}'.format(i) for i in range(length)], 'test2': [(-1)**(i+1) > 0 for i in range(length)]}
+        params2 = {'test0': ['x{}'.format(i) for i in range(length)],
+                   'test2': [(-1)**(i+1) > 0 for i in range(length)]}
         self.epc.array_annotate(**params2)
         self.epc.array_annotations['test1'][2] = 'shallowtest'
 
-        self.assertFalse(all(self.epc.array_annotations['test0'][1:4] == result.array_annotations['test0']))
-        self.assertFalse(all(self.epc.array_annotations['test1'][1:4] == result.array_annotations['test1']))
-        self.assertFalse(all(self.epc.array_annotations['test2'][1:4] == result.array_annotations['test2']))
+        self.assertFalse(all(self.epc.array_annotations['test0'][1:4]
+                             == result.array_annotations['test0']))
+        self.assertFalse(all(self.epc.array_annotations['test1'][1:4]
+                             == result.array_annotations['test1']))
+        self.assertFalse(all(self.epc.array_annotations['test2'][1:4]
+                             == result.array_annotations['test2']))
 
         # Change annotations of result
         params3 = {'test0': ['z{}'.format(i) for i in range(1, 4)]}
         result.array_annotate(**params3)
         result.array_annotations['test1'][1] = 'shallow2'
 
-        self.assertFalse(all(self.epc.array_annotations['test0'][1:4] == result.array_annotations['test0']))
-        self.assertFalse(all(self.epc.array_annotations['test1'][1:4] == result.array_annotations['test1']))
-        self.assertFalse(all(self.epc.array_annotations['test2'][1:4] == result.array_annotations['test2']))
+        self.assertFalse(all(self.epc.array_annotations['test0'][1:4]
+                             == result.array_annotations['test0']))
+        self.assertFalse(all(self.epc.array_annotations['test1'][1:4]
+                             == result.array_annotations['test1']))
+        self.assertFalse(all(self.epc.array_annotations['test2'][1:4]
+                             == result.array_annotations['test2']))
 
     def test__time_slice_deepcopy_data(self):
         result = self.epc.time_slice(None, None)
@@ -576,6 +589,36 @@ class TestEpoch(unittest.TestCase):
         # Deepcopy should destroy references to parents
         result = deepcopy(self.epc)
         self.assertEqual(result.segment, None)
+    
+    def test__time_shift_same_attributes(self):
+        result = self.epc.time_shift(1 * pq.ms)
+        assert_same_attributes(result, self.epc, exclude=['times'])
+
+    def test__time_shift_same_annotations(self):
+        result = self.epc.time_shift(1 * pq.ms)
+        assert_same_annotations(result, self.epc)
+
+    def test__time_shift_same_array_annotations(self):
+        result = self.epc.time_shift(1 * pq.ms)
+        assert_same_array_annotations(result, self.epc)
+
+    def test__time_shift_should_set_parents_to_None(self):
+        # When time-shifting, a deep copy is made,
+        # thus the reference to parent objects should be destroyed
+        result = self.epc.time_shift(1 * pq.ms)
+        self.assertEqual(result.segment, None)
+
+    def test__time_shift_by_zero(self):
+        shifted = self.epc.time_shift(0*pq.ms)
+        assert_arrays_equal(shifted.times, self.epc.times)
+
+    def test__time_shift_same_units(self):
+        shifted = self.epc.time_shift(10 * pq.ms)
+        assert_arrays_equal(shifted.times, self.epc.times + 10*pq.ms)
+
+    def test__time_shift_different_units(self):
+        shifted = self.epc.time_shift(1 * pq.s)
+        assert_arrays_equal(shifted.times, self.epc.times + 1000 * pq.ms)
 
     def test_as_array(self):
         times = [2, 3, 4, 5]

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -212,7 +212,7 @@ class TestEvent(unittest.TestCase):
 
         # Change annotations of original
         params2 = {'test0': ['x{}'.format(i) for i in range(length)],
-                   'test2': [(-1)**(i+1) > 0 for i in range(length)]}
+                   'test2': [(-1) ** (i + 1) > 0 for i in range(length)]}
         self.evt.array_annotate(**params2)
         self.evt.array_annotations['test1'][6] = 'shallowtest'
 
@@ -561,12 +561,12 @@ class TestEvent(unittest.TestCase):
         self.assertEqual(result.segment, None)
 
     def test__time_shift_by_zero(self):
-        shifted = self.evt.time_shift(0*pq.ms)
+        shifted = self.evt.time_shift(0 * pq.ms)
         assert_arrays_equal(shifted.times, self.evt.times)
 
     def test__time_shift_same_units(self):
         shifted = self.evt.time_shift(10 * pq.ms)
-        assert_arrays_equal(shifted.times, self.evt.times + 10*pq.ms)
+        assert_arrays_equal(shifted.times, self.evt.times + 10 * pq.ms)
 
     def test__time_shift_different_units(self):
         shifted = self.evt.time_shift(1 * pq.s)

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -25,7 +25,9 @@ from neo.core.event import Event
 from neo.core.epoch import Epoch
 from neo.core import Segment
 from neo.test.tools import (assert_neo_object_is_compliant, assert_arrays_equal,
-                            assert_arrays_almost_equal, assert_same_sub_schema)
+                            assert_arrays_almost_equal, assert_same_sub_schema,
+                            assert_same_attributes, assert_same_annotations,
+                            assert_same_array_annotations)
 from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_neo,
                                         TEST_ANNOTATIONS)
 
@@ -106,10 +108,12 @@ class TestEvent(unittest.TestCase):
     def setUp(self):
         self.params = {'test2': 'y1', 'test3': True}
         self.arr_ann = {'index': np.arange(10), 'test': np.arange(100, 110)}
+        self.seg = Segment()
         self.evt = Event([0.1, 0.5, 1.1, 1.5, 1.7, 2.2, 2.9, 3.0, 3.1, 3.3] * pq.ms, name='test',
                     description='tester', file_origin='test.file', test1=1,
                     array_annotations=self.arr_ann, **self.params)
         self.evt.annotate(test1=1.1, test0=[1, 2])
+        self.evt.segment = self.seg
 
     def test_setup_compliant(self):
         assert_neo_object_is_compliant(self.evt)
@@ -197,7 +201,8 @@ class TestEvent(unittest.TestCase):
 
     def test__time_slice_deepcopy_array_annotations(self):
         length = self.evt.shape[-1]
-        params1 = {'test0': ['y{}'.format(i) for i in range(length)], 'test1': ['deeptest' for i in range(length)],
+        params1 = {'test0': ['y{}'.format(i) for i in range(length)],
+                   'test1': ['deeptest' for i in range(length)],
                    'test2': [(-1)**i > 0 for i in range(length)]}
         self.evt.array_annotate(**params1)
         # time_slice spike train, keep sliced spike times
@@ -206,22 +211,29 @@ class TestEvent(unittest.TestCase):
         result = self.evt.time_slice(t_start, t_stop)
 
         # Change annotations of original
-        params2 = {'test0': ['x{}'.format(i) for i in range(length)], 'test2': [(-1)**(i+1) > 0 for i in range(length)]}
+        params2 = {'test0': ['x{}'.format(i) for i in range(length)],
+                   'test2': [(-1)**(i+1) > 0 for i in range(length)]}
         self.evt.array_annotate(**params2)
         self.evt.array_annotations['test1'][6] = 'shallowtest'
 
-        self.assertFalse(all(self.evt.array_annotations['test0'][5:8] == result.array_annotations['test0']))
-        self.assertFalse(all(self.evt.array_annotations['test1'][5:8] == result.array_annotations['test1']))
-        self.assertFalse(all(self.evt.array_annotations['test2'][5:8] == result.array_annotations['test2']))
+        self.assertFalse(all(self.evt.array_annotations['test0'][5:8]
+                             == result.array_annotations['test0']))
+        self.assertFalse(all(self.evt.array_annotations['test1'][5:8]
+                             == result.array_annotations['test1']))
+        self.assertFalse(all(self.evt.array_annotations['test2'][5:8]
+                             == result.array_annotations['test2']))
 
         # Change annotations of result
         params3 = {'test0': ['z{}'.format(i) for i in range(5, 8)]}
         result.array_annotate(**params3)
         result.array_annotations['test1'][1] = 'shallow2'
 
-        self.assertFalse(all(self.evt.array_annotations['test0'][5:8] == result.array_annotations['test0']))
-        self.assertFalse(all(self.evt.array_annotations['test1'][5:8] == result.array_annotations['test1']))
-        self.assertFalse(all(self.evt.array_annotations['test2'][5:8] == result.array_annotations['test2']))
+        self.assertFalse(all(self.evt.array_annotations['test0'][5:8]
+                             == result.array_annotations['test0']))
+        self.assertFalse(all(self.evt.array_annotations['test1'][5:8]
+                             == result.array_annotations['test1']))
+        self.assertFalse(all(self.evt.array_annotations['test2'][5:8]
+                             == result.array_annotations['test2']))
 
     def test__time_slice_deepcopy_data(self):
         result = self.evt.time_slice(None, None)
@@ -529,6 +541,36 @@ class TestEvent(unittest.TestCase):
 
         evt3 = evt.time_slice(2.2 * pq.ms, None)
         assert_arrays_equal(evt3.times, [3, 4, 5] * pq.ms)
+
+    def test__time_shift_same_attributes(self):
+        result = self.evt.time_shift(1 * pq.ms)
+        assert_same_attributes(result, self.evt, exclude=['times'])
+
+    def test__time_shift_same_annotations(self):
+        result = self.evt.time_shift(1 * pq.ms)
+        assert_same_annotations(result, self.evt)
+
+    def test__time_shift_same_array_annotations(self):
+        result = self.evt.time_shift(1 * pq.ms)
+        assert_same_array_annotations(result, self.evt)
+
+    def test__time_shift_should_set_parents_to_None(self):
+        # When time-shifting, a deep copy is made,
+        # thus the reference to parent objects should be destroyed
+        result = self.evt.time_shift(1 * pq.ms)
+        self.assertEqual(result.segment, None)
+
+    def test__time_shift_by_zero(self):
+        shifted = self.evt.time_shift(0*pq.ms)
+        assert_arrays_equal(shifted.times, self.evt.times)
+
+    def test__time_shift_same_units(self):
+        shifted = self.evt.time_shift(10 * pq.ms)
+        assert_arrays_equal(shifted.times, self.evt.times + 10*pq.ms)
+
+    def test__time_shift_different_units(self):
+        shifted = self.evt.time_shift(1 * pq.s)
+        assert_arrays_equal(shifted.times, self.evt.times + 1000 * pq.ms)
 
     def test_as_array(self):
         data = [2, 3, 4, 5]

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -464,7 +464,7 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
 
         # Change annotations of original
         params2 = {'test0': ['x{}'.format(i) for i in range(length)],
-                   'test2': [(-1)**(i+1) > 0 for i in range(length)]}
+                   'test2': [(-1) ** (i + 1) > 0 for i in range(length)]}
         self.signal1.array_annotate(**params2)
         self.signal1.array_annotations['test1'][0] = 'shallowtest'
 
@@ -663,7 +663,7 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         result = deepcopy(self.signal1)
         self.assertEqual(result.segment, None)
         self.assertEqual(result.channel_index, None)
-    
+
     def test__time_shift_same_attributes(self):
         result = self.signal1.time_shift(1 * pq.ms)
         assert_same_attributes(result, self.signal1, exclude=['times', 't_start', 't_stop'])
@@ -684,12 +684,12 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         self.assertEqual(result.channel_index, None)
 
     def test__time_shift_by_zero(self):
-        shifted = self.signal1.time_shift(0*pq.ms)
+        shifted = self.signal1.time_shift(0 * pq.ms)
         assert_arrays_equal(shifted.times, self.signal1.times)
 
     def test__time_shift_same_units(self):
         shifted = self.signal1.time_shift(10 * pq.ms)
-        assert_arrays_equal(shifted.times, self.signal1.times + 10*pq.ms)
+        assert_arrays_equal(shifted.times, self.signal1.times + 10 * pq.ms)
 
     def test__time_shift_different_units(self):
         shifted = self.signal1.time_shift(1 * pq.s)

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -27,7 +27,9 @@ from neo.core.irregularlysampledsignal import IrregularlySampledSignal
 from neo.core import Segment, ChannelIndex
 from neo.core.baseneo import MergeError
 from neo.test.tools import (assert_arrays_almost_equal, assert_arrays_equal,
-                            assert_neo_object_is_compliant, assert_same_sub_schema)
+                            assert_neo_object_is_compliant, assert_same_sub_schema,
+                            assert_same_attributes, assert_same_annotations,
+                            assert_same_array_annotations)
 from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_neo,
                                         TEST_ANNOTATIONS)
 
@@ -454,27 +456,35 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
 
     def test__time_slice_deepcopy_array_annotations(self):
         length = self.signal1.shape[-1]
-        params1 = {'test0': ['y{}'.format(i) for i in range(length)], 'test1': ['deeptest' for i in range(length)],
+        params1 = {'test0': ['y{}'.format(i) for i in range(length)],
+                   'test1': ['deeptest' for i in range(length)],
                    'test2': [(-1)**i > 0 for i in range(length)]}
         self.signal1.array_annotate(**params1)
         result = self.signal1.time_slice(None, None)
 
         # Change annotations of original
-        params2 = {'test0': ['x{}'.format(i) for i in range(length)], 'test2': [(-1)**(i+1) > 0 for i in range(length)]}
+        params2 = {'test0': ['x{}'.format(i) for i in range(length)],
+                   'test2': [(-1)**(i+1) > 0 for i in range(length)]}
         self.signal1.array_annotate(**params2)
         self.signal1.array_annotations['test1'][0] = 'shallowtest'
 
-        self.assertFalse(all(self.signal1.array_annotations['test0'] == result.array_annotations['test0']))
-        self.assertFalse(all(self.signal1.array_annotations['test1'] == result.array_annotations['test1']))
-        self.assertFalse(all(self.signal1.array_annotations['test2'] == result.array_annotations['test2']))
+        self.assertFalse(all(self.signal1.array_annotations['test0']
+                             == result.array_annotations['test0']))
+        self.assertFalse(all(self.signal1.array_annotations['test1']
+                             == result.array_annotations['test1']))
+        self.assertFalse(all(self.signal1.array_annotations['test2']
+                             == result.array_annotations['test2']))
 
         # Change annotations of result
         params3 = {'test0': ['z{}'.format(i) for i in range(1, result.shape[-1]+1)]}
         result.array_annotate(**params3)
         result.array_annotations['test1'][0] = 'shallow2'
-        self.assertFalse(all(self.signal1.array_annotations['test0'] == result.array_annotations['test0']))
-        self.assertFalse(all(self.signal1.array_annotations['test1'] == result.array_annotations['test1']))
-        self.assertFalse(all(self.signal1.array_annotations['test2'] == result.array_annotations['test2']))
+        self.assertFalse(all(self.signal1.array_annotations['test0']
+                             == result.array_annotations['test0']))
+        self.assertFalse(all(self.signal1.array_annotations['test1']
+                             == result.array_annotations['test1']))
+        self.assertFalse(all(self.signal1.array_annotations['test2']
+                             == result.array_annotations['test2']))
 
     def test__time_slice_deepcopy_data(self):
         result = self.signal1.time_slice(None, None)
@@ -650,9 +660,40 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
 
     def test__deepcopy_should_set_parents_objects_to_None(self):
         # Deepcopy should destroy references to parents
-         result = deepcopy(self.signal1)
-         self.assertEqual(result.segment, None)
-         self.assertEqual(result.channel_index, None)
+        result = deepcopy(self.signal1)
+        self.assertEqual(result.segment, None)
+        self.assertEqual(result.channel_index, None)
+    
+    def test__time_shift_same_attributes(self):
+        result = self.signal1.time_shift(1 * pq.ms)
+        assert_same_attributes(result, self.signal1, exclude=['times', 't_start', 't_stop'])
+
+    def test__time_shift_same_annotations(self):
+        result = self.signal1.time_shift(1 * pq.ms)
+        assert_same_annotations(result, self.signal1)
+
+    def test__time_shift_same_array_annotations(self):
+        result = self.signal1.time_shift(1 * pq.ms)
+        assert_same_array_annotations(result, self.signal1)
+
+    def test__time_shift_should_set_parents_to_None(self):
+        # When time-shifting, a deep copy is made,
+        # thus the reference to parent objects should be destroyed
+        result = self.signal1.time_shift(1 * pq.ms)
+        self.assertEqual(result.segment, None)
+        self.assertEqual(result.channel_index, None)
+
+    def test__time_shift_by_zero(self):
+        shifted = self.signal1.time_shift(0*pq.ms)
+        assert_arrays_equal(shifted.times, self.signal1.times)
+
+    def test__time_shift_same_units(self):
+        shifted = self.signal1.time_shift(10 * pq.ms)
+        assert_arrays_equal(shifted.times, self.signal1.times + 10*pq.ms)
+
+    def test__time_shift_different_units(self):
+        shifted = self.signal1.time_shift(1 * pq.s)
+        assert_arrays_equal(shifted.times, self.signal1.times + 1000 * pq.ms)
 
     def test_as_array(self):
         sig_as_arr = self.signal1.as_array()

--- a/neo/test/coretest/test_segment.py
+++ b/neo/test/coretest/test_segment.py
@@ -783,7 +783,7 @@ class TestSegment(unittest.TestCase):
 
         assert_same_sub_schema(result21, [self.trains1a[0]])
         assert_same_sub_schema(result22, [self.trains1a[1]])
-    
+
     def test__time_slice(self):
         time_slice = [.5, 5.6] * pq.s
 
@@ -878,8 +878,7 @@ class TestSegment(unittest.TestCase):
         assert_same_attributes(sliced.analogsignals[0], anasig_target)
         irrsig_target = irrsig.copy()
         irrsig_target = irrsig_target.time_shift(- time_slice[0]).time_slice(t_start=0 * pq.s,
-                                                                             t_stop=time_slice[1] -
-                                                                                    time_slice[0])
+                                                t_stop=time_slice[1] - time_slice[0])
         assert_same_attributes(sliced.irregularlysampledsignals[0], irrsig_target)
         assert_same_attributes(sliced.events[0],
                                event.time_shift(- time_slice[0]).time_slice(
@@ -892,7 +891,7 @@ class TestSegment(unittest.TestCase):
 
         reader = ExampleRawIO(filename='my_filename.fake')
         reader.parse_header()
-        
+
         proxy_anasig = AnalogSignalProxy(rawio=reader,
                                          global_channel_indexes=None,
                                          block_index=0, seg_index=0)

--- a/neo/test/coretest/test_segment.py
+++ b/neo/test/coretest/test_segment.py
@@ -23,14 +23,17 @@ else:
     HAVE_IPYTHON = True
 
 from neo.core.segment import Segment
-from neo.core import (AnalogSignal, Block,
+from neo.core import (AnalogSignal, Block, Event,
                       Epoch, ChannelIndex, SpikeTrain, Unit)
 from neo.core.container import filterdata
 from neo.test.tools import (assert_neo_object_is_compliant,
-                            assert_same_sub_schema)
+                            assert_same_sub_schema, assert_same_attributes)
 from neo.test.generate_datasets import (fake_neo, get_fake_value,
                                         get_fake_values, get_annotations,
                                         clone_object, TEST_ANNOTATIONS)
+from neo.rawio.examplerawio import ExampleRawIO
+from neo.io.proxyobjects import (AnalogSignalProxy, SpikeTrainProxy,
+                EventProxy, EpochProxy)
 
 
 class Test__generate_datasets(unittest.TestCase):
@@ -780,6 +783,163 @@ class TestSegment(unittest.TestCase):
 
         assert_same_sub_schema(result21, [self.trains1a[0]])
         assert_same_sub_schema(result22, [self.trains1a[1]])
+    
+    def test__time_slice(self):
+        time_slice = [.5, 5.6] * pq.s
+
+        epoch2 = Epoch([0.6, 9.5, 16.8, 34.1] * pq.s, durations=[4.5, 4.8, 5.0, 5.0] * pq.s,
+                       t_start=.1 * pq.s)
+        epoch2.annotate(epoch_type='b')
+        epoch2.array_annotate(trial_id=[1, 2, 3, 4])
+
+        event = Event(times=[0.5, 10.0, 25.2] * pq.s, t_start=.1 * pq.s)
+        event.annotate(event_type='trial start')
+        event.array_annotate(trial_id=[1, 2, 3])
+
+        anasig = AnalogSignal(np.arange(50.0) * pq.mV, t_start=.1 * pq.s,
+                              sampling_rate=1.0 * pq.Hz)
+        st = SpikeTrain(np.arange(0.5, 50, 7) * pq.s, t_start=.1 * pq.s, t_stop=50.0 * pq.s,
+                        waveforms=np.array([[[0., 1.], [0.1, 1.1]], [[2., 3.], [2.1, 3.1]],
+                                            [[4., 5.], [4.1, 5.1]], [[6., 7.], [6.1, 7.1]],
+                                            [[8., 9.], [8.1, 9.1]], [[12., 13.], [12.1, 13.1]],
+                                            [[14., 15.], [14.1, 15.1]],
+                                            [[16., 17.], [16.1, 17.1]]]) * pq.mV,
+                        array_annotations={'spikenum': np.arange(1, 9)})
+
+        seg = Segment()
+        seg.epochs = [epoch2]
+        seg.events = [event]
+        seg.analogsignals = [anasig]
+        seg.spiketrains = [st]
+
+        block = Block()
+        block.segments = [seg]
+        block.create_many_to_one_relationship()
+
+        # test without resetting the time
+        sliced = seg.time_slice(time_slice[0], time_slice[1])
+
+        assert_neo_object_is_compliant(sliced)
+
+        self.assertEqual(len(sliced.events), 1)
+        self.assertEqual(len(sliced.spiketrains), 1)
+        self.assertEqual(len(sliced.analogsignals), 1)
+        self.assertEqual(len(sliced.epochs), 1)
+
+        assert_same_attributes(sliced.spiketrains[0],
+                               st.time_slice(t_start=time_slice[0],
+                                             t_stop=time_slice[1]))
+        assert_same_attributes(sliced.analogsignals[0],
+                               anasig.time_slice(t_start=time_slice[0],
+                                                 t_stop=time_slice[1]))
+        assert_same_attributes(sliced.events[0],
+                               event.time_slice(t_start=time_slice[0],
+                                                t_stop=time_slice[1]))
+        assert_same_attributes(sliced.epochs[0],
+                               epoch2.time_slice(t_start=time_slice[0],
+                                                t_stop=time_slice[1]))
+
+        seg = Segment()
+        seg.epochs = [epoch2]
+        seg.events = [event]
+        seg.analogsignals = [anasig]
+        seg.spiketrains = [st]
+
+        block = Block()
+        block.segments = [seg]
+        block.create_many_to_one_relationship()
+
+        # test with resetting the time
+        sliced = seg.time_slice(time_slice[0], time_slice[1], reset_time=True)
+
+        assert_neo_object_is_compliant(sliced)
+
+        self.assertEqual(len(sliced.events), 1)
+        self.assertEqual(len(sliced.spiketrains), 1)
+        self.assertEqual(len(sliced.analogsignals), 1)
+        self.assertEqual(len(sliced.epochs), 1)
+
+        assert_same_attributes(sliced.spiketrains[0],
+                               st.time_shift(- time_slice[0]).time_slice(
+                                   t_start=0 * pq.s, t_stop=time_slice[1] - time_slice[0]))
+
+        anasig_target = anasig.copy()
+        anasig_target = anasig_target.time_shift(- time_slice[0]).time_slice(t_start=0 * pq.s,
+                                                 t_stop=time_slice[1] - time_slice[0])
+        assert_same_attributes(sliced.analogsignals[0], anasig_target)
+        assert_same_attributes(sliced.events[0],
+                               event.time_shift(- time_slice[0]).time_slice(
+                                   t_start=0 * pq.s, t_stop=time_slice[1] - time_slice[0]))
+        assert_same_attributes(sliced.epochs[0],
+                               epoch2.time_shift(- time_slice[0]).time_slice(t_start=0 * pq.s,
+                                                    t_stop=time_slice[1] - time_slice[0]))
+
+        seg = Segment()
+
+        reader = ExampleRawIO(filename='my_filename.fake')
+        reader.parse_header()
+        
+        proxy_anasig = AnalogSignalProxy(rawio=reader,
+                                         global_channel_indexes=None,
+                                         block_index=0, seg_index=0)
+        seg.analogsignals.append(proxy_anasig)
+
+        proxy_st = SpikeTrainProxy(rawio=reader, unit_index=0,
+                                     block_index=0, seg_index=0)
+        seg.spiketrains.append(proxy_st)
+
+        proxy_event = EventProxy(rawio=reader, event_channel_index=0,
+                                 block_index=0, seg_index=0)
+        seg.events.append(proxy_event)
+
+        proxy_epoch = EpochProxy(rawio=reader, event_channel_index=1,
+                                 block_index=0, seg_index=0)
+        proxy_epoch.annotate(pick='me')
+        seg.epochs.append(proxy_epoch)
+
+        loaded_epoch = proxy_epoch.load()
+        loaded_event = proxy_event.load()
+        loaded_st = proxy_st.load()
+        loaded_anasig = proxy_anasig.load()
+
+        block = Block()
+        block.segments = [seg]
+        block.create_many_to_one_relationship()
+
+        # test with proxy objects
+        sliced = seg.time_slice(time_slice[0], time_slice[1])
+
+        assert_neo_object_is_compliant(sliced)
+
+        sliced_event = loaded_event.time_slice(t_start=time_slice[0],
+                                             t_stop=time_slice[1])
+        has_event = len(sliced_event) > 0
+
+        sliced_anasig = loaded_anasig.time_slice(t_start=time_slice[0],
+                                             t_stop=time_slice[1])
+
+        sliced_st = loaded_st.time_slice(t_start=time_slice[0],
+                                             t_stop=time_slice[1])
+
+        self.assertEqual(len(sliced.events), int(has_event))
+        self.assertEqual(len(sliced.spiketrains), 1)
+        self.assertEqual(len(sliced.analogsignals), 1)
+
+        self.assertTrue(isinstance(sliced.spiketrains[0],
+                                   SpikeTrain))
+        assert_same_attributes(sliced.spiketrains[0],
+                               sliced_st)
+
+        self.assertTrue(isinstance(sliced.analogsignals[0],
+                                   AnalogSignal))
+        assert_same_attributes(sliced.analogsignals[0],
+                               sliced_anasig)
+
+        if has_event:
+            self.assertTrue(isinstance(sliced.events[0],
+                                       Event))
+            assert_same_attributes(sliced.events[0],
+                               sliced_event)
 
     # to remove
     # def test_segment_take_analogsignal_by_unit(self):

--- a/neo/test/coretest/test_segment.py
+++ b/neo/test/coretest/test_segment.py
@@ -23,7 +23,7 @@ else:
     HAVE_IPYTHON = True
 
 from neo.core.segment import Segment
-from neo.core import (AnalogSignal, Block, Event,
+from neo.core import (AnalogSignal, Block, Event, IrregularlySampledSignal,
                       Epoch, ChannelIndex, SpikeTrain, Unit)
 from neo.core.container import filterdata
 from neo.test.tools import (assert_neo_object_is_compliant,
@@ -798,6 +798,8 @@ class TestSegment(unittest.TestCase):
 
         anasig = AnalogSignal(np.arange(50.0) * pq.mV, t_start=.1 * pq.s,
                               sampling_rate=1.0 * pq.Hz)
+        irrsig = IrregularlySampledSignal(signal=np.arange(50.0) * pq.mV,
+                                          times=anasig.times, t_start=.1 * pq.s)
         st = SpikeTrain(np.arange(0.5, 50, 7) * pq.s, t_start=.1 * pq.s, t_stop=50.0 * pq.s,
                         waveforms=np.array([[[0., 1.], [0.1, 1.1]], [[2., 3.], [2.1, 3.1]],
                                             [[4., 5.], [4.1, 5.1]], [[6., 7.], [6.1, 7.1]],
@@ -810,6 +812,7 @@ class TestSegment(unittest.TestCase):
         seg.epochs = [epoch2]
         seg.events = [event]
         seg.analogsignals = [anasig]
+        seg.irregularlysampledsignals = [irrsig]
         seg.spiketrains = [st]
 
         block = Block()
@@ -824,6 +827,7 @@ class TestSegment(unittest.TestCase):
         self.assertEqual(len(sliced.events), 1)
         self.assertEqual(len(sliced.spiketrains), 1)
         self.assertEqual(len(sliced.analogsignals), 1)
+        self.assertEqual(len(sliced.irregularlysampledsignals), 1)
         self.assertEqual(len(sliced.epochs), 1)
 
         assert_same_attributes(sliced.spiketrains[0],
@@ -831,6 +835,9 @@ class TestSegment(unittest.TestCase):
                                              t_stop=time_slice[1]))
         assert_same_attributes(sliced.analogsignals[0],
                                anasig.time_slice(t_start=time_slice[0],
+                                                 t_stop=time_slice[1]))
+        assert_same_attributes(sliced.irregularlysampledsignals[0],
+                               irrsig.time_slice(t_start=time_slice[0],
                                                  t_stop=time_slice[1]))
         assert_same_attributes(sliced.events[0],
                                event.time_slice(t_start=time_slice[0],
@@ -843,6 +850,7 @@ class TestSegment(unittest.TestCase):
         seg.epochs = [epoch2]
         seg.events = [event]
         seg.analogsignals = [anasig]
+        seg.irregularlysampledsignals = [irrsig]
         seg.spiketrains = [st]
 
         block = Block()
@@ -857,6 +865,7 @@ class TestSegment(unittest.TestCase):
         self.assertEqual(len(sliced.events), 1)
         self.assertEqual(len(sliced.spiketrains), 1)
         self.assertEqual(len(sliced.analogsignals), 1)
+        self.assertEqual(len(sliced.irregularlysampledsignals), 1)
         self.assertEqual(len(sliced.epochs), 1)
 
         assert_same_attributes(sliced.spiketrains[0],
@@ -867,6 +876,11 @@ class TestSegment(unittest.TestCase):
         anasig_target = anasig_target.time_shift(- time_slice[0]).time_slice(t_start=0 * pq.s,
                                                  t_stop=time_slice[1] - time_slice[0])
         assert_same_attributes(sliced.analogsignals[0], anasig_target)
+        irrsig_target = irrsig.copy()
+        irrsig_target = irrsig_target.time_shift(- time_slice[0]).time_slice(t_start=0 * pq.s,
+                                                                             t_stop=time_slice[1] -
+                                                                                    time_slice[0])
+        assert_same_attributes(sliced.irregularlysampledsignals[0], irrsig_target)
         assert_same_attributes(sliced.events[0],
                                event.time_shift(- time_slice[0]).time_slice(
                                    t_start=0 * pq.s, t_stop=time_slice[1] - time_slice[0]))

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -988,7 +988,7 @@ class TestTimeSlice(unittest.TestCase):
 
         # Change annotations of original
         params2 = {'test0': ['x{}'.format(i) for i in range(length)],
-                   'test2': [(-1)**(i+1) > 0 for i in range(length)]}
+                   'test2': [(-1) ** (i + 1) > 0 for i in range(length)]}
         self.train1.array_annotate(**params2)
         self.train1.array_annotations['test1'][2] = 'shallowtest'
 
@@ -1231,12 +1231,12 @@ class TestTimeShift(unittest.TestCase):
         self.assertEqual(result.unit, None)
 
     def test__time_shift_by_zero(self):
-        shifted = self.train1.time_shift(0*pq.ms)
+        shifted = self.train1.time_shift(0 * pq.ms)
         assert_arrays_equal(shifted.times, self.train1.times)
 
     def test__time_shift_same_units(self):
         shifted = self.train1.time_shift(10 * pq.ms)
-        assert_arrays_equal(shifted.times, self.train1.times + 10*pq.ms)
+        assert_arrays_equal(shifted.times, self.train1.times + 10 * pq.ms)
 
     def test__time_shift_different_units(self):
         shifted = self.train1.time_shift(1 * pq.s)

--- a/neo/test/test_utils.py
+++ b/neo/test/test_utils.py
@@ -367,9 +367,9 @@ class TestUtilsWithoutProxyObjects(unittest.TestCase):
             self.assertEqual(len(block.segments[epoch_idx].analogsignals), 1)
 
             if epoch_idx != 0:
-                self.assertEqual(len(block.segments[epoch_idx].epochs), 0)
-            else:
                 self.assertEqual(len(block.segments[epoch_idx].epochs), 1)
+            else:
+                self.assertEqual(len(block.segments[epoch_idx].epochs), 2)
 
             assert_same_attributes(block.segments[epoch_idx].spiketrains[0],
                                    st.time_slice(t_start=epoch.times[epoch_idx],
@@ -384,6 +384,9 @@ class TestUtilsWithoutProxyObjects(unittest.TestCase):
                                                     t_stop=epoch.times[epoch_idx]
                                                            + epoch.durations[epoch_idx]))
         assert_same_attributes(block.segments[0].epochs[0],
+                               epoch.time_slice(t_start=epoch.times[0],
+                                                 t_stop=epoch.times[0] + epoch.durations[0]))
+        assert_same_attributes(block.segments[0].epochs[1],
                                epoch2.time_slice(t_start=epoch.times[0],
                                                 t_stop=epoch.times[0] + epoch.durations[0]))
 
@@ -409,9 +412,9 @@ class TestUtilsWithoutProxyObjects(unittest.TestCase):
             self.assertEqual(len(block.segments[epoch_idx].spiketrains), 1)
             self.assertEqual(len(block.segments[epoch_idx].analogsignals), 1)
             if epoch_idx != 0:
-                self.assertEqual(len(block.segments[epoch_idx].epochs), 0)
-            else:
                 self.assertEqual(len(block.segments[epoch_idx].epochs), 1)
+            else:
+                self.assertEqual(len(block.segments[epoch_idx].epochs), 2)
 
             assert_same_attributes(block.segments[epoch_idx].spiketrains[0],
                                    st.duplicate_with_new_data(st.times - epoch.times[epoch_idx],
@@ -430,6 +433,11 @@ class TestUtilsWithoutProxyObjects(unittest.TestCase):
                                        t_start=0 * pq.s, t_stop=epoch.durations[epoch_idx]))
 
         assert_same_attributes(block.segments[0].epochs[0],
+                               epoch.duplicate_with_new_data(epoch.times - epoch.times[0],
+                                                              epoch.durations,
+                                                              epoch.labels)
+                               .time_slice(t_start=0 * pq.s, t_stop=epoch.durations[0]))
+        assert_same_attributes(block.segments[0].epochs[1],
                                epoch2.duplicate_with_new_data(epoch2.times - epoch.times[0],
                                                               epoch2.durations,
                                                               epoch2.labels)

--- a/neo/utils.py
+++ b/neo/utils.py
@@ -49,11 +49,9 @@ def get_events(container, **properties):
 
     Example:
     --------
-        >>> event = neo.Event(
-                times = [0.5, 10.0, 25.2] * pq.s)
-        >>> event.annotate(
-                event_type = 'trial start',
-                trial_id = [1, 2, 3])
+        >>> event = neo.Event(times=[0.5, 10.0, 25.2] * pq.s)
+        >>> event.annotate(event_type='trial start',
+                           trial_id=[1, 2, 3])
         >>> seg = neo.Segment()
         >>> seg.events = [event]
 
@@ -120,12 +118,10 @@ def get_epochs(container, **properties):
 
     Example:
     --------
-        >>> epoch = neo.Epoch(
-                times = [0.5, 10.0, 25.2] * pq.s,
-                durations = [100, 100, 100] * pq.ms)
-        >>> epoch.annotate(
-                event_type = 'complete trial',
-                trial_id = [1, 2, 3]
+        >>> epoch = neo.Epoch(times=[0.5, 10.0, 25.2] * pq.s,
+                              durations = [100, 100, 100] * pq.ms)
+        >>> epoch.annotate(event_type='complete trial',
+                           trial_id=[1, 2, 3])
         >>> seg = neo.Segment()
         >>> seg.epochs = [epoch]
 

--- a/neo/utils.py
+++ b/neo/utils.py
@@ -703,7 +703,7 @@ def seg_time_slice(seg, t_start=None, t_stop=None, reset_time=False, **kwargs):
         elif isinstance(seg.events[ev_id], neo.io.proxyobjects.EventProxy):
             ev_time_slice = seg.events[ev_id].load(time_slice=(t_start, t_stop))
         if reset_time:
-            ev_time_slice = shift_event(ev_time_slice, t_shift)
+            ev_time_slice = ev_time_slice.time_shift(t_shift)
         # appending only non-empty events
         if len(ev_time_slice):
             subseg.events.append(ev_time_slice)
@@ -715,7 +715,7 @@ def seg_time_slice(seg, t_start=None, t_stop=None, reset_time=False, **kwargs):
         elif isinstance(seg.epochs[ep_id], neo.io.proxyobjects.EpochProxy):
             ep_time_slice = seg.epochs[ep_id].load(time_slice=(t_start, t_stop))
         if reset_time:
-            ep_time_slice = shift_epoch(ep_time_slice, t_shift)
+            ep_time_slice = ep_time_slice.time_shift(t_shift)
         # appending only non-empty epochs
         if len(ep_time_slice):
             subseg.epochs.append(ep_time_slice)
@@ -746,57 +746,3 @@ def shift_spiketrain(spiketrain, t_shift):
         t_start=spiketrain.t_start + t_shift,
         t_stop=spiketrain.t_stop + t_shift)
     return new_st
-
-
-def shift_event(ev, t_shift):
-    """
-    Shifts an event by an amount of time.
-
-    Parameters:
-    -----------
-    event: Event
-        Event of which a copy will be generated with shifted times
-    t_shift: Quantity (time)
-        Amount of time by which to shift the Event.
-
-    Returns:
-    --------
-    epoch: Event
-        New instance of an Event object starting at t_shift later than the
-        original Event (the original Event is not modified).
-    """
-    return _shift_time_signal(ev, t_shift)
-
-
-def shift_epoch(epoch, t_shift):
-    """
-    Shifts an epoch by an amount of time.
-
-    Parameters:
-    -----------
-    epoch: Epoch
-        Epoch of which a copy will be generated with shifted times
-    t_shift: Quantity (time)
-        Amount of time by which to shift the Epoch.
-
-    Returns:
-    --------
-    epoch: Epoch
-        New instance of an Epoch object starting at t_shift later than the
-        original Epoch (the original Epoch is not modified).
-    """
-    return epoch.duplicate_with_new_data(times=epoch.times + t_shift,
-                                         durations=epoch.durations,
-                                         labels=epoch.labels)
-
-
-def _shift_time_signal(sig, t_shift):
-    """
-    Internal function.
-    """
-    if not hasattr(sig, 'times'):
-        raise AttributeError(
-            'Can only shift signals, which have an attribute'
-            ' "times", not %s' % type(sig))
-    new_sig = sig.duplicate_with_new_data(signal=sig.times + t_shift)
-    return new_sig

--- a/neo/utils.py
+++ b/neo/utils.py
@@ -683,7 +683,7 @@ def seg_time_slice(seg, t_start=None, t_stop=None, reset_time=False, **kwargs):
         elif isinstance(seg.analogsignals[ana_id], neo.io.proxyobjects.AnalogSignalProxy):
             ana_time_slice = seg.analogsignals[ana_id].load(time_slice=(t_start, t_stop))
         if reset_time:
-            ana_time_slice.t_start = ana_time_slice.t_start + t_shift
+            ana_time_slice = ana_time_slice.time_shift(t_shift)
         subseg.analogsignals.append(ana_time_slice)
 
     # cut spiketrains

--- a/neo/utils.py
+++ b/neo/utils.py
@@ -699,7 +699,7 @@ def seg_time_slice(seg, t_start=None, t_stop=None, reset_time=False, **kwargs):
     # cut events
     for ev_id in range(len(seg.events)):
         if isinstance(seg.events[ev_id], neo.Event):
-            ev_time_slice = event_time_slice(seg.events[ev_id], t_start, t_stop)
+            ev_time_slice = seg.events[ev_id].time_slice(t_start, t_stop)
         elif isinstance(seg.events[ev_id], neo.io.proxyobjects.EventProxy):
             ev_time_slice = seg.events[ev_id].load(time_slice=(t_start, t_stop))
         if reset_time:
@@ -711,7 +711,7 @@ def seg_time_slice(seg, t_start=None, t_stop=None, reset_time=False, **kwargs):
     # cut epochs
     for ep_id in range(len(seg.epochs)):
         if isinstance(seg.epochs[ep_id], neo.Epoch):
-            ep_time_slice = epoch_time_slice(seg.epochs[ep_id], t_start, t_stop)
+            ep_time_slice = seg.epochs[ep_id].time_slice(t_start, t_stop)
         elif isinstance(seg.epochs[ep_id], neo.io.proxyobjects.EpochProxy):
             ep_time_slice = seg.epochs[ep_id].load(time_slice=(t_start, t_stop))
         if reset_time:
@@ -746,70 +746,6 @@ def shift_spiketrain(spiketrain, t_shift):
         t_start=spiketrain.t_start + t_shift,
         t_stop=spiketrain.t_stop + t_shift)
     return new_st
-
-
-def event_time_slice(event, t_start=None, t_stop=None):
-    """
-    Slices an Event object to retain only those events that fall in a certain
-    time window.
-
-    Parameters:
-    -----------
-    event: Event
-        The Event to slice.
-    t_start, t_stop: Quantity (time)
-        Time window in which to retain events. An event at time t is retained
-        if t_start <= t < t_stop.
-
-    Returns:
-    --------
-    event: Event
-        New instance of an Event object containing only the events in the time
-        range.
-    """
-    if t_start is None:
-        t_start = -np.inf
-    if t_stop is None:
-        t_stop = np.inf
-
-    valid_ids = np.where(np.logical_and(
-        event.times >= t_start, event.times < t_stop))[0]
-
-    new_event = _event_epoch_slice_by_valid_ids(event, valid_ids=valid_ids)
-
-    return new_event
-
-
-def epoch_time_slice(epoch, t_start=None, t_stop=None):
-    """
-    Slices an Epoch object to retain only those epochs that fall in a certain
-    time window.
-
-    Parameters:
-    -----------
-    epoch: Epoch
-        The Epoch to slice.
-    t_start, t_stop: Quantity (time)
-        Time window in which to retain epochs. An epoch at time t and
-        duration d is retained if t_start <= t < t_stop - d.
-
-    Returns:
-    --------
-    epoch: Epoch
-        New instance of an Epoch object containing only the epochs in the time
-        range.
-    """
-    if t_start is None:
-        t_start = -np.inf
-    if t_stop is None:
-        t_stop = np.inf
-
-    valid_ids = np.where(np.logical_and(
-        epoch.times >= t_start, epoch.times + epoch.durations < t_stop))[0]
-
-    new_epoch = _event_epoch_slice_by_valid_ids(epoch, valid_ids=valid_ids)
-
-    return new_epoch
 
 
 def shift_event(ev, t_shift):

--- a/neo/utils.py
+++ b/neo/utils.py
@@ -693,7 +693,7 @@ def seg_time_slice(seg, t_start=None, t_stop=None, reset_time=False, **kwargs):
         elif isinstance(seg.spiketrains[st_id], neo.io.proxyobjects.SpikeTrainProxy):
             st_time_slice = seg.spiketrains[st_id].load(time_slice=(t_start, t_stop))
         if reset_time:
-            st_time_slice = shift_spiketrain(st_time_slice, t_shift)
+            st_time_slice = st_time_slice.time_shift(t_shift)
         subseg.spiketrains.append(st_time_slice)
 
     # cut events
@@ -721,28 +721,3 @@ def seg_time_slice(seg, t_start=None, t_stop=None, reset_time=False, **kwargs):
             subseg.epochs.append(ep_time_slice)
 
     return subseg
-
-
-def shift_spiketrain(spiketrain, t_shift):
-    """
-    Shifts a spike train to start at a new time.
-
-    Parameters:
-    -----------
-    spiketrain: SpikeTrain
-        Spiketrain of which a copy will be generated with shifted spikes and
-        starting and stopping times
-    t_shift: Quantity (time)
-        Amount of time by which to shift the SpikeTrain.
-
-    Returns:
-    --------
-    spiketrain: SpikeTrain
-        New instance of a SpikeTrain object starting at t_start (the original
-        SpikeTrain is not modified).
-    """
-    new_st = spiketrain.duplicate_with_new_data(
-        signal=spiketrain.times.view(pq.Quantity) + t_shift,
-        t_start=spiketrain.t_start + t_shift,
-        t_stop=spiketrain.t_stop + t_shift)
-    return new_st


### PR DESCRIPTION
As suggested by @apdavison in #657 I turned utility functions that operate on single objects into methods of the respective classes. Time-shifting and -slicing deep-copies the object and thus destroys links to parents as discussed in #668 .

I circumnavigated import-cycles by identifying proxy-objects by their `_rawio` attribute instead of an explicit `isinstance`. I'm open to suggestions on how to do this more elegantly.

While adding `IrregularlySampledSignals` to `Segment.time_slice` I noticed that there is no proxy-object for them. The code should still work if and when they are added.