### PR TITLE
Write Proxyobjects with NixIO

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -1004,9 +1004,9 @@ class NixIO(BaseIO):
             wftime.unit = units_to_string(spiketrain.sampling_period.units)
             wftime.label = "time"
 
-        if spiketrain.left_sweep is not None:
-            self._write_property(wfda.metadata, "left_sweep",
-                                 spiketrain.left_sweep)
+            if spiketrain.left_sweep is not None:
+                self._write_property(wfda.metadata, "left_sweep",
+                                     spiketrain.left_sweep)
 
     def _write_unit(self, neounit, nixchxsource):
         """

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -34,7 +34,7 @@ import numpy as np
 from .baseio import BaseIO
 from ..core import (Block, Segment, ChannelIndex, AnalogSignal,
                     IrregularlySampledSignal, Epoch, Event, SpikeTrain, Unit)
-from ..io.basefromrawio.proxyobjects import BaseProxy
+from ..io.proxyobjects import BaseProxy
 from ..version import version as neover
 
 try:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -703,7 +703,6 @@ class NixIO(BaseIO):
                                            "neo.analogsignal.metadata")
         nixdas = list()
         for idx, row in enumerate(data):
-            print(idx)
             daname = "{}.{}".format(nix_name, idx)
             da = nixblock.create_data_array(daname, "neo.analogsignal",
                                             data=row)

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -823,9 +823,11 @@ class NixIO(BaseIO):
             full_event = event.load()
             times = full_event.times.magnitude
             units = units_to_string(full_event.times.units)
+            labels = full_event.labels
         else:
             times = event.times.magnitude
             units = units_to_string(event.times.units)
+            labels = event.labels
         timesda = nixblock.create_data_array(
             "{}.times".format(nix_name), "neo.event.times", data=times
         )
@@ -839,7 +841,7 @@ class NixIO(BaseIO):
         metadata = nixmt.metadata
 
         labeldim = timesda.append_set_dimension()
-        labeldim.labels = event.labels
+        labeldim.labels = labels
 
         neoname = event.name if event.name is not None else ""
         metadata["neo_name"] = neoname
@@ -947,9 +949,11 @@ class NixIO(BaseIO):
             full_spiketrain = spiketrain.load()
             times = full_spiketrain.times.magnitude
             tunits = units_to_string(full_spiketrain.times.units)
+            waveforms = full_spiketrain.waveforms
         else:
             times = spiketrain.times.magnitude
             tunits = units_to_string(spiketrain.times.units)
+            waveforms = spiketrain.waveforms
 
         timesda = nixblock.create_data_array("{}.times".format(nix_name),
                                              "neo.spiketrain.times", data=times)
@@ -976,7 +980,7 @@ class NixIO(BaseIO):
         if nixgroup:
             nixgroup.multi_tags.append(nixmt)
 
-        if spiketrain.waveforms is not None:
+        if waveforms is not None:
             wfdata = list(wf.magnitude for wf in
                           list(wfgroup for wfgroup in
                                spiketrain.waveforms))

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -819,14 +819,11 @@ class NixIO(BaseIO):
             return
 
         if isinstance(event, BaseProxy):
-            full_event = event.load()
-            times = full_event.times.magnitude
-            units = units_to_string(full_event.times.units)
-            labels = full_event.labels
-        else:
-            times = event.times.magnitude
-            units = units_to_string(event.times.units)
-            labels = event.labels
+            event = event.load()
+
+        times = event.times.magnitude
+        units = units_to_string(event.times.units)
+        labels = event.labels
         timesda = nixblock.create_data_array(
             "{}.times".format(nix_name), "neo.event.times", data=times
         )
@@ -878,14 +875,12 @@ class NixIO(BaseIO):
             return
 
         if isinstance(epoch, BaseProxy):
-            full_epoch = epoch.load()
-            times = full_epoch.times.magnitude
-            tunits = units_to_string(full_epoch.times.units)
-        else:
-            times = epoch.times.magnitude
-            tunits = units_to_string(epoch.times.units)
+            epoch = epoch.load()
+        times = epoch.times.magnitude
+        tunits = units_to_string(epoch.times.units)
         durations = epoch.durations.magnitude
         dunits = units_to_string(epoch.durations.units)
+
 
         timesda = nixblock.create_data_array(
             "{}.times".format(nix_name), "neo.epoch.times", data=times
@@ -945,14 +940,11 @@ class NixIO(BaseIO):
             return
 
         if isinstance(spiketrain, BaseProxy):
-            full_spiketrain = spiketrain.load()
-            times = full_spiketrain.times.magnitude
-            tunits = units_to_string(full_spiketrain.times.units)
-            waveforms = full_spiketrain.waveforms
-        else:
-            times = spiketrain.times.magnitude
-            tunits = units_to_string(spiketrain.times.units)
-            waveforms = spiketrain.waveforms
+            spiketrain = spiketrain.load()
+
+        times = spiketrain.times.magnitude
+        tunits = units_to_string(spiketrain.times.units)
+        waveforms = spiketrain.waveforms
 
         timesda = nixblock.create_data_array("{}.times".format(nix_name),
                                              "neo.spiketrain.times", data=times)

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -1329,9 +1329,11 @@ class NixIOWriteTest(NixIOTest):
             seg.events.append(event)
 
             # add channel index and unit
-            channel = ChannelIndex([0], channel_names=['mychannelname'], channel_ids=[4], name=['testname'])
+            channel = ChannelIndex([0], channel_names=['mychannelname'], channel_ids=[4],
+                                   name=['testname'])
             block.channel_indexes.append(channel)
-            unit = Unit(name='myunit', description='blablabla', file_origin='fileA.nix', myannotation='myannotation')
+            unit = Unit(name='myunit', description='blablabla', file_origin='fileA.nix',
+                        myannotation='myannotation')
             channel.units.append(unit)
             unit.spiketrains.append(spiketrain)
 

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -223,6 +223,8 @@ class NixIOTest(unittest.TestCase):
     def compare_eests_mtags(self, eestlist, mtaglist):
         self.assertEqual(len(eestlist), len(mtaglist))
         for eest in eestlist:
+            if isinstance(eest, (EventProxy, EpochProxy, SpikeTrainProxy)):
+                eest = eest.load()
             mtag = mtaglist[eest.annotations["nix_name"]]
             if isinstance(eest, Epoch):
                 self.compare_epoch_mtag(eest, mtag)
@@ -230,6 +232,8 @@ class NixIOTest(unittest.TestCase):
                 self.compare_event_mtag(eest, mtag)
             elif isinstance(eest, SpikeTrain):
                 self.compare_spiketrain_mtag(eest, mtag)
+            else:
+                self.fail("Stray object")
 
     def compare_epoch_mtag(self, epoch, mtag):
         self.assertEqual(mtag.type, "neo.epoch")


### PR DESCRIPTION
This PR add enables the NixIO to write ProxyObjects by loading them on request and adds a test for this.