### PR TITLE
Fixed handling of empty .nev files in NeuralynxRawIO

### DIFF
--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -183,7 +183,7 @@ class NeuralynxRawIO(BaseRawIO):
 
                     if (os.path.getsize(filename) <= HEADER_SIZE):
                         self._empty_nev.append(filename)
-                        data = np.zeros((0,), dtype=dtype)
+                        data = np.zeros((0,), dtype=nev_dtype)
                         internal_ids = []
                     else:
                         data = np.memmap(filename, dtype=nev_dtype, mode='r', offset=HEADER_SIZE)

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -73,7 +73,7 @@ class NeuralynxRawIO(BaseRawIO):
         self._spike_memmap = {}
         self.internal_unit_ids = []  # channel_index > ((channel_name, channel_id), unit_id)
         self.internal_event_ids = []
-        self._empty_ncs = []  # this list contains filenames of empty records
+        self._empty_ncs_nev = []  # this list contains filenames of empty records
         self._empty_nse_ntt = []
 
         # explore the directory looking for ncs, nev, nse and ntt
@@ -90,8 +90,8 @@ class NeuralynxRawIO(BaseRawIO):
             if ext not in self.extensions:
                 continue
 
-            if (os.path.getsize(filename) <= HEADER_SIZE) and (ext in ['ncs']):
-                self._empty_ncs.append(filename)
+            if (os.path.getsize(filename) <= HEADER_SIZE) and (ext in ['ncs', 'nev']):
+                self._empty_ncs_nev.append(filename)
                 continue
 
             # All file have more or less the same header structure

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -73,7 +73,8 @@ class NeuralynxRawIO(BaseRawIO):
         self._spike_memmap = {}
         self.internal_unit_ids = []  # channel_index > ((channel_name, channel_id), unit_id)
         self.internal_event_ids = []
-        self._empty_ncs_nev = []  # this list contains filenames of empty records
+        self._empty_ncs = []  # this list contains filenames of empty records
+        self._empty_nev = []
         self._empty_nse_ntt = []
 
         # explore the directory looking for ncs, nev, nse and ntt
@@ -90,8 +91,8 @@ class NeuralynxRawIO(BaseRawIO):
             if ext not in self.extensions:
                 continue
 
-            if (os.path.getsize(filename) <= HEADER_SIZE) and (ext in ['ncs', 'nev']):
-                self._empty_ncs_nev.append(filename)
+            if (os.path.getsize(filename) <= HEADER_SIZE) and (ext in ['ncs']):
+                self._empty_ncs.append(filename)
                 continue
 
             # All file have more or less the same header structure
@@ -179,10 +180,14 @@ class NeuralynxRawIO(BaseRawIO):
                     # an event channel
                     # each ('event_id',  'ttl_input') give a new event channel
                     self.nev_filenames[chan_id] = filename
-                    data = np.memmap(
-                        filename, dtype=nev_dtype, mode='r', offset=HEADER_SIZE)
-                    internal_ids = np.unique(
-                        data[['event_id', 'ttl_input']]).tolist()
+
+                    if (os.path.getsize(filename) <= HEADER_SIZE):
+                        self._empty_nev.append(filename)
+                        data = np.zeros((0,), dtype=dtype)
+                        internal_ids = []
+                    else:
+                        data = np.memmap(filename, dtype=nev_dtype, mode='r', offset=HEADER_SIZE)
+                        internal_ids = np.unique(data[['event_id', 'ttl_input']]).tolist()
                     for internal_event_id in internal_ids:
                         if internal_event_id not in self.internal_event_ids:
                             event_id, ttl_input = internal_event_id


### PR DESCRIPTION
Hi guys, I noticed a small bug in how empty or header only files are handled in NeuralynxRawIO. While empty .ncs files are skipped entirely and empty .nse and .ntt files are mapped to empty Numpy arrays, the current code attempts to memmap empty .nev files, which results in an error since the memmap offset is larger than the file size.

In contrast to .nse and .ntt files (see discussion on #553 ), I'm not convinced that empty .nev files are interesting enough to convey to the user, so I chose to handle them like the .ncs files, i.e. ignore them.