### PR TITLE
Fix for duration of signals in `generate_one_simple_segment`

### DIFF
--- a/neo/test/generate_datasets.py
+++ b/neo/test/generate_datasets.py
@@ -64,7 +64,7 @@ def generate_one_simple_segment(seg_name='segment 0', supported_objects=[], nb_a
     seg = Segment(name=seg_name)
     if AnalogSignal in supported_objects:
         for a in range(nb_analogsignal):
-            anasig = AnalogSignal(rand(int(sampling_rate * duration)), sampling_rate=sampling_rate,
+            anasig = AnalogSignal(rand(int((sampling_rate * duration).simplified)), sampling_rate=sampling_rate,
                                   t_start=t_start, units=pq.mV, channel_index=a,
                                   name='sig %d for segment %s' % (a, seg.name))
             seg.analogsignals.append(anasig)

--- a/neo/test/generate_datasets.py
+++ b/neo/test/generate_datasets.py
@@ -64,7 +64,8 @@ def generate_one_simple_segment(seg_name='segment 0', supported_objects=[], nb_a
     seg = Segment(name=seg_name)
     if AnalogSignal in supported_objects:
         for a in range(nb_analogsignal):
-            anasig = AnalogSignal(rand(int((sampling_rate * duration).simplified)), sampling_rate=sampling_rate,
+            anasig = AnalogSignal(rand(int((sampling_rate * duration).simplified)),
+                                  sampling_rate=sampling_rate,
                                   t_start=t_start, units=pq.mV, channel_index=a,
                                   name='sig %d for segment %s' % (a, seg.name))
             seg.analogsignals.append(anasig)


### PR DESCRIPTION
The default `sampling_rate` has units kHz, and the default `duration` has units s. By dropping units from their product without first simplifying, the number of data points was off by a factor of 1000. Consequently, the default 6 second signal was instead 6 milliseconds long.