### PR TITLE
[nixio] Discard 'neo_name' property on read

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -1160,7 +1160,9 @@ class NixIO(BaseIO):
                 else:
                     values = list(values)
                 neo_attrs[prop.name] = values
-        neo_attrs["name"] = stringify(neo_attrs.get("neo_name"))
+        # since the 'neo_name' NIX property becomes the actual object's name,
+        # there's no reason to keep it in the annotations
+        neo_attrs["name"] = stringify(neo_attrs.pop("neo_name", None))
 
         if "file_datetime" in neo_attrs:
             neo_attrs["file_datetime"] = datetime.fromtimestamp(


### PR DESCRIPTION
Small modification of the naming scheme described in PR #331:
In step 4, upon reading the 'neo_name' property and restoring the original Neo object's name, the 'neo_name' attribute is now discarded.  Since we already restore this to the name of the object, there's no need to keep it around in the object's annotations.  More importantly, it would create a conflict on rewrite of an object, since the creation of the property is handled explicitly, outside of the general annotation conversion function.

Fixes #694