### PR TITLE
Suggestion: Add time_slice method to all proxy objects

### DIFF
--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -37,7 +37,7 @@ class BaseProxy(BaseNeo):
 
         BaseNeo.__init__(self, **annotations)
 
-    def load(self, time_slice):
+    def load(self, time_slice=None, **kwargs):
         # should be implemented by subclass
         raise NotImplementedError
 

--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -37,6 +37,17 @@ class BaseProxy(BaseNeo):
 
         BaseNeo.__init__(self, **annotations)
 
+    def load(self, time_slice):
+        # should be implemented by subclass
+        raise NotImplementedError
+
+    def time_slice(self, t_start, t_stop):
+        '''
+        Load the proxy object within the specified time range. Has the same
+        call signature as AnalogSignal.time_slice, Epoch.time_slice, etc.
+        '''
+        return self.load(time_slice=(t_start, t_stop))
+
 
 class AnalogSignalProxy(BaseProxy):
     '''


### PR DESCRIPTION
I was wondering what people think about adding a `time_slice` method to all proxy objects?

They already have `load(time_slice=(t_start, t_stop), ...)`, but this call signature differs from the `time_slice(t_start, t_stop)` call signature used by non-proxy objects. It would be nice to have identical call signatures for both proxy and non-proxy objects so that code that uses them can be agnostic about whether the object has already be loaded into memory or not.

For example,

```python
import neo
io = neo.io.get_io(filename)
blk = io.read_block(lazy=True)  # or lazy=False
sig = blk.segments[0].analogsignals[0]
sig.time_slice(0*pq.s, 5*pq.s)
```

could just work for both `lazy = True` and `lazy = False`.

This pull request implements the simplest solution I could think of, which is basically to add this to `BaseProxy`:

```python
def time_slice(self, t_start, t_stop):
    '''
    Load the proxy object within the specified time range. Has the same
    call signature as AnalogSignal.time_slice, Epoch.time_slice, etc.
    '''
    return self.load(time_slice=(t_start, t_stop))
```

The call signature `time_slice(t_start, t_stop)` doesn't provide the user with access to all of the `load` method's other parameters (`channel_indexes`, `magnitude_mode`, etc.) because the non-proxy versions of `load` do not have these things.

I haven't added any tests to the pull request because I wanted to get others' reactions first.