### PR TITLE
Fix merge behaviour

### DIFF
--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -392,3 +392,15 @@ class BaseNeo(object):
         See :meth:`merge_annotations` for details of the merge operation.
         """
         self.merge_annotations(other)
+
+    def set_parent(self, obj):
+        """
+        Set the appropriate "parent" attribute of this object
+        according to the type of "obj"
+        """
+        if obj.__class__.__name__ not in self._single_parent_objects:
+            raise TypeError("{} can only have parents of type {}, not {}".format(
+                self.__class__.__name__, self._single_parent_objects, obj.__class__.__name__))
+        loc = self._single_parent_objects.index(obj.__class__.__name__)
+        parent_attr = self._single_parent_attrs[loc]
+        setattr(self, parent_attr, obj)

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -562,6 +562,9 @@ class Container(BaseNeo):
 
         Annotations are merged such that only items not present in the current
         annotations are added.
+
+        Note that the `other` object will be in an inconsistent state after the
+        merge operation and should not be used further.
         """
         # merge containers with the same name
         for container in (self._container_child_containers +

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -585,8 +585,8 @@ class Container(BaseNeo):
             ids = [id(obj) for obj in objs]
             for obj in getattr(other, container):
                 if id(obj) in ids:
-                    continue
-                if hasattr(obj, 'merge') and obj.name is not None and obj.name in lookup:
+                    pass
+                elif hasattr(obj, 'merge') and obj.name is not None and obj.name in lookup:
                     ind = lookup[obj.name]
                     try:
                         newobj = getattr(self, container)[ind].merge(obj)
@@ -598,6 +598,7 @@ class Container(BaseNeo):
                     lookup[obj.name] = obj
                     ids.append(id(obj))
                     getattr(self, container).append(obj)
+                obj.set_parent(self)
 
         # use the BaseNeo merge as well
         super(Container, self).merge(other)

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -563,8 +563,8 @@ class Container(BaseNeo):
         Annotations are merged such that only items not present in the current
         annotations are added.
 
-        Note that the `other` object will be in an inconsistent state after the
-        merge operation and should not be used further.
+        Note that the other object will be linked inconsistently to other Neo objects
+        after the merge operation and should not be used further.
         """
         # merge containers with the same name
         for container in (self._container_child_containers +

--- a/neo/test/coretest/test_channelindex.py
+++ b/neo/test/coretest/test_channelindex.py
@@ -207,7 +207,6 @@ class TestChannelIndex(unittest.TestCase):
         chx1a.annotate(seed=self.seed2)
         chx1a.analogsignals.append(self.sigarrs2[0])
         chx1a.merge(self.chx2)
-        self.check_creation(self.chx2)
 
         assert_same_sub_schema(self.sigarrs1a + self.sigarrs2,
                                chx1a.analogsignals,

--- a/neo/test/coretest/test_segment.py
+++ b/neo/test/coretest/test_segment.py
@@ -235,9 +235,7 @@ class TestSegment(unittest.TestCase):
         seg1a = fake_neo(Block, seed=self.seed1, n=self.nchildren).segments[0]
         assert_same_sub_schema(self.seg1, seg1a)
         seg1a.epochs.append(self.epcs2[0])
-        seg1a.annotate(seed=self.seed2)
         seg1a.merge(self.seg2)
-        self.check_creation(self.seg2)
 
         assert_same_sub_schema(self.sigarrs1a + self.sigarrs2,
                                seg1a.analogsignals)

--- a/neo/test/coretest/test_unit.py
+++ b/neo/test/coretest/test_unit.py
@@ -135,7 +135,6 @@ class TestUnit(unittest.TestCase):
         unit1a.annotate(seed=self.seed2)
         unit1a.spiketrains.append(self.trains2[0])
         unit1a.merge(self.unit2)
-        self.check_creation(self.unit2)
 
         assert_same_sub_schema(self.trains1a + self.trains2,
                                unit1a.spiketrains)

--- a/neo/test/tools.py
+++ b/neo/test/tools.py
@@ -156,7 +156,7 @@ def assert_neo_object_is_compliant(ob, check_type=True):
                              '' % (container, _reference_name(classname))
             if hasattr(child, _reference_name(classname)):
                 parent = getattr(child, _reference_name(classname))
-                assert parent == ob, '%s.%s %s is not symetric with %s.%s' \
+                assert parent == ob, '%s.%s %s is not symmetric with %s.%s' \
                                      '' % (container, _reference_name(classname), i, classname,
                                            container)
 


### PR DESCRIPTION
When merging two container objects, the children merged from the other container into the target container should have the appropriate parent attribute set to reference the target.

Example:

After `seg1.merge(seg2)`, we expect that all the AnalogSignal objects in `seg1.analogsignals` should have `sig.segment == seg1`, whether `sig` was originally in `seg1.analogsignals` or `seg2.analogsignals`.

After the operation, `seg2` will be in an inconsistent state, but I think this is ok, as I wouldn't normally expect to continue using an object after merging it into another. The alternative is to take a copy of `seg2` before merging it, but this would likely have a bad effect on the performance of `merge()` for little benefit.