### PR TITLE
Fix error when Neuralynx application version is not specified.

### DIFF
--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -628,7 +628,7 @@ def read_txt_header(filename):
             'Number of channel ids does not match input range values.'
 
     # filename and datetime
-    if info['version'] <= distutils.version.LooseVersion('5.6.4'):
+    if 'version' in info and info['version'] <= distutils.version.LooseVersion('5.6.4'):
         datetime1_regex = r'## Time Opened \(m/d/y\): (?P<date>\S+)  \(h:m:s\.ms\) (?P<time>\S+)'
         datetime2_regex = r'## Time Closed \(m/d/y\): (?P<date>\S+)  \(h:m:s\.ms\) (?P<time>\S+)'
         filename_regex = r'## File Name (?P<filename>\S+)'


### PR DESCRIPTION
I'm attempting to read Neuralynx Events.nev files, which don't specify version the same way as other files (e.g., .ncs). neo.rawio.neuralynxrawio.read_txt_header crashes on these files.

In a block earlier in the same function, there is a check of `if 'version' in info:`, but there is no check later on in the function. I've just added another check to that later if statement to make it consistent and avoid an error when a version isn't read from the header.

Sample file that fails on commit c442ae7 of the master branch:
[Events_0008.nev.zip](https://github.com/NeuralEnsemble/python-neo/files/3379104/Events_0008.nev.zip)

Attempting to read the header of this file:
In [2]: nlxio                                                                                                            
Out[2]: <module 'neo.rawio.neuralynxrawio' from '/Users/morton/analysis/python-neo/neo/rawio/neuralynxrawio.py'>

In [3]: info = nlxio.read_txt_header('/Volumes/Monolith/data/ecog/DS1902/nlx/2019-06-28_17-36-50/Events_0008.nev')       
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-3-20b968c4aaab> in <module>
----> 1 info = nlxio.read_txt_header('/Volumes/Monolith/data/ecog/DS1902/nlx/2019-06-28_17-36-50/Events_0008.nev')

~/analysis/python-neo/neo/rawio/neuralynxrawio.py in read_txt_header(filename)
    629 
    630     # filename and datetime
--> 631     if info['version'] <= distutils.version.LooseVersion('5.6.4'):
    632         datetime1_regex = r'## Time Opened \(m/d/y\): (?P<date>\S+)  \(h:m:s\.ms\) (?P<time>\S+)'
    633         datetime2_regex = r'## Time Closed \(m/d/y\): (?P<date>\S+)  \(h:m:s\.ms\) (?P<time>\S+)'

KeyError: 'version'
