### PR TITLE
Add list of implemented RawIO classes to docs

### DIFF
--- a/doc/source/io_developers_guide.rst
+++ b/doc/source/io_developers_guide.rst
@@ -13,7 +13,7 @@ Guidelines for IO implementation
 There are two ways to add a new IO module:
   * By directly adding a new IO class in a module within :mod:`neo.io`: the reader/writer will deal directly with Neo objects
   * By adding a RawIO class in a module within :mod:`neo.rawio`: the reader should work with raw buffers from the file and provide
-    some internal headers for the scale/units/name/... 
+    some internal headers for the scale/units/name/...
     You can then generate an IO module simply by inheriting from your RawIO class and from :class:`neo.io.BaseFromRaw`
 
 For read only classes, we encourage you to write a :class:`RawIO` class because it allows slice reading,
@@ -64,7 +64,7 @@ Each test must have at least one class that inherits ``BaseTestRawIO`` and that 
 
 Here is an example test script taken from the distribution: :file:`test_axonrawio.py`:
 
-.. literalinclude:: ../../neo/rawio/tests/test_axonrawio.py
+.. literalinclude:: ../../neo/test/rawiotest/test_axonrawio.py
 
 
 Logging

--- a/doc/source/rawio.rst
+++ b/doc/source/rawio.rst
@@ -14,7 +14,7 @@ For performance and memory consumption reasons a new layer has been added to Neo
 
 In brief:
     * **neo.io** is the user-oriented read/write layer. Reading consists of getting a tree
-      of Neo objects from a data source (file, url, or directory). 
+      of Neo objects from a data source (file, url, or directory).
       When  reading, all Neo objects are correctly scaled to the correct units.
       Writing consists of making a set of Neo objects persistent in a file format.
     * **neo.rawio** is a low-level layer for reading data only. Reading consists of getting
@@ -23,7 +23,7 @@ In brief:
       Here the underlying objects must be consistent across Blocks and Segments for a given
       data source.
 
-      
+
 The neo.rawio API has been added for developers.
 The neo.rawio is close to what could be a C API for reading data but in Python/NumPy.
 
@@ -49,14 +49,14 @@ The :mod:`neo.rawio` API is less flexible than :mod:`neo.io` and has some limita
   * Units must have SpikeTrain event if empty across all Block and Segment
   * Epoch and Event are processed the same way (with ``durations=None`` for Event).
 
-    
+
 For an intuitive comparison of :mod:`neo.io` and :mod:`neo.rawio` see:
   * :file:`example/read_file_neo_io.py`
   * :file:`example/read_file_neo_rawio.py`
 
-  
-One speculative benefit of the :mod:`neo.rawio` API should be that a developer 
-should be able to code a new RawIO class with little knowledge of the Neo tree of 
+
+One speculative benefit of the :mod:`neo.rawio` API should be that a developer
+should be able to code a new RawIO class with little knowledge of the Neo tree of
 objects or of the :mod:`quantities` package.
 
 
@@ -99,7 +99,7 @@ All this information is internally available in the *header* dict::
 Read signal chunks of data and scale them::
 
     >>> channel_indexes = None  #could be channel_indexes = [0]
-    >>> raw_sigs = reader.get_analogsignal_chunk(block_index=0, seg_index=0, 
+    >>> raw_sigs = reader.get_analogsignal_chunk(block_index=0, seg_index=0,
                         i_start=1024, i_stop=2048, channel_indexes=channel_indexes)
     >>> float_sigs = reader.rescale_signal_raw_to_float(raw_sigs, dtype='float64')
     >>> sampling_rate = reader.get_signal_sampling_rate()
@@ -149,7 +149,7 @@ sorting. So the nb_unit could be more than physical channel or signal channels.
     unit_index 8 nb_spike 33
     ...
 
-    
+
 Get spike timestamps only between 0 and 10 seconds and convert them to spike times::
 
     >>> spike_timestamps = reader.spike_timestamps(block_index=0, seg_index=0, unit_index=0,
@@ -189,7 +189,7 @@ Count events per channel::
     chan_index 3 nb_event 0
     ...
 
-   
+
 
 Read event timestamps and times for chanindex=0 and with time limits (t_start=None, t_stop=None)::
 
@@ -200,6 +200,14 @@ Read event timestamps and times for chanindex=0 and with time limits (t_start=No
     >>> ev_times = reader.rescale_event_timestamp(ev_timestamps, dtype='float64')
     >>> print(ev_times)
     [ 0.0317]
+
+
+
+
+List of implemented formats
+===========================
+
+.. automodule:: neo.rawio
 
 
 

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -55,77 +55,151 @@ Classes:
 
 .. autoclass:: neo.io.AlphaOmegaIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.AsciiSignalIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.AsciiSpikeTrainIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.AxographIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.AxonIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.BCI2000IO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.BlackrockIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.BrainVisionIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.BrainwareDamIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.BrainwareF32IO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.BrainwareSrcIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.ElanIO
+
+    .. autoattribute:: extensions
 
 .. .. autoclass:: neo.io.ElphyIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.IgorIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.IntanIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.KlustaKwikIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.KwikIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.MicromedIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.NeoHdf5IO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.NeoMatlabIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.NestIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.NeuralynxIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.NeuroExplorerIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.NeuroScopeIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.NeuroshareIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.NixIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.NSDFIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.OpenEphysIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.PickleIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.PlexonIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.RawBinarySignalIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.RawMCSIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: Spike2IO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.StimfitIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.io.TdtIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.WinEdrIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.io.WinWcpIO
+
+    .. autoattribute:: extensions
 
 """
 

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -15,6 +15,44 @@ Functions:
 
 Classes:
 
+* :attr:`AlphaOmegaIO`
+* :attr:`AsciiSignalIO`
+* :attr:`AsciiSpikeTrainIO`
+* :attr:`AxographIO`
+* :attr:`AxonIO`
+* :attr:`BCI2000IO`
+* :attr:`BlackrockIO`
+* :attr:`BrainVisionIO`
+* :attr:`BrainwareDamIO`
+* :attr:`BrainwareF32IO`
+* :attr:`BrainwareSrcIO`
+* :attr:`ElanIO`
+* :attr:`IgorIO`
+* :attr:`IntanIO`
+* :attr:`KlustaKwikIO`
+* :attr:`KwikIO`
+* :attr:`MicromedIO`
+* :attr:`NeoHdf5IO`
+* :attr:`NeoMatlabIO`
+* :attr:`NestIO`
+* :attr:`NeuralynxIO`
+* :attr:`NeuroExplorerIO`
+* :attr:`NeuroScopeIO`
+* :attr:`NeuroshareIO`
+* :attr:`NixIO`
+* :attr:`NSDFIO`
+* :attr:`OpenEphysIO`
+* :attr:`PickleIO`
+* :attr:`PlexonIO`
+* :attr:`RawBinarySignalIO`
+* :attr:`RawMCSIO`
+* :attr:`Spike2IO`
+* :attr:`StimfitIO`
+* :attr:`TdtIO`
+* :attr:`WinEdrIO`
+* :attr:`WinWcpIO`
+
+
 .. autoclass:: neo.io.AlphaOmegaIO
 
 .. autoclass:: neo.io.AsciiSignalIO
@@ -78,6 +116,8 @@ Classes:
 .. autoclass:: neo.io.RawBinarySignalIO
 
 .. autoclass:: neo.io.RawMCSIO
+
+.. autoclass:: Spike2IO
 
 .. autoclass:: neo.io.StimfitIO
 

--- a/neo/rawio/__init__.py
+++ b/neo/rawio/__init__.py
@@ -36,41 +36,79 @@ Classes:
 
 .. autoclass:: neo.rawio.AxographRawIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.rawio.AxonRawIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.rawio.BlackrockRawIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.rawio.BrainVisionRawIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.rawio.ElanRawIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.rawio.IntanRawIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.rawio.MicromedRawIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.rawio.NeuralynxRawIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.rawio.NeuroExplorerRawIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.rawio.NeuroScopeRawIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.rawio.NIXRawIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.rawio.OpenEphysRawIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.rawio.PlexonRawIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.rawio.RawBinarySignalRawIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.rawio.RawMCSRawIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.rawio.Spike2RawIO
+
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.rawio.TdtRawIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.rawio.WinEdrRawIO
 
+    .. autoattribute:: extensions
+
 .. autoclass:: neo.rawio.WinWcpRawIO
+
+    .. autoattribute:: extensions
 
 """
 import os

--- a/neo/rawio/__init__.py
+++ b/neo/rawio/__init__.py
@@ -13,6 +13,27 @@ Functions:
 
 Classes:
 
+* :attr:`AxographRawIO`
+* :attr:`AxonRawIO`
+* :attr:`BlackrockRawIO`
+* :attr:`BrainVisionRawIO`
+* :attr:`ElanRawIO`
+* :attr:`IntanRawIO`
+* :attr:`MicromedRawIO`
+* :attr:`NeuralynxRawIO`
+* :attr:`NeuroExplorerRawIO`
+* :attr:`NeuroScopeRawIO`
+* :attr:`NIXRawIO`
+* :attr:`OpenEphysRawIO`
+* :attr:`PlexonRawIO`
+* :attr:`RawBinarySignalRawIO`
+* :attr:`RawMCSRawIO`
+* :attr:`Spike2RawIO`
+* :attr:`TdtRawIO`
+* :attr:`WinEdrRawIO`
+* :attr:`WinWcpRawIO`
+
+
 .. autoclass:: neo.rawio.AxographRawIO
 
 .. autoclass:: neo.rawio.AxonRawIO

--- a/neo/rawio/__init__.py
+++ b/neo/rawio/__init__.py
@@ -3,11 +3,53 @@
 :mod:`neo.rawio` provides classes for reading with low level API
 electrophysiological data files.
 
+:attr:`neo.rawio.rawiolist` provides a list of successfully imported rawio
+classes.
+
+Functions:
+
+.. autofunction:: neo.rawio.get_rawio_class
+
 
 Classes:
 
+.. autoclass:: neo.rawio.AxographRawIO
+
+.. autoclass:: neo.rawio.AxonRawIO
 
 .. autoclass:: neo.rawio.BlackrockRawIO
+
+.. autoclass:: neo.rawio.BrainVisionRawIO
+
+.. autoclass:: neo.rawio.ElanRawIO
+
+.. autoclass:: neo.rawio.IntanRawIO
+
+.. autoclass:: neo.rawio.MicromedRawIO
+
+.. autoclass:: neo.rawio.NeuralynxRawIO
+
+.. autoclass:: neo.rawio.NeuroExplorerRawIO
+
+.. autoclass:: neo.rawio.NeuroScopeRawIO
+
+.. autoclass:: neo.rawio.NIXRawIO
+
+.. autoclass:: neo.rawio.OpenEphysRawIO
+
+.. autoclass:: neo.rawio.PlexonRawIO
+
+.. autoclass:: neo.rawio.RawBinarySignalRawIO
+
+.. autoclass:: neo.rawio.RawMCSRawIO
+
+.. autoclass:: neo.rawio.Spike2RawIO
+
+.. autoclass:: neo.rawio.TdtRawIO
+
+.. autoclass:: neo.rawio.WinEdrRawIO
+
+.. autoclass:: neo.rawio.WinWcpRawIO
 
 """
 import os

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -104,14 +104,12 @@ class BlackrockRawIO(BaseRawIO):
             File name of the .nev file (without extension). If None,
             filename is used.
             Default: None.
-        nsx_to_load (int):
-            ID of nsX file from which to load data, e.g., if set to
-            5 only data from the ns5 file are loaded. If None, the Io
-            will take the maximum if file is present.
-            Contrary to previous version of the IO:
-
-              * nsx_to_load is not a list
-              * must be set at the init before parse_header()
+        nsx_to_load (int, list, 'max', 'all' (=None)) default None:
+            IDs of nsX file from which to load data, e.g., if set to
+            5 only data from the ns5 file are loaded.
+            If 'all', then all nsX will be loaded.
+            Contrary to previsous version of the IO  (<0.7), nsx_to_load
+            must be set at the init before parse_header().
 
     Examples:
         >>> reader = BlackrockRawIO(filename='FileSpec2.3001', nsx_to_load=5)

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -108,7 +108,8 @@ class BlackrockRawIO(BaseRawIO):
             ID of nsX file from which to load data, e.g., if set to
             5 only data from the ns5 file are loaded. If None, the Io
             will take the maximum if file is present.
-            Contrary to previsous version of the IO:
+            Contrary to previous version of the IO:
+
               * nsx_to_load is not a list
               * must be set at the init before parse_header()
 

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -43,7 +43,7 @@ class OpenEphysRawIO(BaseRawIO):
     In contrast to previous code for reading this format, here all data use memmap so it should
     be super fast and light compared to legacy code.
 
-    When the acquisition is stopped and restarted then files are named *_2, *_3.
+    When the acquisition is stopped and restarted then files are named ``*_2``, ``*_3``.
     In that case this class creates a new Segment. Note that timestamps are reset in this
     situation.
 


### PR DESCRIPTION
The [Neo IO doc page](https://neo.readthedocs.io/en/latest/io.html#module-neo.io) has a list of implemented formats, but the [Neo RawIO doc page](https://neo.readthedocs.io/en/latest/rawio.html) does not. This PR fixes that, as well as some doc build warnings.

Think we can fit this in before the release?