### PR TITLE
[NIXIO] Trim nix_name annotation for chx objects

### DIFF
--- a/neo/io/nixio_fr.py
+++ b/neo/io/nixio_fr.py
@@ -15,6 +15,16 @@ class NixIO(NIXRawIO, BaseFromRaw):
         NIXRawIO.__init__(self, filename)
         BaseFromRaw.__init__(self, filename)
 
+    def read_block(self, block_index=0, lazy=False, signal_group_mode=None,
+                   units_group_mode=None, load_waveforms=False):
+        bl = super().read_block(block_index, lazy, signal_group_mode,
+                                units_group_mode, load_waveforms)
+        for chx in bl.channel_indexes:
+            if "nix_name" in chx.annotations:
+                nixname = chx.annotations["nix_name"]
+                chx.annotations["nix_name"] = nixname[0]
+        return bl
+
     def __enter__(self):
         return self
 

--- a/neo/io/nixio_fr.py
+++ b/neo/io/nixio_fr.py
@@ -17,8 +17,10 @@ class NixIO(NIXRawIO, BaseFromRaw):
 
     def read_block(self, block_index=0, lazy=False, signal_group_mode=None,
                    units_group_mode=None, load_waveforms=False):
-        bl = super().read_block(block_index, lazy, signal_group_mode,
-                                units_group_mode, load_waveforms)
+        bl = super(NixIO, self).read_block(block_index, lazy,
+                                           signal_group_mode,
+                                           units_group_mode,
+                                           load_waveforms)
         for chx in bl.channel_indexes:
             if "nix_name" in chx.annotations:
                 nixname = chx.annotations["nix_name"]

--- a/neo/rawio/nixrawio.py
+++ b/neo/rawio/nixrawio.py
@@ -12,7 +12,6 @@ from .baserawio import (BaseRawIO, _signal_channel_dtype,
                         _unit_channel_dtype, _event_channel_dtype)
 from ..io.nixio import NixIO
 import numpy as np
-import warnings
 try:
     import nixio as nix
 
@@ -22,6 +21,9 @@ except ImportError:
     nix = None
 
 
+# When reading metadata properties, the following keys are ignored since they
+# are used to store Neo object properties.
+# This dictionary is used in the _filter_properties() method.
 neo_attributes = {
     "segment": ["index"],
     "analogsignal": ["units", "copy", "sampling_rate", "t_start"],
@@ -191,10 +193,10 @@ class NIXRawIO(BaseRawIO):
                     if da.type == 'neo.analogsignal' and seg_ann['signals']:
                         # collect and group DataArrays
                         sig_ann = seg_ann['signals'][sig_idx]
-                        # sig_chan_ann = self.raw_annotations['signal_channels'][sig_idx]
+                        sig_chan_ann = self.raw_annotations['signal_channels'][sig_idx]
                         props = da.metadata.inherited_properties()
                         sig_ann.update(self._filter_properties(props, 'analogsignal'))
-                        # sig_chan_ann.update(self._filter_properties(props, 'analogsignal'))
+                        sig_chan_ann.update(self._filter_properties(props, 'analogsignal'))
                         sig_idx += 1
                 sp_idx = 0
                 ev_idx = 0

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -1381,7 +1381,6 @@ class NixIOWriteTest(NixIOTest):
 
         # TODO: multi dimensional value (GH Issue #501)
 
-    @unittest.SkipTest  # NIXRawIO requires fixing
     def test_write_proxyobjects(self):
 
         def generate_complete_block():


### PR DESCRIPTION
This PR fixes the bug that was introduced in #629 that required disabling the lazy load test (see #721).  The test is now enabled again.

### Explanation for the fix

The basefromrawio class creates ChannelIndex objects and appends annotation values to existing annotations, one for each signal in the channel.  This creates an issue with the `nix_name` annotation which is meant to be used as the NIX object name when the Neo structure is written to a NIX file.  We override the `read_block()` method from the `BaseFromRaw` class to first call the original method and then trim the `nix_name` annotation to make it a single value rather than a list.

### A note on the test and the RawIO

https://github.com/NeuralEnsemble/python-neo/blob/5fae976d1d944bf16285dc51f57d0e7d4c2c62ad/neo/test/iotest/test_nixio.py#L1385

The lazy load test (linked above) performs the following steps:
1. Creates a full Neo structure (single Block with all types of child objects).  Let's call this the *Original Block*.
2. Writes the *Original Block* to NIX using the NIXIO.
3. Reads the Block back using the Raw NixIO (nixio_fr) in lazy mode.  Let's call this the *Lazy Block*.
4. Writes back the lazy-loaded Block (*Lazy Block*) and runs a test utility function that checks the *Lazy Block* structure against the written file for consistency.

There's an issue here that's not caught by the test and I'm not sure if it should be considered a bug or just a side-effect of the RawIO implementation.  If we compare the *Original Block* to the *Lazy Block* they are **not** the same Neo structure.  You can run the following code to verify this (the structure created in this script is the same as the one created for the test):

<details>
  <summary>Click to expand</summary>

```python
import quantities as pq
import numpy as np
import neo

FILENAME = "rawcheck.nix"


def create_block() -> neo.Block:
    blk = neo.Block("neoblock")
    seg = neo.Segment("neoseg")
    blk.segments.append(seg)

    # signals
    signal = neo.AnalogSignal(name="signal",
                              signal=np.random.random((10, 5))*pq.mV,
                              sampling_period=pq.ms)
    seg.analogsignals.append(signal)
    irsig = neo.IrregularlySampledSignal(signal=np.random.random((20, 30)),
                                         times=np.arange(20)*pq.ms,
                                         units=pq.A)
    seg.irregularlysampledsignals.append(irsig)


    # add spiketrain
    waveforms = np.random.random((3, 5, 10)) * pq.mV
    spiketrain = neo.SpikeTrain(times=[1, 1.1, 1.2] * pq.ms, t_stop=1.5 * pq.s,
                                name="spikes with wf",
                                description="spikes for waveform test",
                                waveforms=waveforms)
    seg.spiketrains.append(spiketrain)

    # add events and epochs
    epoch = neo.Epoch(times=[1, 1, 10, 3] * pq.ms,
                      durations=[3, 3, 3, 1] * pq.ms,
                      labels=np.array(["one", "two", "three", "four"]),
                      name="test epoch", description="an epoch for testing")
    seg.epochs.append(epoch)
    event = neo.Event(times=np.arange(0, 30, 10) * pq.s,
                      labels=np.array(["0", "1", "2"]),
                      name="event name",
                      description="event description")
    seg.events.append(event)

    chx = neo.ChannelIndex(index=[0], name="probe", channel_ids=[4],
                           channel_names=["A"])
    blk.channel_indexes.append(chx)
    # chx.analogsignals.append(signal)
    unit = neo.Unit(name="myunit", description="blablabla",
                    file_origin="fileA.nix",
                    myannotation="myannotation")
    chx.units.append(unit)
    unit.spiketrains.append(spiketrain)
    blk.create_relationship()
    return blk


def write_nix(blk: neo.Block):
    with neo.io.NixIO(FILENAME, "ow") as io:
        io.write_block(blk)
    return


def read_raw() -> neo.Block:
    with neo.io.NixIOFr(FILENAME) as io:
        blk = io.read_block()
    return blk


def print_neo(obj: neo.core.baseneo.BaseNeo, d=0):
    indent = "  "*d
    print(f"{indent}Type: {type(obj).__name__}", end=" | ")
    print(f"Name: {obj.name}", end=" | ")
    print(f"NIX Name: {obj.annotations.get('nix_name', '<none>')}")
    if isinstance(obj, neo.core.container.Container):
        for child in obj.children:
            print_neo(child, d+1)
    elif isinstance(obj, neo.core.dataobject.DataObject):
        print(f"{indent} :{obj.shape}")


def main():
    blk = create_block()
    write_nix(blk)
    print("::Original::")
    print_neo(blk)

    rblk = read_raw()

    print("::Raw read::")
    print_neo(rblk)


if __name__ == "__main__":
    main()
```
</details>

The output should look like this:
<details>
<summary>Click to expand</summary>

```
::Original::
Type: Block | Name: neoblock | NIX Name: neo.block.4bc46f7304e7403dab2f0d6f57b639a6
  Type: Segment | Name: neoseg | NIX Name: neo.segment.d8d1b1155431467c8b27948c6fab23ad
    Type: AnalogSignal | Name: signal | NIX Name: neo.analogsignal.73f83ba62af346ceac8268b197918c14
     :(10, 5)
    Type: Epoch | Name: test epoch | NIX Name: neo.epoch.0b2524afe1214285b644d67c6e46c1c5
     :(4,)
    Type: Event | Name: event name | NIX Name: neo.event.48697cd087f5428fb87883ca167dd849
     :(3,)
    Type: IrregularlySampledSignal | Name: None | NIX Name: neo.irregularlysampledsignal.47b71994b64444979be6ffb3df1575af
     :(20, 30)
    Type: SpikeTrain | Name: spikes with wf | NIX Name: neo.spiketrain.6a25f52176574dd98372a478d321829d
     :(3,)
  Type: ChannelIndex | Name: probe | NIX Name: neo.channelindex.76e725a56bf54d95afe87ccf85cb718a
    Type: Unit | Name: myunit | NIX Name: neo.unit.7c2473e16c0747a1beb94aa2cc3a60a4
      Type: SpikeTrain | Name: spikes with wf | NIX Name: neo.spiketrain.6a25f52176574dd98372a478d321829d
       :(3,)
::Raw read::
Type: Block | Name: None | NIX Name: neo.block.4bc46f7304e7403dab2f0d6f57b639a6
  Type: Segment | Name: None | NIX Name: neo.segment.d8d1b1155431467c8b27948c6fab23ad
    Type: AnalogSignal | Name: Channel bundle (signal,signal,signal,signal,signal)  | NIX Name: <none>
     :(10, 5)
    Type: Epoch | Name: test epoch | NIX Name: neo.epoch.0b2524afe1214285b644d67c6e46c1c5
     :(4,)
    Type: Event | Name: event name | NIX Name: neo.event.48697cd087f5428fb87883ca167dd849
     :(3,)
    Type: SpikeTrain | Name: spikes with wf | NIX Name: neo.spiketrain.6a25f52176574dd98372a478d321829d
     :(3,)
  Type: ChannelIndex | Name: Channel group 0 | NIX Name: neo.channelindex.76e725a56bf54d95afe87ccf85cb718a
    Type: AnalogSignal | Name: Channel bundle (signal,signal,signal,signal,signal)  | NIX Name: <none>
     :(10, 5)
  Type: ChannelIndex | Name: ChannelIndex for Unit | NIX Name: <none>
    Type: Unit | Name: spikes with wf | NIX Name: <none>
      Type: SpikeTrain | Name: spikes with wf | NIX Name: neo.spiketrain.6a25f52176574dd98372a478d321829d
       :(3,)
```
</details>

Notice how the original Block contains only one  ChannelIndex (named `probe`) that we created but the Raw read Block contains two ChannelIndex objects which the RawIO creates, one for the AnalogSignal (`Channel group 0`) and one for the Unit and SpikeTrains (`ChannelIndex for Unit`).  This means that using the nixio_fr (NIXIO From Raw) doesn't guarantee you'll get the same Neo structure that was originally written to the file.  More importantly, given how the RawIO creates ChannelIndexes based on signals, events/epochs, units, and spiketrains, we (@hkchekc and I) are not sure what the RawIO header should look like to make this possible.