### PR TITLE
Improve consistency between Epoch, Event and SpikeTrain

### DIFF
--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -58,10 +58,12 @@ class Epoch(DataObject):
               dtype='|S4')
 
     *Required attributes/properties*:
-        :times: (quantity array 1D) The start times of each time period.
-        :durations: (quantity array 1D or quantity scalar) The length(s) of each time period.
+        :times: (quantity array 1D, numpy array 1D or list) The start times
+           of each time period.
+        :durations: (quantity array 1D, numpy array 1D, list, or quantity scalar)
+           The length(s) of each time period.
            If a scalar, the same value is used for all time periods.
-        :labels: (numpy.array 1D dtype='S') Names or labels for the time periods.
+        :labels: (numpy.array 1D dtype='S' or list) Names or labels for the time periods.
 
     *Recommended attributes/properties*:
         :name: (str) A label for the dataset,
@@ -87,6 +89,10 @@ class Epoch(DataObject):
                 description=None, file_origin=None, array_annotations=None, **annotations):
         if times is None:
             times = np.array([]) * pq.s
+        elif isinstance(times, (list, tuple)):
+            times = np.array(times)
+        if isinstance(durations, (list, tuple)):
+            durations = np.array(durations)
         if durations is None:
             durations = np.array([]) * pq.s
         elif durations.size != times.size:
@@ -112,6 +118,8 @@ class Epoch(DataObject):
                 dim = units.dimensionality
             else:
                 dim = pq.quantity.validate_dimensionality(units)
+        if not hasattr(durations, "dimensionality"):
+            durations = pq.Quantity(durations, dim)
         # check to make sure the units are time
         # this approach is much faster than comparing the
         # reference dimensionality
@@ -189,8 +197,9 @@ class Epoch(DataObject):
         '''
         Get the item or slice :attr:`i`.
         '''
-        obj = Epoch(times=super(Epoch, self).__getitem__(i))
-        obj._copy_data_complement(self)
+        obj = super(Epoch, self).__getitem__(i)
+        #obj = Epoch(times=super(Epoch, self).__getitem__(i))
+        #obj._copy_data_complement(self)
         obj._durations = self.durations[i]
         if self._labels is not None and self._labels.size > 0:
             obj._labels = self.labels[i]
@@ -199,8 +208,11 @@ class Epoch(DataObject):
         try:
             # Array annotations need to be sliced accordingly
             obj.array_annotate(**deepcopy(self.array_annotations_at_index(i)))
+            obj._copy_data_complement(self)
         except AttributeError:  # If Quantity was returned, not Epoch
-            pass
+            obj.times = obj
+            obj.durations = obj._durations
+            obj.labels = obj._labels
         return obj
 
     def __getslice__(self, i, j):

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -198,8 +198,6 @@ class Epoch(DataObject):
         Get the item or slice :attr:`i`.
         '''
         obj = super(Epoch, self).__getitem__(i)
-        #obj = Epoch(times=super(Epoch, self).__getitem__(i))
-        #obj._copy_data_complement(self)
         obj._durations = self.durations[i]
         if self._labels is not None and self._labels.size > 0:
             obj._labels = self.labels[i]

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -213,7 +213,7 @@ class Event(DataObject):
         # Note: Array annotations, including labels, cannot be copied
         # because they are linked to their respective timestamps and length of data can be changed
         # here which would cause inconsistencies
-        for attr in ("_labels", "name", "file_origin", "description",
+        for attr in ("name", "file_origin", "description",
                      "annotations"):
             setattr(self, attr, deepcopy(getattr(other, attr, None)))
 
@@ -225,6 +225,7 @@ class Event(DataObject):
             obj.labels = self._labels
         try:
             obj.array_annotate(**deepcopy(self.array_annotations_at_index(i)))
+            obj._copy_data_complement(self)
         except AttributeError:  # If Quantity was returned, not Event
             obj.times = obj
         return obj

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -55,8 +55,8 @@ class Event(DataObject):
               dtype='|S5')
 
     *Required attributes/properties*:
-        :times: (quantity array 1D) The time of the events.
-        :labels: (numpy.array 1D dtype='S') Names or labels for the events.
+        :times: (quantity array 1D, numpy array 1D or list) The times of the events.
+        :labels: (numpy.array 1D dtype='S' or list) Names or labels for the events.
 
     *Recommended attributes/properties*:
         :name: (str) A label for the dataset.
@@ -81,6 +81,8 @@ class Event(DataObject):
                 file_origin=None, array_annotations=None, **annotations):
         if times is None:
             times = np.array([]) * pq.s
+        elif isinstance(times, (list, tuple)):
+            times = np.array(times)
         if labels is None:
             labels = np.array([], dtype='S')
         else:
@@ -224,7 +226,7 @@ class Event(DataObject):
         try:
             obj.array_annotate(**deepcopy(self.array_annotations_at_index(i)))
         except AttributeError:  # If Quantity was returned, not Event
-            pass
+            obj.times = obj
         return obj
 
     def set_labels(self, labels):

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -161,6 +161,16 @@ class TestEpoch(unittest.TestCase):
         assert_arrays_equal(epc.labels,
                             np.array(['test epoch 1', 'test epoch 2', 'test epoch 3'], dtype='S'))
 
+    def test_Epoch_creation_from_lists(self):
+        epc = Epoch([1.1, 1.5, 1.7],
+                    [20.0, 20.0, 20.0],
+                    ['test event 1', 'test event 2', 'test event 3'],
+                    units=pq.ms)
+        assert_arrays_equal(epc.times, [1.1, 1.5, 1.7] * pq.ms)
+        assert_arrays_equal(epc.durations, [20.0, 20.0, 20.0] * pq.ms)
+        assert_arrays_equal(epc.labels,
+                            np.array(['test event 1', 'test event 2', 'test event 3']))
+
     def test_Epoch_repr(self):
         params = {'test2': 'y1', 'test3': True}
         epc = Epoch([1.1, 1.5, 1.7] * pq.ms, durations=[20, 40, 60] * pq.ns,
@@ -654,13 +664,13 @@ class TestEpoch(unittest.TestCase):
         self.assertIsInstance(epc_as_q, pq.Quantity)
         assert_array_equal(times * pq.ms, epc_as_q)
 
-    def test_getitem(self):
+    def test_getitem_scalar(self):
         times = [2, 3, 4, 5]
         durations = [0.1, 0.2, 0.3, 0.4]
         labels = ["A", "B", "C", "D"]
         epc = Epoch(times * pq.ms, durations=durations * pq.ms, labels=labels)
         single_epoch = epc[2]
-        self.assertIsInstance(single_epoch, Epoch)
+        self.assertIsInstance(single_epoch, pq.Quantity)
         assert_array_equal(single_epoch.times, np.array([4.0]))
         assert_array_equal(single_epoch.durations, np.array([0.3]))
         assert_array_equal(single_epoch.labels, np.array(["C"]))

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -146,11 +146,13 @@ class TestEvent(unittest.TestCase):
         self.assertRaises(ValueError, Event, [1.1, 1.5, 1.7] * pq.ms,
                           labels=["A", "B"])
 
-    def test_Epoch_creation_scalar_duration(self):
-        # test with scalar for durations
-        epc = Epoch([1.1, 1.5, 1.7] * pq.ms, durations=20 * pq.ns,
-                    labels=np.array(['test epoch 1', 'test epoch 2', 'test epoch 3'], dtype='S'))
-        assert_neo_object_is_compliant(epc)
+    def test_Event_creation_from_lists(self):
+        evt = Event([1.1, 1.5, 1.7],
+                    ['test event 1', 'test event 2', 'test event 3'],
+                    units=pq.ms)
+        assert_arrays_equal(evt.times, [1.1, 1.5, 1.7] * pq.ms)
+        assert_arrays_equal(evt.labels,
+                            np.array(['test event 1', 'test event 2', 'test event 3']))
 
     def tests_time_slice(self):
 


### PR DESCRIPTION
* all can be created with lists (provided the units parameter is provided), not just with arrays
* `obj.__getitem__` with a scalar argument returns a Quantity
* `obj.__getitem__` with a slice or array argument returns an object of the same type

cf #490 