### PR TITLE
switch to tuples in chan_id in neuralynxrawio.py

### DIFF
--- a/doc/source/authors.rst
+++ b/doc/source/authors.rst
@@ -43,8 +43,8 @@ and may not be the current affiliation of a contributor.
 * Jeffrey Gill [18]
 * Lucas (lkoelman@github)
 * Mark Histed
-* Mike Sintsov
-* Scott W Harden [19]
+* Mike Sintsov [19]
+* Scott W Harden [20]
 
 1. Centre de Recherche en Neuroscience de Lyon, CNRS UMR5292 - INSERM U1028 - Universite Claude Bernard Lyon 1
 2. Unité de Neuroscience, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France
@@ -64,6 +64,7 @@ and may not be the current affiliation of a contributor.
 16. Ottawa Hospital Research Institute, Canada
 17. Swinburne University of Technology, Australia
 18. Case Western Reserve University (CWRU) · Department of Biology
-19. Harden Technologies, LLC
+19. IAL Developmental Neurobiology, Kazan Federal University, Kazan, Russia
+20. Harden Technologies, LLC
 
 If we've somehow missed you off the list we're very sorry - please let us know.

--- a/neo/test/iotest/test_neuralynxio.py
+++ b/neo/test/iotest/test_neuralynxio.py
@@ -224,8 +224,10 @@ class TestData(CommonNeuralynxIOTest, unittest.TestCase):
             block = nio.read_block()
 
             for anasig_id, anasig in enumerate(block.segments[0].analogsignals):
-                chid = anasig.channel_index.annotations['channel_id'][anasig_id]
-                filename = nio.ncs_filenames[chid][:-3] + 'txt'
+                chid = anasig.channel_index.channel_ids[anasig_id]
+                chname = anasig.channel_index.channel_names[anasig_id].decode('UTF-8') # need to decode, unless keyerror
+                chuid = (chname, chid)
+                filename = nio.ncs_filenames[chuid][:-3] + 'txt'
                 filename = filename.replace('original_data', 'plain_data')
                 plain_data = np.loadtxt(filename)[:, 5:].flatten()  # first columns are meta info
                 overlap = 512 * 500


### PR DESCRIPTION
@samuelgarcia 

As we discussed in #591, I've switched to tuples in memmaps, because channel IDs are not unique for the acquisition, but the channel names are. The thing is that NLX allows to set different preprocessing parameters for each channel ID and create new files, e.g. one file contains highpassed data for spikes, second - true DC recording, third - common channel with LFP 0.1Hz-100Hz, etc. And they all could be collected from the same channel ID!

Note, CSC1 and CSC33 have the same ID, but different gains (also different highpass parameters)
![image](https://user-images.githubusercontent.com/4338049/60384063-1a595980-9a82-11e9-8259-2d49179edf6a.png)

An example of simultaneous recording of DC and AC from the same channel ID
![image](https://user-images.githubusercontent.com/4338049/60384017-b6369580-9a81-11e9-9160-d8b0f5ee3797.png)

Now, memmaps and dicts have the following structure:
![image](https://user-images.githubusercontent.com/4338049/60384091-512f6f80-9a82-11e9-9568-f730f984cef3.png)









