### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 

--- a/doc/source/developers_guide.rst
+++ b/doc/source/developers_guide.rst
@@ -3,7 +3,7 @@ Developers' guide
 =================
 
 These instructions are for developing on a Unix-like platform, e.g. Linux or
-Mac OS X, with the bash shell. If you develop on Windows, please get in touch.
+macOS, with the bash shell. If you develop on Windows, please get in touch.
 
 
 Mailing lists
@@ -38,7 +38,7 @@ a GitHub account and then set to watch the repository at `GitHub Repository`_
 Requirements
 ------------
 
-    * Python_ 2.7, 3.4 or later
+    * Python_ 2.7, 3.5 or later
     * numpy_ >= 1.7.1
     * quantities_ >= 0.9.0
     * nose_ >= 0.11.1 (for running tests)
@@ -199,7 +199,7 @@ open a pull request on GitHub
 Python version
 --------------
 
-Neo core should work with both Python 2.7 and Python 3 (version 3.4 or newer).
+Neo core should work with both Python 2.7 and Python 3 (version 3.5 or newer).
 Neo IO modules should ideally work with both Python 2 and 3, but certain
 modules may only work with one or the other (see :doc:`install`).
 
@@ -222,7 +222,7 @@ Coding standards and style
 --------------------------
 
 All code should conform as much as possible to `PEP 8`_, and should run with
-Python 2.7, and 3.4 or newer.
+Python 2.7, and 3.5 or newer.
 
 You can use the `pep8`_ program to check the code for PEP 8 conformity.
 You can also use `flake8`_, which combines pep8 and pyflakes.
@@ -278,7 +278,6 @@ See :ref:`io_dev_guide` for implementation of a new IO.
 
 .. _Python: http://www.python.org
 .. _nose: http://somethingaboutorange.com/mrl/projects/nose/
-.. _unittest2: http://pypi.python.org/pypi/unittest2
 .. _Setuptools: https://pypi.python.org/pypi/setuptools/
 .. _tox: http://codespeak.net/tox/
 .. _coverage: http://nedbatchelder.com/code/coverage/

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -440,8 +440,8 @@ class AnalogSignal(BaseSignal):
             with pp.group(indent=1):
                 pp.text(line)
 
-        for line in ["sampling rate: {0}".format(self.sampling_rate),
-                     "time: {0} to {1}".format(self.t_start, self.t_stop)]:
+        for line in ["sampling rate: {}".format(self.sampling_rate),
+                     "time: {} to {}".format(self.t_start, self.t_stop)]:
             _pp(line)
 
     def time_index(self, t):

--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -72,7 +72,7 @@ def merge_annotation(a, b):
         For strings: concatenate with ';'
         Otherwise: fail if the annotations are not equal
     """
-    assert type(a) == type(b), 'type(%s) %s != type(%s) %s' % (a, type(a),
+    assert type(a) == type(b), 'type({}) {} != type({}) {}'.format(a, type(a),
                                                                b, type(b))
     if isinstance(a, dict):
         return merge_annotations(a, b)
@@ -86,7 +86,7 @@ def merge_annotation(a, b):
         else:
             return a + ";" + b
     else:
-        assert a == b, '%s != %s' % (a, b)
+        assert a == b, '{} != {}'.format(a, b)
         return a
 
 
@@ -308,7 +308,7 @@ class BaseNeo(object):
                 else:
                     pp.breakable()
                 with pp.group(indent=1):
-                    pp.text("{0}: ".format(key))
+                    pp.text("{}: ".format(key))
                     pp.pretty(value)
 
     def _repr_pretty_(self, pp, cycle):

--- a/neo/core/basesignal.py
+++ b/neo/core/basesignal.py
@@ -264,7 +264,7 @@ class BaseSignal(DataObject):
             if attr_self == attr_other:
                 kwargs[name] = attr_self
             else:
-                kwargs[name] = "merge(%s, %s)" % (attr_self, attr_other)
+                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
         merged_annotations = merge_annotations(self.annotations, other.annotations)
         kwargs.update(merged_annotations)
 

--- a/neo/core/channelindex.py
+++ b/neo/core/channelindex.py
@@ -22,12 +22,12 @@ class ChannelIndex(Container):
 
     This container has several purposes:
 
-      * Grouping all :class:`AnalogSignal`\s and
-        :class:`IrregularlySampledSignal`\s inside a :class:`Block` across
-        :class:`Segment`\s;
+      * Grouping all :class:`AnalogSignal`\\s and
+        :class:`IrregularlySampledSignal`\\s inside a :class:`Block` across
+        :class:`Segment`\\s;
       * Indexing a subset of the channels within an :class:`AnalogSignal` and
-        :class:`IrregularlySampledSignal`\s;
-      * Container of :class:`Unit`\s. Discharges of multiple neurons
+        :class:`IrregularlySampledSignal`\\s;
+      * Container of :class:`Unit`\\s. Discharges of multiple neurons
         (:class:`Unit`\'s) can be seen on the same channel.
 
     *Usage 1* providing channel IDs across multiple :class:`Segment`::

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -374,8 +374,8 @@ class Container(BaseNeo):
         Get dictionary containing the names of child containers in the current
         object as keys and the number of children of that type as values.
         """
-        return dict((name, len(getattr(self, name)))
-                    for name in self._child_containers)
+        return {name: len(getattr(self, name))
+                    for name in self._child_containers}
 
     def filter(self, targdict=None, data=True, container=False, recursive=True,
                objects=None, **kwargs):
@@ -569,7 +569,7 @@ class Container(BaseNeo):
         # merge containers with the same name
         for container in (self._container_child_containers +
                               self._multi_child_containers):
-            lookup = dict((obj.name, obj) for obj in getattr(self, container))
+            lookup = {obj.name: obj for obj in getattr(self, container)}
             ids = [id(obj) for obj in getattr(self, container)]
             for obj in getattr(other, container):
                 if id(obj) in ids:
@@ -584,7 +584,7 @@ class Container(BaseNeo):
         # for data objects, ignore the name and just add them
         for container in self._data_child_containers:
             objs = getattr(self, container)
-            lookup = dict((obj.name, i) for i, obj in enumerate(objs))
+            lookup = {obj.name: i for i, obj in enumerate(objs)}
             ids = [id(obj) for obj in objs]
             for obj in getattr(other, container):
                 if id(obj) in ids:
@@ -617,7 +617,7 @@ class Container(BaseNeo):
         for container in self._child_containers:
             objs = getattr(self, container)
             if objs:
-                vals.append('%s %s' % (len(objs), container))
+                vals.append('{} {}'.format(len(objs), container))
         pp.text(', '.join(vals))
 
         if self._has_repr_pretty_attrs_():
@@ -627,7 +627,7 @@ class Container(BaseNeo):
         for container in self._repr_pretty_containers:
             pp.breakable()
             objs = getattr(self, container)
-            pp.text("# %s (N=%s)" % (container, len(objs)))
+            pp.text("# {} (N={})".format(container, len(objs)))
             for (i, obj) in enumerate(objs):
                 pp.breakable()
                 pp.text("%s: " % i)

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -248,7 +248,7 @@ class Epoch(DataObject):
             if attr_self == attr_other:
                 kwargs[name] = attr_self
             else:
-                kwargs[name] = "merge(%s, %s)" % (attr_self, attr_other)
+                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
 
         merged_annotations = merge_annotations(self.annotations, other.annotations)
         kwargs.update(merged_annotations)

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -106,7 +106,7 @@ class Event(DataObject):
         # reference dimensionality
         if (len(dim) != 1 or list(dim.values())[0] != 1 or not isinstance(list(dim.keys())[0],
                                                                           pq.UnitTime)):
-            ValueError("Unit %s has dimensions %s, not [time]" % (units, dim.simplified))
+            ValueError("Unit {} has dimensions {}, not [time]".format(units, dim.simplified))
 
         obj = pq.Quantity(times, units=dim).view(cls)
         obj._labels = labels
@@ -192,7 +192,7 @@ class Event(DataObject):
             if attr_self == attr_other:
                 kwargs[name] = attr_self
             else:
-                kwargs[name] = "merge(%s, %s)" % (attr_self, attr_other)
+                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
 
         print('Event: merge annotations')
         merged_annotations = merge_annotations(self.annotations, other.annotations)

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -285,7 +285,8 @@ class IrregularlySampledSignal(BaseSignal):
             return
         # dimensionality should match
         if self.ndim != other.ndim:
-            raise ValueError('Dimensionality does not match: {} vs {}'.format(self.ndim, other.ndim))
+            raise ValueError('Dimensionality does not match: {} vs {}'.format(
+                self.ndim, other.ndim))
         # if if the other array does not have a times property,
         # then it should be okay to add it directly
         if not hasattr(other, 'times'):

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -191,7 +191,7 @@ class IrregularlySampledSignal(BaseSignal):
         '''
         Returns a string representing the :class:`IrregularlySampledSignal`.
         '''
-        return '<%s(%s at times %s)>' % (
+        return '<{}({} at times {})>'.format(
             self.__class__.__name__, super(IrregularlySampledSignal, self).__repr__(), self.times)
 
     def __getitem__(self, i):
@@ -285,7 +285,7 @@ class IrregularlySampledSignal(BaseSignal):
             return
         # dimensionality should match
         if self.ndim != other.ndim:
-            raise ValueError('Dimensionality does not match: %s vs %s' % (self.ndim, other.ndim))
+            raise ValueError('Dimensionality does not match: {} vs {}'.format(self.ndim, other.ndim))
         # if if the other array does not have a times property,
         # then it should be okay to add it directly
         if not hasattr(other, 'times'):
@@ -293,7 +293,7 @@ class IrregularlySampledSignal(BaseSignal):
 
         # if there is a times property, the times need to be the same
         if not (self.times == other.times).all():
-            raise ValueError('Times do not match: %s vs %s' % (self.times, other.times))
+            raise ValueError('Times do not match: {} vs {}'.format(self.times, other.times))
 
     def __rsub__(self, other, *args):
         '''
@@ -320,7 +320,7 @@ class IrregularlySampledSignal(BaseSignal):
             with pp.group(indent=1):
                 pp.text(line)
 
-        for line in ["sample times: {0}".format(self.times)]:
+        for line in ["sample times: {}".format(self.times)]:
             _pp(line)
 
     @property
@@ -453,7 +453,7 @@ class IrregularlySampledSignal(BaseSignal):
             if attr_self == attr_other:
                 kwargs[name] = attr_self
             else:
-                kwargs[name] = "merge(%s, %s)" % (attr_self, attr_other)
+                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
         merged_annotations = merge_annotations(self.annotations, other.annotations)
         kwargs.update(merged_annotations)
 

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -41,7 +41,7 @@ def check_has_dimensions_time(*values):
         dim = value.dimensionality
         if (len(dim) != 1 or list(dim.values())[0] != 1 or not isinstance(list(dim.keys())[0],
                                                                           pq.UnitTime)):
-            errmsgs.append("value %s has dimensions %s, not [time]" % (value, dim.simplified))
+            errmsgs.append("value {} has dimensions {}, not [time]".format(value, dim.simplified))
     if errmsgs:
         raise ValueError("\n".join(errmsgs))
 
@@ -57,7 +57,7 @@ def _check_time_in_range(value, t_start, t_stop, view=False):
     '''
 
     if t_start > t_stop:
-        raise ValueError("t_stop (%s) is before t_start (%s)" % (t_stop, t_start))
+        raise ValueError("t_stop ({}) is before t_start ({})".format(t_stop, t_start))
 
     if not value.size:
         return
@@ -68,9 +68,9 @@ def _check_time_in_range(value, t_start, t_stop, view=False):
         t_stop = t_stop.view(np.ndarray)
 
     if value.min() < t_start:
-        raise ValueError("The first spike (%s) is before t_start (%s)" % (value, t_start))
+        raise ValueError("The first spike ({}) is before t_start ({})".format(value, t_start))
     if value.max() > t_stop:
-        raise ValueError("The last spike (%s) is after t_stop (%s)" % (value, t_stop))
+        raise ValueError("The last spike ({}) is after t_stop ({})".format(value, t_stop))
 
 
 def _check_waveform_dimensions(spiketrain):
@@ -678,7 +678,7 @@ class SpikeTrain(DataObject):
             if attr_self == attr_other:
                 kwargs[name] = attr_self
             else:
-                kwargs[name] = "merge(%s, %s)" % (attr_self, attr_other)
+                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
         merged_annotations = merge_annotations(self.annotations, other.annotations)
         kwargs.update(merged_annotations)
 

--- a/neo/io/asciispiketrainio.py
+++ b/neo/io/asciispiketrainio.py
@@ -131,6 +131,6 @@ class AsciiSpikeTrainIO(BaseIO):
         f = open(self.filename, 'w')
         for s, sptr in enumerate(segment.spiketrains):
             for ts in sptr:
-                f.write('%f%s' % (ts, delimiter))
+                f.write('{:f}{}'.format(ts, delimiter))
             f.write('\n')
         f.close()

--- a/neo/io/blackrockio_v4.py
+++ b/neo/io/blackrockio_v4.py
@@ -383,7 +383,7 @@ class BlackrockIO(BaseIO):
         if nsx_file_id['file_id'].decode() == 'NEURALSG':
             spec = '2.1'
         elif nsx_file_id['file_id'].decode() == 'NEURALCD':
-            spec = '{0}.{1}'.format(
+            spec = '{}.{}'.format(
                 nsx_file_id['ver_major'], nsx_file_id['ver_minor'])
         else:
             raise IOError('Unsupported NSX file type.')
@@ -404,10 +404,10 @@ class BlackrockIO(BaseIO):
 
         nev_file_id = np.fromfile(filename, count=1, dtype=dt0)[0]
         if nev_file_id['file_id'].decode() == 'NEURALEV':
-            spec = '{0}.{1}'.format(
+            spec = '{}.{}'.format(
                 nev_file_id['ver_major'], nev_file_id['ver_minor'])
         else:
-            raise IOError('NEV file type {0} is not supported'.format(
+            raise IOError('NEV file type {} is not supported'.format(
                 nev_file_id['file_id']))
 
         return spec
@@ -732,7 +732,7 @@ class BlackrockIO(BaseIO):
         dt0 = [
             ('timestamp', 'uint32'),
             ('packet_id', 'uint16'),
-            ('value', 'S{0}'.format(data_size - 6))]
+            ('value', 'S{}'.format(data_size - 6))]
 
         raw_data = np.memmap(filename, mode='r', offset=header_size, dtype=dt0)
 
@@ -945,7 +945,7 @@ class BlackrockIO(BaseIO):
                     ('analog_input_channel_3', 'int16'),
                     ('analog_input_channel_4', 'int16'),
                     ('analog_input_channel_5', 'int16'),
-                    ('unused', 'S{0}'.format(data_size - 20))],
+                    ('unused', 'S{}'.format(data_size - 20))],
                 # Version>=2.3
                 'b': [
                     ('timestamp', 'uint32'),
@@ -953,14 +953,14 @@ class BlackrockIO(BaseIO):
                     ('packet_insertion_reason', 'uint8'),
                     ('reserved', 'uint8'),
                     ('digital_input', 'uint16'),
-                    ('unused', 'S{0}'.format(data_size - 10))]},
+                    ('unused', 'S{}'.format(data_size - 10))]},
             'Spikes': {
                 'a': [
                     ('timestamp', 'uint32'),
                     ('packet_id', 'uint16'),
                     ('unit_class_nb', 'uint8'),
                     ('reserved', 'uint8'),
-                    ('waveform', 'S{0}'.format(data_size - 8))]},
+                    ('waveform', 'S{}'.format(data_size - 8))]},
             'Comments': {
                 'a': [
                     ('timestamp', 'uint32'),
@@ -968,7 +968,7 @@ class BlackrockIO(BaseIO):
                     ('char_set', 'uint8'),
                     ('flag', 'uint8'),
                     ('data', 'uint32'),
-                    ('comment', 'S{0}'.format(data_size - 12))]},
+                    ('comment', 'S{}'.format(data_size - 12))]},
             'VideoSync': {
                 'a': [
                     ('timestamp', 'uint32'),
@@ -998,7 +998,7 @@ class BlackrockIO(BaseIO):
                     ('timestamp', 'uint32'),
                     ('packet_id', 'uint16'),
                     ('config_change_type', 'uint16'),
-                    ('config_changed', 'S{0}'.format(data_size - 8))]}}
+                    ('config_changed', 'S{}'.format(data_size - 8))]}}
 
         return __nev_data_types
 
@@ -1020,7 +1020,7 @@ class BlackrockIO(BaseIO):
             'max_res': self.__nev_basic_header['timestamp_resolution'],
             'channel_ids': self.__nev_ext_header[b'NEUEVWAV']['electrode_id'],
             'channel_labels': self.__channel_labels[self.__nev_spec](),
-            'event_unit': pq.CompoundUnit("1.0/{0} * s".format(
+            'event_unit': pq.CompoundUnit("1.0/{} * s".format(
                 self.__nev_basic_header['timestamp_resolution'])),
             'nb_units': dict(zip(
                 self.__nev_ext_header[b'NEUEVWAV']['electrode_id'],
@@ -1033,7 +1033,7 @@ class BlackrockIO(BaseIO):
             'waveform_dtypes': self.__get_waveforms_dtype(),
             'waveform_sampling_rate':
                 self.__nev_basic_header['sample_resolution'] * pq.Hz,
-            'waveform_time_unit': pq.CompoundUnit("1.0/{0} * s".format(
+            'waveform_time_unit': pq.CompoundUnit("1.0/{} * s".format(
                 self.__nev_basic_header['sample_resolution'])),
             'waveform_unit': pq.uV}
 
@@ -1155,7 +1155,7 @@ class BlackrockIO(BaseIO):
         # get the dtype of waveform (this is stupidly complicated)
         if self.__is_set(
                 np.array(self.__nev_basic_header['additionnal_flags']), 0):
-            dtype_waveforms = dict((k, 'int16') for k in all_el_ids)
+            dtype_waveforms = {k: 'int16' for k in all_el_ids}
         else:
             # extract bytes per waveform
             waveform_bytes = \
@@ -1196,9 +1196,9 @@ class BlackrockIO(BaseIO):
         wf_dtypes = self.__get_waveforms_dtype()
         nb_bytes_wf = self.__nev_basic_header['bytes_in_data_packets'] - 8
 
-        wf_sizes = dict([
-            (ch, int(nb_bytes_wf / np.dtype(dt).itemsize)) for ch, dt in
-            wf_dtypes.items()])
+        wf_sizes = {
+            ch: int(nb_bytes_wf / np.dtype(dt).itemsize) for ch, dt in
+            wf_dtypes.items()}
 
         return wf_sizes
 
@@ -1223,7 +1223,7 @@ class BlackrockIO(BaseIO):
 
         # TODO: Double check if this is the correct assumption (10 samples)
         # default value: threshold crossing after 10 samples of waveform
-        wf_left_sweep = dict([(ch, 10 * wf_t_unit) for ch in all_ch])
+        wf_left_sweep = {ch: 10 * wf_t_unit for ch in all_ch}
 
         # non-default: threshold crossing at center of waveform
         # wf_size = self.__nev_params('waveform_size')
@@ -1282,7 +1282,7 @@ class BlackrockIO(BaseIO):
                 * self.__nsx_basic_header[nsx_nb]['channel_count'],
             'sampling_rate':
                 30000 / self.__nsx_basic_header[nsx_nb]['period'] * pq.Hz,
-            'time_unit': pq.CompoundUnit("1.0/{0}*s".format(
+            'time_unit': pq.CompoundUnit("1.0/{}*s".format(
                 30000 / self.__nsx_basic_header[nsx_nb]['period']))}
 
         return nsx_parameters[param_name]
@@ -1312,7 +1312,7 @@ class BlackrockIO(BaseIO):
             'sampling_rate':
                 self.__nsx_basic_header[nsx_nb]['timestamp_resolution']
                 / self.__nsx_basic_header[nsx_nb]['period'] * pq.Hz,
-            'time_unit': pq.CompoundUnit("1.0/{0}*s".format(
+            'time_unit': pq.CompoundUnit("1.0/{}*s".format(
                 self.__nsx_basic_header[nsx_nb]['timestamp_resolution']
                 / self.__nsx_basic_header[nsx_nb]['period']))}
 
@@ -1366,22 +1366,22 @@ class BlackrockIO(BaseIO):
                 return data_parameters[param_name]
             elif n_start < t_starts[d_bl - 1] < n_stop <= t_stops[d_bl - 1]:
                 self._print_verbose(
-                    "User n_start ({0}) is smaller than the corresponding "
-                    "t_start of the available ns{1} datablock "
-                    "({2}).".format(n_start, nsx_nb, t_starts[d_bl - 1]))
+                    "User n_start ({}) is smaller than the corresponding "
+                    "t_start of the available ns{} datablock "
+                    "({}).".format(n_start, nsx_nb, t_starts[d_bl - 1]))
                 return data_parameters[param_name]
             elif t_starts[d_bl - 1] <= n_start < t_stops[d_bl - 1] < n_stop:
                 self._print_verbose(
-                    "User n_stop ({0}) is larger than the corresponding "
-                    "t_stop of the available ns{1} datablock "
-                    "({2}).".format(n_stop, nsx_nb, t_stops[d_bl - 1]))
+                    "User n_stop ({}) is larger than the corresponding "
+                    "t_stop of the available ns{} datablock "
+                    "({}).".format(n_stop, nsx_nb, t_stops[d_bl - 1]))
                 return data_parameters[param_name]
             elif n_start < t_starts[d_bl - 1] < t_stops[d_bl - 1] < n_stop:
                 self._print_verbose(
-                    "User n_start ({0}) is smaller than the corresponding "
-                    "t_start and user n_stop ({1}) is larger than the "
-                    "corresponding t_stop of the available ns{2} datablock "
-                    "({3}).".format(
+                    "User n_start ({}) is smaller than the corresponding "
+                    "t_start and user n_stop ({}) is larger than the "
+                    "corresponding t_stop of the available ns{} datablock "
+                    "({}).".format(
                         n_start, n_stop, nsx_nb,
                         (t_starts[d_bl - 1], t_stops[d_bl - 1])))
                 return data_parameters[param_name]
@@ -1417,12 +1417,12 @@ class BlackrockIO(BaseIO):
         # analog input events via threshold crossings
         for ch in range(5):
             event_types.update({
-                'analog_input_channel_{0}'.format(ch + 1): {
-                    'name': 'analog_input_channel_{0}'.format(ch + 1),
-                    'field': 'analog_input_channel_{0}'.format(ch + 1),
+                'analog_input_channel_{}'.format(ch + 1): {
+                    'name': 'analog_input_channel_{}'.format(ch + 1),
+                    'field': 'analog_input_channel_{}'.format(ch + 1),
                     'mask': self.__is_set(
                         data['packet_insertion_reason'], ch + 1),
-                    'desc': "Values of analog input channel {0} in mV "
+                    'desc': "Values of analog input channel {} in mV "
                             "(+/- 5000)".format(ch + 1)}})
 
         # TODO: define field and desc
@@ -1466,14 +1466,14 @@ class BlackrockIO(BaseIO):
         if un_id == 0:
             return 'unclassified'
         elif 1 <= un_id <= 16:
-            return '{0}'.format(un_id)
+            return '{}'.format(un_id)
         elif 17 <= un_id <= 244:
             raise ValueError(
-                "Unit id {0} is not used by daq system".format(un_id))
+                "Unit id {} is not used by daq system".format(un_id))
         elif un_id == 255:
             return 'noise'
         else:
-            raise ValueError("Unit id {0} cannot be classified".format(un_id))
+            raise ValueError("Unit id {} cannot be classified".format(un_id))
 
     def __is_set(self, flag, pos):
         """
@@ -1792,9 +1792,9 @@ class BlackrockIO(BaseIO):
 
         # define a name for spiketrain
         # (unique identifier: 1000 * elid + unit_nb)
-        name = "Unit {0}".format(1000 * channel_id + unit_id)
+        name = "Unit {}".format(1000 * channel_id + unit_id)
         # define description for spiketrain
-        desc = 'SpikeTrain from channel: {0}, unit: {1}'.format(
+        desc = 'SpikeTrain from channel: {}, unit: {}'.format(
             channel_id, self.__get_unit_classification(unit_id))
 
         # get spike times for given time interval
@@ -1888,7 +1888,7 @@ class BlackrockIO(BaseIO):
             return None
 
         description = \
-            "AnalogSignal from channel: {0}, label: {1}, nsx: {2}".format(
+            "AnalogSignal from channel: {}, label: {}, nsx: {}".format(
                 channel_id, labels[idx_ch], nsx_nb)
 
         # TODO: Find a more time/memory efficient way to handle lazy loading
@@ -1953,9 +1953,9 @@ class BlackrockIO(BaseIO):
         """
         # define a name for spiketrain
         # (unique identifier: 1000 * elid + unit_nb)
-        name = "Unit {0}".format(1000 * channel_id + unit_id)
+        name = "Unit {}".format(1000 * channel_id + unit_id)
         # define description for spiketrain
-        desc = 'Unit from channel: {0}, id: {1}'.format(
+        desc = 'Unit from channel: {}, id: {}'.format(
             channel_id, self.__get_unit_classification(unit_id))
 
         un = Unit(
@@ -1985,7 +1985,7 @@ class BlackrockIO(BaseIO):
 
         if index is not None:
             chidx.index = index
-            chidx.name = "ChannelIndex {0}".format(chidx.index)
+            chidx.name = "ChannelIndex {}".format(chidx.index)
         else:
             chidx.name = "ChannelIndex"
 
@@ -2164,7 +2164,7 @@ class BlackrockIO(BaseIO):
         else:
             seg.index = index
         if name is None:
-            seg.name = "Segment {0}".format(seg.index)
+            seg.name = "Segment {}".format(seg.index)
         else:
             seg.name = name
         if description is None:
@@ -2243,12 +2243,12 @@ class BlackrockIO(BaseIO):
 
                         if not_existing_units:
                             self._print_verbose(
-                                "Units {0} on channel {1} do not "
+                                "Units {} on channel {} do not "
                                 "exist".format(not_existing_units, ch_id))
                     else:
                         self._print_verbose(
                             "There are no units specified for channel "
-                            "{0}".format(ch_id))
+                            "{}".format(ch_id))
 
         if nsx_to_load is not None:
             for nsx_nb in nsx_to_load:

--- a/neo/io/elphyio.py
+++ b/neo/io/elphyio.py
@@ -3400,7 +3400,8 @@ class ElphyFile(object):
         if hasattr(title, 'decode'):
             title = title.decode()
         if title not in factories:
-            title = "format is not implemented ('{}' not in {})".format(title, str(factories.keys()))
+            title = "format is not implemented ('{}' not in {})".format(
+                title, str(factories.keys()))
         return title
 
     def set_nomenclature(self):

--- a/neo/io/elphyio.py
+++ b/neo/io/elphyio.py
@@ -186,7 +186,7 @@ class ElphySignal(BaseSignal):
         self.units = [x_unit, y_unit]
 
     def __str__(self):
-        return "%s ep_%s ch_%s [%s, %s]" % (
+        return "{} ep_{} ch_{} [{}, {}]".format(
             self.layout.file.name, self.episode, self.channel, self.x_unit, self.y_unit)
 
     def __repr__(self):
@@ -227,7 +227,7 @@ class ElphyTag(BaseSignal):
         self.units = [x_unit, None]
 
     def __str__(self):
-        return "%s : ep_%s tag_ch_%s [%s]" % (
+        return "{} : ep_{} tag_ch_{} [{}]".format(
             self.layout.file.name, self.episode, self.number, self.x_unit)
 
     def __repr__(self):
@@ -280,7 +280,7 @@ class ElphyEvent(object):
         self.ch_number = ch_number
 
     def __str__(self):
-        return "%s : ep_%s evt_ch_%s [%s]" % (
+        return "{} : ep_{} evt_ch_{} [{}]".format(
             self.layout.file.name, self.episode, self.number, self.x_unit)
 
     def __repr__(self):
@@ -437,7 +437,7 @@ class ElphyBlock(BaseBlock):
         self.sub_blocks = list()
 
     def __repr__(self):
-        return "%s : size = %s, start = %s, end = %s" % (
+        return "{} : size = {}, start = {}, end = {}".format(
             self.identifier, self.size, self.start, self.end)
 
     def add_sub_block(self, block):
@@ -530,7 +530,7 @@ class ClassicFileInfo(FileInfoBlock):
     """
 
     def detect_protocol_from_name(self, path):
-        pattern = "\d{4}(\d+|\D)\D"
+        pattern = r"\d{4}(\d+|\D)\D"
         codes = {
             'r': 'sparsenoise',
             'o': 'movingbar',
@@ -1921,7 +1921,7 @@ class ElphyLayout(object):
         data = np.empty([len(reshape), n_samples], dtype=(int, int))
         for index, bit_mask in enumerate(bit_masks):
             tmp = self.filter_bytes(databytes, bit_mask)
-            tp = '%s%s%s' % (order, datatypes[index], reshape[index])
+            tp = '{}{}{}'.format(order, datatypes[index], reshape[index])
             data[index] = np.frombuffer(tmp, dtype=tp)
 
         return data.T
@@ -2177,7 +2177,7 @@ class Acquis1Layout(ElphyLayout):
         Y0 = self.header.Y0_ar[ch - 1]
         # TODO: see why this kind of exception exists
         if dY is None or Y0 is None:
-            raise Exception('bad Y-scale factors for episode %s channel %s' % (ep, ch))
+            raise Exception('bad Y-scale factors for episode {} channel {}'.format(ep, ch))
         return ElphyScaleFactor(dY, Y0)
 
     def x_unit(self, ep, ch):
@@ -3370,7 +3370,7 @@ class ElphyFile(object):
         try:
             self.file = open(self.path, 'rb')
         except Exception as e:
-            raise Exception("python couldn't open file %s : %s" % (self.path, e))
+            raise Exception("python couldn't open file {} : {}".format(self.path, e))
         self.file_size = path.getsize(self.file.name)
         self.creation_date = datetime.fromtimestamp(path.getctime(self.file.name))
         self.modification_date = datetime.fromtimestamp(path.getmtime(self.file.name))
@@ -3400,7 +3400,7 @@ class ElphyFile(object):
         if hasattr(title, 'decode'):
             title = title.decode()
         if title not in factories:
-            title = "format is not implemented ('%s' not in %s)" % (title, str(factories.keys()))
+            title = "format is not implemented ('{}' not in {})".format(title, str(factories.keys()))
         return title
 
     def set_nomenclature(self):
@@ -3448,7 +3448,7 @@ class ElphyFile(object):
         try:
             self.file = open(self.path, 'wb')
         except Exception as e:
-            raise Exception("python couldn't open file %s : %s" % (self.path, e))
+            raise Exception("python couldn't open file {} : {}".format(self.path, e))
         self.file_size = 0
         self.creation_date = datetime.now()
         self.modification_date = datetime.now()
@@ -3810,7 +3810,7 @@ class ElphyIO(BaseIO):
             self.elphy_file.open()
         except Exception as e:
             self.elphy_file.close()
-            raise Exception("cannot open file %s : %s" % (self.filename, e))
+            raise Exception("cannot open file {} : {}".format(self.filename, e))
 
         # create a segment containing all analog,
         # tag and event channels for the episode
@@ -4216,7 +4216,7 @@ class ElphyIO(BaseIO):
                 t_stop=signal.t_stop * getattr(pq, signal.x_unit.strip()),
                 # sampling_rate = signal.sampling_frequency * pq.kHz,
                 sampling_period=signal.sampling_period * getattr(pq, signal.x_unit.strip()),
-                channel_name="episode %s, channel %s" % (int(episode + 1), int(channel + 1))
+                channel_name="episode {}, channel {}".format(int(episode + 1), int(channel + 1))
             )
             analog_signal.segment = segment
             segment.analogsignals.append(analog_signal)
@@ -4244,7 +4244,7 @@ class ElphyIO(BaseIO):
         """
         n_spikes = self.elphy_file.n_spikes
         group = ChannelIndex(
-            name="episode %s, group of %s electrodes" % (episode, n_spikes)
+            name="episode {}, group of {} electrodes".format(episode, n_spikes)
         )
         for spk in range(0, n_spikes):
             channel = self.read_channelindex(episode, spk)
@@ -4260,7 +4260,7 @@ class ElphyIO(BaseIO):
             episode : number of elphy episode, roughly corresponding to a segment.
             chl : electrode number.
         """
-        channel = ChannelIndex(name="episode %s, electrodes %s" % (episode, chl), index=[0])
+        channel = ChannelIndex(name="episode {}, electrodes {}".format(episode, chl), index=[0])
         return channel
 
     def read_event(self, episode, evt):
@@ -4276,7 +4276,7 @@ class ElphyIO(BaseIO):
         event = self.elphy_file.get_event(episode, evt)
         neo_event = Event(
             times=event.times * pq.s,
-            channel_name="episode %s, event channel %s" % (episode + 1, evt + 1)
+            channel_name="episode {}, event channel {}".format(episode + 1, evt + 1)
         )
         return neo_event
 
@@ -4305,7 +4305,7 @@ class ElphyIO(BaseIO):
             # electrode providing the spiketrain
             # event though it is redundant with
             # waveforms
-            'label': "episode %s, electrode %s" % (episode, spk),
+            'label': "episode {}, electrode {}".format(episode, spk),
             'electrode_id': spk
         }
         # new spiketrain

--- a/neo/io/hdf5io.py
+++ b/neo/io/hdf5io.py
@@ -350,9 +350,9 @@ class NeoHdf5IO(BaseIO):
             channel_indexes = channel_indexes[:]
             for ci1 in channel_indexes:
                 # this works only on analogsignals
-                signal_group1 = set(tuple(x[1]) for x in ci1._channels)
+                signal_group1 = {tuple(x[1]) for x in ci1._channels}
                 for ci2 in channel_indexes:  # need to take irregularly sampled signals
-                    signal_group2 = set(tuple(x[1]) for x in ci2._channels)  # into account too
+                    signal_group2 = {tuple(x[1]) for x in ci2._channels}  # into account too
                     if signal_group1 != signal_group2:
                         if signal_group2.issubset(signal_group1):
                             channel_indexes.remove(ci2)

--- a/neo/io/igorproio.py
+++ b/neo/io/igorproio.py
@@ -95,14 +95,14 @@ class IgorIO(BaseIO):
         assert not lazy, 'Do not support lazy'
 
         if not HAVE_IGOR:
-            raise Exception(("`igor` package not installed. "
-                             "Try `pip install igor`"))
+            raise Exception("`igor` package not installed. "
+                             "Try `pip install igor`")
         if self.extension == 'ibw':
             data = bw.load(self.filename)
             version = data['version']
             if version > 5:
-                raise IOError(("Igor binary wave file format version {0} "
-                               "is not supported.".format(version)))
+                raise IOError("Igor binary wave file format version {} "
+                               "is not supported.".format(version))
         elif self.extension == 'pxp':
             assert type(path) is str, \
                 "A colon-separated Igor-style path must be provided."

--- a/neo/io/klustakwikio.py
+++ b/neo/io/klustakwikio.py
@@ -448,7 +448,7 @@ class FilenameParser:
         for v in all_filenames:
             # Test whether matches format, ie ends with digits
             split_fn = os.path.split(v)[1]
-            m = glob.re.search(('^(\w+)\.%s\.(\d+)$' % typestring), split_fn)
+            m = glob.re.search((r'^(\w+)\.%s\.(\d+)$' % typestring), split_fn)
             if m is not None:
                 # get basename from first hit if not specified
                 if self.basename is None:

--- a/neo/io/kwikio.py
+++ b/neo/io/kwikio.py
@@ -189,7 +189,7 @@ class KwikIO(BaseIO):
             A KwikModel object obtained by klusta.kwik.KwikModel(fname)
         """
         try:
-            if ((not (cluster_id in model.cluster_ids))):
+            if (not (cluster_id in model.cluster_ids)):
                 raise ValueError
         except ValueError:
             print("Exception: cluster_id (%d) not found !! " % cluster_id)

--- a/neo/io/neomatlabio.py
+++ b/neo/io/neomatlabio.py
@@ -379,7 +379,7 @@ class NeoMatlabIO(BaseIO):
             item = getattr(struct, attrname)
 
             attributes = cl._necessary_attrs + cl._recommended_attrs
-            dict_attributes = dict([(a[0], a[1:]) for a in attributes])
+            dict_attributes = {a[0]: a[1:] for a in attributes}
             if attrname in dict_attributes:
                 attrtype = dict_attributes[attrname][0]
                 if attrtype == datetime:

--- a/neo/io/neuralynxio_v1.py
+++ b/neo/io/neuralynxio_v1.py
@@ -1876,7 +1876,7 @@ class NeuralynxIO(BaseIO):
 
                 if matching_key in parameter_dict:
                     warnings.warn(
-                        'Multiple entries for %s in text header of %s' % (
+                        'Multiple entries for {} in text header of {}'.format(
                             matching_key, filename))
                 else:
                     parameter_dict[matching_key] = minor_value
@@ -2133,10 +2133,10 @@ class NeuralynxIO(BaseIO):
             for d in event_types:
                 d.pop('timestamp')
             self.parameters_nev[filename]['event_types'] = [dict(y) for y in
-                                                            set(tuple(
+                                                            {tuple(
                                                                 x.items())
                                                                 for x in
-                                                                event_types)]
+                                                                event_types}]
 
     # ________________ File Checks __________________________________
 

--- a/neo/io/tools.py
+++ b/neo/io/tools.py
@@ -88,8 +88,8 @@ class LazyList(MutableSequence):
     contain the information that ``load_lazy_cascade`` needs to load the
     respective object.
     """
-    _container_objects = set(
-        [Block, Segment, ChannelIndex, Unit])
+    _container_objects = {
+        Block, Segment, ChannelIndex, Unit}
     _neo_objects = _container_objects.union(
         [AnalogSignal, Epoch, Event,
          IrregularlySampledSignal, SpikeTrain])

--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -348,7 +348,7 @@ class AxonRawIO(BaseRawIO):
                         i_end = i_last + epoch['lEpochInitDuration'] + \
                             epoch['lEpochDurationInc'] * epiNum
                         dif = i_end - i_begin
-                        sig[i_begin:i_end] = np.ones((dif)) * \
+                        sig[i_begin:i_end] = np.ones(dif) * \
                             (epoch['fEpochInitLevel'] + epoch['fEpochLevelInc'] * epiNum)
                         i_last += epoch['lEpochInitDuration'] + \
                             epoch['lEpochDurationInc'] * epiNum

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -800,7 +800,7 @@ class BlackrockRawIO(BaseRawIO):
         if nsx_file_id['file_id'].decode() == 'NEURALSG':
             spec = '2.1'
         elif nsx_file_id['file_id'].decode() == 'NEURALCD':
-            spec = '{0}.{1}'.format(
+            spec = '{}.{}'.format(
                 nsx_file_id['ver_major'], nsx_file_id['ver_minor'])
         else:
             raise IOError('Unsupported NSX file type.')
@@ -821,10 +821,10 @@ class BlackrockRawIO(BaseRawIO):
 
         nev_file_id = np.fromfile(filename, count=1, dtype=dt0)[0]
         if nev_file_id['file_id'].decode() == 'NEURALEV':
-            spec = '{0}.{1}'.format(
+            spec = '{}.{}'.format(
                 nev_file_id['ver_major'], nev_file_id['ver_minor'])
         else:
-            raise IOError('NEV file type {0} is not supported'.format(
+            raise IOError('NEV file type {} is not supported'.format(
                 nev_file_id['file_id']))
 
         return spec
@@ -1149,7 +1149,7 @@ class BlackrockRawIO(BaseRawIO):
         dt0 = [
             ('timestamp', 'uint32'),
             ('packet_id', 'uint16'),
-            ('value', 'S{0}'.format(data_size - 6))]
+            ('value', 'S{}'.format(data_size - 6))]
 
         raw_data = np.memmap(filename, offset=header_size, dtype=dt0, mode='r')
 
@@ -1511,7 +1511,7 @@ class BlackrockRawIO(BaseRawIO):
                     ('analog_input_channel_3', 'int16'),
                     ('analog_input_channel_4', 'int16'),
                     ('analog_input_channel_5', 'int16'),
-                    ('unused', 'S{0}'.format(data_size - 20))],
+                    ('unused', 'S{}'.format(data_size - 20))],
                 # Version>=2.3
                 'b': [
                     ('timestamp', 'uint32'),
@@ -1519,14 +1519,14 @@ class BlackrockRawIO(BaseRawIO):
                     ('packet_insertion_reason', 'uint8'),
                     ('reserved', 'uint8'),
                     ('digital_input', 'uint16'),
-                    ('unused', 'S{0}'.format(data_size - 10))]},
+                    ('unused', 'S{}'.format(data_size - 10))]},
             'Spikes': {
                 'a': [
                     ('timestamp', 'uint32'),
                     ('packet_id', 'uint16'),
                     ('unit_class_nb', 'uint8'),
                     ('reserved', 'uint8'),
-                    ('waveform', 'S{0}'.format(data_size - 8))]},
+                    ('waveform', 'S{}'.format(data_size - 8))]},
             'Comments': {
                 'a': [
                     ('timestamp', 'uint32'),
@@ -1534,7 +1534,7 @@ class BlackrockRawIO(BaseRawIO):
                     ('char_set', 'uint8'),
                     ('flag', 'uint8'),
                     ('color', 'uint32'),
-                    ('comment', 'S{0}'.format(data_size - 12))]},
+                    ('comment', 'S{}'.format(data_size - 12))]},
             'VideoSync': {
                 'a': [
                     ('timestamp', 'uint32'),
@@ -1564,7 +1564,7 @@ class BlackrockRawIO(BaseRawIO):
                     ('timestamp', 'uint32'),
                     ('packet_id', 'uint16'),
                     ('config_change_type', 'uint16'),
-                    ('config_changed', 'S{0}'.format(data_size - 8))]}}
+                    ('config_changed', 'S{}'.format(data_size - 8))]}}
 
         return __nev_data_types
 
@@ -1586,7 +1586,7 @@ class BlackrockRawIO(BaseRawIO):
             'max_res': self.__nev_basic_header['timestamp_resolution'],
             'channel_ids': self.__nev_ext_header[b'NEUEVWAV']['electrode_id'],
             'channel_labels': self.__channel_labels[self.__nev_spec](),
-            'event_unit': pq.CompoundUnit("1.0/{0} * s".format(
+            'event_unit': pq.CompoundUnit("1.0/{} * s".format(
                 self.__nev_basic_header['timestamp_resolution'])),
             'nb_units': dict(zip(
                 self.__nev_ext_header[b'NEUEVWAV']['electrode_id'],
@@ -1599,7 +1599,7 @@ class BlackrockRawIO(BaseRawIO):
             'waveform_dtypes': self.__get_waveforms_dtype(),
             'waveform_sampling_rate':
                 self.__nev_basic_header['sample_resolution'] * pq.Hz,
-            'waveform_time_unit': pq.CompoundUnit("1.0/{0} * s".format(
+            'waveform_time_unit': pq.CompoundUnit("1.0/{} * s".format(
                 self.__nev_basic_header['sample_resolution'])),
             'waveform_unit': pq.uV}
 
@@ -1673,7 +1673,7 @@ class BlackrockRawIO(BaseRawIO):
         # get the dtype of waveform (this is stupidly complicated)
         if self.__is_set(
                 np.array(self.__nev_basic_header['additionnal_flags']), 0):
-            dtype_waveforms = dict((k, 'int16') for k in all_el_ids)
+            dtype_waveforms = {k: 'int16' for k in all_el_ids}
         else:
             # extract bytes per waveform
             waveform_bytes = \
@@ -1714,9 +1714,9 @@ class BlackrockRawIO(BaseRawIO):
         wf_dtypes = self.__get_waveforms_dtype()
         nb_bytes_wf = self.__nev_basic_header['bytes_in_data_packets'] - 8
 
-        wf_sizes = dict([
-            (ch, int(nb_bytes_wf / np.dtype(dt).itemsize)) for ch, dt in
-            wf_dtypes.items()])
+        wf_sizes = {
+            ch: int(nb_bytes_wf / np.dtype(dt).itemsize) for ch, dt in
+            wf_dtypes.items()}
 
         return wf_sizes
 
@@ -1741,7 +1741,7 @@ class BlackrockRawIO(BaseRawIO):
 
         # TODO: Double check if this is the correct assumption (10 samples)
         # default value: threshold crossing after 10 samples of waveform
-        wf_left_sweep = dict([(ch, 10 * wf_t_unit) for ch in all_ch])
+        wf_left_sweep = {ch: 10 * wf_t_unit for ch in all_ch}
 
         # non-default: threshold crossing at center of waveform
         # wf_size = self.__nev_params('waveform_size')
@@ -1808,7 +1808,7 @@ class BlackrockRawIO(BaseRawIO):
             'timestamp_resolution': 30000,
             'bytes_in_headers': bytes_in_headers,
             'sampling_rate': 30000 / self.__nsx_basic_header[nsx_nb]['period'] * pq.Hz,
-            'time_unit': pq.CompoundUnit("1.0/{0}*s".format(
+            'time_unit': pq.CompoundUnit("1.0/{}*s".format(
                 30000 / self.__nsx_basic_header[nsx_nb]['period']))}
 
         # Returns complete dictionary because then it does not need to be called so often
@@ -1839,7 +1839,7 @@ class BlackrockRawIO(BaseRawIO):
             'sampling_rate':
                 self.__nsx_basic_header[nsx_nb]['timestamp_resolution']
                 / self.__nsx_basic_header[nsx_nb]['period'] * pq.Hz,
-            'time_unit': pq.CompoundUnit("1.0/{0}*s".format(
+            'time_unit': pq.CompoundUnit("1.0/{}*s".format(
                 self.__nsx_basic_header[nsx_nb]['timestamp_resolution']
                 / self.__nsx_basic_header[nsx_nb]['period']))}
 
@@ -1868,12 +1868,12 @@ class BlackrockRawIO(BaseRawIO):
         # analog input events via threshold crossings
         for ch in range(5):
             event_types.update({
-                'analog_input_channel_{0}'.format(ch + 1): {
-                    'name': 'analog_input_channel_{0}'.format(ch + 1),
-                    'field': 'analog_input_channel_{0}'.format(ch + 1),
+                'analog_input_channel_{}'.format(ch + 1): {
+                    'name': 'analog_input_channel_{}'.format(ch + 1),
+                    'field': 'analog_input_channel_{}'.format(ch + 1),
                     'mask': self.__is_set(
                         data['packet_insertion_reason'], ch + 1),
-                    'desc': "Values of analog input channel {0} in mV "
+                    'desc': "Values of analog input channel {} in mV "
                             "(+/- 5000)".format(ch + 1)}})
 
         # TODO: define field and desc

--- a/neo/rawio/rawmcsrawio.py
+++ b/neo/rawio/rawmcsrawio.py
@@ -146,7 +146,7 @@ def parse_mcs_raw_header(filename):
                             break
                     assert split_pos is not None, 'Impossible to find units and scaling'
                     info['signal_gain'] = float(v[:split_pos])
-                    info['signal_units'] = v[split_pos:].replace(u'µ', u'u')
+                    info['signal_units'] = v[split_pos:].replace('µ', 'u')
                     info['signal_offset'] = -info['signal_gain'] * info['adc_zero']
 
                 elif key == b'Streams':

--- a/neo/rawio/tdtrawio.py
+++ b/neo/rawio/tdtrawio.py
@@ -114,7 +114,7 @@ class TdtRawIO(BaseRawIO):
 
             # If there exists an external sortcode in ./sort/[sortname]/*.SortResult
             #  (generated after offline sorting)
-            if self.sortname is not '':
+            if self.sortname != '':
                 try:
                     for file in os.listdir(os.path.join(path, 'sort', sortname)):
                         if file.endswith(".SortResult"):

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -40,8 +40,8 @@ from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_ne
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict(
-            [(str(x), TEST_ANNOTATIONS[x]) for x in range(len(TEST_ANNOTATIONS))])
+        self.annotations = {
+            str(x): TEST_ANNOTATIONS[x] for x in range(len(TEST_ANNOTATIONS))}
 
     def test__fake_neo__cascade(self):
         self.annotations['seed'] = None
@@ -447,16 +447,16 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
                               units="mV", name="test")
         self.assertEqual(signal.shape, (100, n))
         signal.channel_index = ChannelIndex(index=np.arange(n, dtype=int),
-                                            channel_names=["channel{0}".format(i) for i in
+                                            channel_names=["channel{}".format(i) for i in
                                                            range(n)])
         signal.channel_index.analogsignals.append(signal)
         odd_channels = signal[:, 1::2]
         self.assertEqual(odd_channels.shape, (100, n // 2))
         assert_array_equal(odd_channels.channel_index.index, np.arange(n // 2, dtype=int))
         assert_array_equal(odd_channels.channel_index.channel_names,
-                           ["channel{0}".format(i) for i in range(1, n, 2)])
+                           ["channel{}".format(i) for i in range(1, n, 2)])
         assert_array_equal(signal.channel_index.channel_names,
-                           ["channel{0}".format(i) for i in range(n)])
+                           ["channel{}".format(i) for i in range(n)])
         self.assertEqual(odd_channels.channel_index.analogsignals[0].name, signal.name)
 
     def test__time_slice_should_set_parents_to_None(self):

--- a/neo/test/coretest/test_analogsignalarray.py
+++ b/neo/test/coretest/test_analogsignalarray.py
@@ -33,8 +33,8 @@ from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_ne
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict(
-            [(str(x), TEST_ANNOTATIONS[x]) for x in range(len(TEST_ANNOTATIONS))])
+        self.annotations = {
+            str(x): TEST_ANNOTATIONS[x] for x in range(len(TEST_ANNOTATIONS))}
 
     def test__get_fake_values(self):
         self.annotations['seed'] = 0

--- a/neo/test/coretest/test_base.py
+++ b/neo/test/coretest/test_base.py
@@ -53,7 +53,7 @@ class Test_check_annotations(unittest.TestCase):
                        np.array([True, False])]
 
     def test__check_annotations__invalid_ValueError(self):
-        value = set([])
+        value = set()
         self.assertRaises(ValueError, _check_annotations, value)
 
     def test__check_annotations__invalid_dtype_ValueError(self):
@@ -572,7 +572,7 @@ class TestBaseNeoContainerTypes(unittest.TestCase):
 
     def test_python_set(self):
         '''test to make sure set type data is rejected'''
-        value = set([None, 10, 9.2, complex(23, 11)])
+        value = {None, 10, 9.2, complex(23, 11)}
         self.assertRaises(ValueError, self.base.annotate, data=value)
 
     def test_python_frozenset(self):
@@ -1097,7 +1097,7 @@ class Test_pprint(unittest.TestCase):
         description = 'this is a test'
         obj = BaseNeo(name=name, description=description)
         res = pretty(obj)
-        targ = "BaseNeo name: '%s' description: '%s'" % (name, description)
+        targ = "BaseNeo name: '{}' description: '{}'".format(name, description)
         self.assertEqual(res, targ)
 
 

--- a/neo/test/coretest/test_block.py
+++ b/neo/test/coretest/test_block.py
@@ -33,8 +33,8 @@ from neo.test.generate_datasets import (get_fake_value, get_fake_values,
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict([(str(x), TEST_ANNOTATIONS[x]) for x in
-                                 range(len(TEST_ANNOTATIONS))])
+        self.annotations = {str(x): TEST_ANNOTATIONS[x] for x in
+                                 range(len(TEST_ANNOTATIONS))}
 
     def test__get_fake_values(self):
         self.annotations['seed'] = 0

--- a/neo/test/coretest/test_channelindex.py
+++ b/neo/test/coretest/test_channelindex.py
@@ -32,8 +32,8 @@ from neo.test.generate_datasets import (fake_neo, get_fake_value,
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict([(str(x), TEST_ANNOTATIONS[x]) for x in
-                                 range(len(TEST_ANNOTATIONS))])
+        self.annotations = {str(x): TEST_ANNOTATIONS[x] for x in
+                                 range(len(TEST_ANNOTATIONS))}
 
     # def test__get_fake_values(self):
     #     self.annotations['seed'] = 0

--- a/neo/test/coretest/test_container.py
+++ b/neo/test/coretest/test_container.py
@@ -26,7 +26,7 @@ class Test_unique_objs(unittest.TestCase):
         a = 1
         b = np.array([3.14159265, 3.1415])
         c = [1, '1', 2.3, '5 8']
-        d = set([1, '2', 'spam'])
+        d = {1, '2', 'spam'}
 
         objs = [a, b, b, b, c, b, a, d, b, b, a, d, d, d, c, d, b, d, c, a]
         targ = [a, b, c, d]
@@ -175,7 +175,7 @@ class Test_pprint(unittest.TestCase):
         description = 'this is a test'
         obj = Container(name=name, description=description)
         res = pretty(obj)
-        targ = "Container with  name: '%s' description: '%s'" % (name,
+        targ = "Container with  name: '{}' description: '{}'".format(name,
                                                                  description)
         self.assertEqual(res, targ)
 

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -35,8 +35,8 @@ from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_ne
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict(
-            [(str(x), TEST_ANNOTATIONS[x]) for x in range(len(TEST_ANNOTATIONS))])
+        self.annotations = {
+            str(x): TEST_ANNOTATIONS[x] for x in range(len(TEST_ANNOTATIONS))}
 
     def test__get_fake_values(self):
         self.annotations['seed'] = 0

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -37,8 +37,8 @@ warnings.simplefilter("always")
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict(
-            [(str(x), TEST_ANNOTATIONS[x]) for x in range(len(TEST_ANNOTATIONS))])
+        self.annotations = {
+            str(x): TEST_ANNOTATIONS[x] for x in range(len(TEST_ANNOTATIONS))}
 
     def test__get_fake_values(self):
         self.annotations['seed'] = 0

--- a/neo/test/coretest/test_generate_datasets.py
+++ b/neo/test/coretest/test_generate_datasets.py
@@ -466,7 +466,7 @@ class Test__get_fake_value(unittest.TestCase):
 
     def test__other_valueerror(self):
         name = 'test__other_fail'
-        datatype = set([1, 2, 3, 4])
+        datatype = {1, 2, 3, 4}
 
         self.assertRaises(ValueError, get_fake_value, name, datatype)
 
@@ -474,8 +474,8 @@ class Test__get_fake_value(unittest.TestCase):
 class Test__get_fake_values(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict(
-            [(str(x), TEST_ANNOTATIONS[x]) for x in range(len(TEST_ANNOTATIONS))])
+        self.annotations = {
+            str(x): TEST_ANNOTATIONS[x] for x in range(len(TEST_ANNOTATIONS))}
         self.annotations['seed'] = 0
 
     def subcheck__get_fake_values(self, cls):
@@ -562,8 +562,8 @@ class Test__get_fake_values(unittest.TestCase):
 
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
-        self.annotations = dict(
-            [(str(x), TEST_ANNOTATIONS[x]) for x in range(len(TEST_ANNOTATIONS))])
+        self.annotations = {
+            str(x): TEST_ANNOTATIONS[x] for x in range(len(TEST_ANNOTATIONS))}
 
     def check__generate_datasets(self, cls):
         clsname = cls.__name__

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -37,8 +37,8 @@ from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_ne
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict(
-            [(str(x), TEST_ANNOTATIONS[x]) for x in range(len(TEST_ANNOTATIONS))])
+        self.annotations = {
+            str(x): TEST_ANNOTATIONS[x] for x in range(len(TEST_ANNOTATIONS))}
 
     def test__get_fake_values(self):
         self.annotations['seed'] = 0
@@ -881,9 +881,9 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         targ = (("IrregularlySampledSignal with %d channels of length %d; units %s; datatype %s \n"
                  "" % (signal.shape[1], signal.shape[0], signal.units.dimensionality.unicode,
                        signal.dtype))
-                + ("name: '%s'\ndescription: '%s'\n" % (signal.name, signal.description))
+                + ("name: '{}'\ndescription: '{}'\n".format(signal.name, signal.description))
                 + ("annotations: %s\n" % str(signal.annotations))
-                + ("sample times: %s" % (signal.times[:10],)))
+                + ("sample times: {}".format(signal.times[:10])))
         self.assertEqual(res, targ)
 
     def test__merge(self):

--- a/neo/test/coretest/test_segment.py
+++ b/neo/test/coretest/test_segment.py
@@ -39,8 +39,8 @@ from neo.io.proxyobjects import (AnalogSignalProxy, SpikeTrainProxy,
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict([(str(x), TEST_ANNOTATIONS[x]) for x in
-                                 range(len(TEST_ANNOTATIONS))])
+        self.annotations = {str(x): TEST_ANNOTATIONS[x] for x in
+                                 range(len(TEST_ANNOTATIONS))}
 
     def test__get_fake_values(self):
         self.annotations['seed'] = 0

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -40,8 +40,8 @@ from neo.test.generate_datasets import (get_fake_value, get_fake_values, fake_ne
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict(
-            [(str(x), TEST_ANNOTATIONS[x]) for x in range(len(TEST_ANNOTATIONS))])
+        self.annotations = {
+            str(x): TEST_ANNOTATIONS[x] for x in range(len(TEST_ANNOTATIONS))}
 
     def test__get_fake_values(self):
         self.annotations['seed'] = 0

--- a/neo/test/coretest/test_unit.py
+++ b/neo/test/coretest/test_unit.py
@@ -32,8 +32,8 @@ from neo.test.generate_datasets import (fake_neo, get_fake_value,
 class Test__generate_datasets(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
-        self.annotations = dict([(str(x), TEST_ANNOTATIONS[x]) for x in
-                                 range(len(TEST_ANNOTATIONS))])
+        self.annotations = {str(x): TEST_ANNOTATIONS[x] for x in
+                                 range(len(TEST_ANNOTATIONS))}
 
     def test__get_fake_values(self):
         self.annotations['seed'] = 0

--- a/neo/test/generate_datasets.py
+++ b/neo/test/generate_datasets.py
@@ -167,14 +167,14 @@ def get_fake_value(name, datatype, dim=0, dtype='float', seed=None, units=None, 
         obj = obj.__name__
 
     if (name in ['name', 'file_origin', 'description'] and (datatype != str or dim)):
-        raise ValueError('%s must be str, not a %sD %s' % (name, dim, datatype))
+        raise ValueError('{} must be str, not a {}D {}'.format(name, dim, datatype))
 
     if name == 'file_origin':
         return 'test_file.txt'
     if name == 'name':
-        return '%s%s' % (obj, get_fake_value('', datatype, seed=seed))
+        return '{}{}'.format(obj, get_fake_value('', datatype, seed=seed))
     if name == 'description':
-        return 'test %s %s' % (obj, get_fake_value('', datatype, seed=seed))
+        return 'test {} {}'.format(obj, get_fake_value('', datatype, seed=seed))
 
     if seed is not None:
         np.random.seed(seed)
@@ -189,7 +189,7 @@ def get_fake_value(name, datatype, dim=0, dtype='float', seed=None, units=None, 
         return datetime.fromtimestamp(1000000000 * np.random.random())
 
     if (name in ['t_start', 't_stop', 'sampling_rate'] and (datatype != pq.Quantity or dim)):
-        raise ValueError('%s must be a 0D Quantity, not a %sD %s' % (name, dim, datatype))
+        raise ValueError('{} must be a 0D Quantity, not a {}D {}'.format(name, dim, datatype))
 
     # only put array types below here
 
@@ -263,7 +263,7 @@ def get_fake_value(name, datatype, dim=0, dtype='float', seed=None, units=None, 
         return arr_ann
 
     # we have gone through everything we know, so it must be something invalid
-    raise ValueError('Unknown name/datatype combination %s %s' % (name, datatype))
+    raise ValueError('Unknown name/datatype combination {} {}'.format(name, datatype))
 
 
 def get_fake_values(cls, annotate=True, seed=None, n=None):
@@ -337,7 +337,7 @@ def get_annotations():
     Returns a dict containing the default values for annotations for
     a class from neo.core.
     '''
-    return dict([(str(i), ann) for i, ann in enumerate(TEST_ANNOTATIONS)])
+    return {str(i): ann for i, ann in enumerate(TEST_ANNOTATIONS)}
 
 
 def fake_epoch(seed=None, n=1):

--- a/neo/test/iotest/common_io_test.py
+++ b/neo/test/iotest/common_io_test.py
@@ -23,11 +23,7 @@ __test__ = False
 
 import os
 from copy import copy
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from neo.core import Block, Segment
 from neo.test.tools import (assert_same_sub_schema,

--- a/neo/test/iotest/test_blackrockio.py
+++ b/neo/test/iotest/test_blackrockio.py
@@ -314,7 +314,7 @@ class CommonTests(BaseTestIO, unittest.TestCase):
                 matlab_spikes = ts_ml[np.nonzero(
                     np.logical_and(elec_ml == channelid, unit_ml == unitid))]
                 # Going sure that unit is really seconds and not 1/30000 seconds
-                if (not st_i.units == pq.CompoundUnit("1.0/{0} * s".format(30000))) and \
+                if (not st_i.units == pq.CompoundUnit("1.0/{} * s".format(30000))) and \
                         st_i.units == pq.s:
                     st_i = np.round(st_i.base * 30000).astype(int)
                 assert_equal(st_i, matlab_spikes)

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -132,9 +132,9 @@ class NixIOTest(unittest.TestCase):
             # AnalogSignals referencing CHX
             neoasigs = list(sig.annotations["nix_name"]
                             for sig in neochx.analogsignals)
-            nixasigs = list(set(da.metadata.name for da in nixblock.data_arrays
+            nixasigs = list({da.metadata.name for da in nixblock.data_arrays
                                 if da.type == "neo.analogsignal" and
-                                nixchx in da.sources))
+                                nixchx in da.sources})
 
             self.assertEqual(len(neoasigs), len(nixasigs))
 
@@ -142,9 +142,9 @@ class NixIOTest(unittest.TestCase):
             neoisigs = list(sig.annotations["nix_name"] for sig in
                             neochx.irregularlysampledsignals)
             nixisigs = list(
-                set(da.metadata.name for da in nixblock.data_arrays
+                {da.metadata.name for da in nixblock.data_arrays
                     if da.type == "neo.irregularlysampledsignal" and
-                    nixchx in da.sources)
+                    nixchx in da.sources}
             )
             self.assertEqual(len(neoisigs), len(nixisigs))
             # SpikeTrains referencing CHX and Units

--- a/neo/test/test_utils.py
+++ b/neo/test/test_utils.py
@@ -284,7 +284,7 @@ class TestUtilsWithoutProxyObjects(unittest.TestCase):
         assert_arrays_almost_equal(ep_starts.times, starts.times - 300 * pq.ms, 1e-12)
         assert_arrays_almost_equal(ep_starts.durations,
                                    (550 * pq.ms).rescale(ep_starts.durations.units)
-                                   * np.ones((len(starts))), 1e-12)
+                                   * np.ones(len(starts)), 1e-12)
 
         # test cutting with two events
         ep_trials = add_epoch(seg, starts, stops)
@@ -613,7 +613,7 @@ class TestUtilsWithProxyObjects(BaseProxyTest):
 
         block2 = Block()
         seg2 = Segment()
-        epoch = Epoch(np.arange(10) * pq.s, durations=np.ones((10)) * pq.s)
+        epoch = Epoch(np.arange(10) * pq.s, durations=np.ones(10) * pq.s)
         epoch.annotate(pick='me instead')
         seg2.epochs = [proxy_epoch, epoch]
         block2.segments = [seg2]

--- a/neo/test/tools.py
+++ b/neo/test/tools.py
@@ -40,7 +40,8 @@ def assert_arrays_equal(a, b, dtype=False):
             assert np.all(a.flatten() == b.flatten()), "{} != {}".format(a, b)
 
     if dtype:
-        assert a.dtype == b.dtype, "{} and {} not same dtype {} and {}".format(a, b, a.dtype, b.dtype)
+        assert a.dtype == b.dtype, "{} and {} not same dtype {} and {}".format(
+            a, b, a.dtype, b.dtype)
 
 
 def assert_arrays_almost_equal(a, b, threshold, dtype=False):
@@ -66,7 +67,8 @@ def assert_arrays_almost_equal(a, b, threshold, dtype=False):
                                        "" % (a, b, (abs(a - b)).max(), threshold)
 
     if dtype:
-        assert a.dtype == b.dtype, "{} and {} not same dtype {} and {}".format(a, b, a.dtype, b.dtype)
+        assert a.dtype == b.dtype, "{} and {} not same dtype {} and {}".format(
+            a, b, a.dtype, b.dtype)
 
 
 def file_digest(filename):
@@ -116,7 +118,8 @@ def assert_neo_object_is_compliant(ob, check_type=True):
         attrname, attrtype = ioattr[0], ioattr[1]
         # ~ if attrname != '':
         if not hasattr(ob, '_quantity_attr'):
-            assert hasattr(ob, attrname), '{} neo obect does not have {}'.format(classname, attrname)
+            assert hasattr(ob, attrname), '{} neo obect does not have {}'.format(
+                classname, attrname)
 
     # test attributes types
     for ioattr in ob._all_attrs:

--- a/neo/test/tools.py
+++ b/neo/test/tools.py
@@ -25,22 +25,22 @@ def assert_arrays_equal(a, b, dtype=False):
     '''
     assert isinstance(a, np.ndarray), "a is a %s" % type(a)
     assert isinstance(b, np.ndarray), "b is a %s" % type(b)
-    assert a.shape == b.shape, "%s != %s" % (a, b)
+    assert a.shape == b.shape, "{} != {}".format(a, b)
     # assert a.dtype == b.dtype, "%s and %s not same dtype %s %s" % (a, b,
     #                                                               a.dtype,
     #                                                               b.dtype)
     try:
-        assert (a.flatten() == b.flatten()).all(), "%s != %s" % (a, b)
+        assert (a.flatten() == b.flatten()).all(), "{} != {}".format(a, b)
     except (AttributeError, ValueError):
         try:
             ar = np.array(a)
             br = np.array(b)
-            assert (ar.flatten() == br.flatten()).all(), "%s != %s" % (ar, br)
+            assert (ar.flatten() == br.flatten()).all(), "{} != {}".format(ar, br)
         except (AttributeError, ValueError):
-            assert np.all(a.flatten() == b.flatten()), "%s != %s" % (a, b)
+            assert np.all(a.flatten() == b.flatten()), "{} != {}".format(a, b)
 
     if dtype:
-        assert a.dtype == b.dtype, "%s and %s not same dtype %s and %s" % (a, b, a.dtype, b.dtype)
+        assert a.dtype == b.dtype, "{} and {} not same dtype {} and {}".format(a, b, a.dtype, b.dtype)
 
 
 def assert_arrays_almost_equal(a, b, threshold, dtype=False):
@@ -56,7 +56,7 @@ def assert_arrays_almost_equal(a, b, threshold, dtype=False):
 
     assert isinstance(a, np.ndarray), "a is a %s" % type(a)
     assert isinstance(b, np.ndarray), "b is a %s" % type(b)
-    assert a.shape == b.shape, "%s != %s" % (a, b)
+    assert a.shape == b.shape, "{} != {}".format(a, b)
     # assert a.dtype == b.dtype, "%s and %b not same dtype %s %s" % (a, b,
     #                                                               a.dtype,
     #                                                               b.dtype)
@@ -66,7 +66,7 @@ def assert_arrays_almost_equal(a, b, threshold, dtype=False):
                                        "" % (a, b, (abs(a - b)).max(), threshold)
 
     if dtype:
-        assert a.dtype == b.dtype, "%s and %s not same dtype %s and %s" % (a, b, a.dtype, b.dtype)
+        assert a.dtype == b.dtype, "{} and {} not same dtype {} and {}".format(a, b, a.dtype, b.dtype)
 
 
 def file_digest(filename):
@@ -116,7 +116,7 @@ def assert_neo_object_is_compliant(ob, check_type=True):
         attrname, attrtype = ioattr[0], ioattr[1]
         # ~ if attrname != '':
         if not hasattr(ob, '_quantity_attr'):
-            assert hasattr(ob, attrname), '%s neo obect does not have %s' % (classname, attrname)
+            assert hasattr(ob, attrname), '{} neo obect does not have {}'.format(classname, attrname)
 
     # test attributes types
     for ioattr in ob._all_attrs:
@@ -166,7 +166,7 @@ def assert_neo_object_is_compliant(ob, check_type=True):
             assert_neo_object_is_compliant(child)
         # intercept exceptions and add more information
         except BaseException as exc:
-            exc.args += ('from %s %s of %s' % (child.__class__.__name__, i, classname),)
+            exc.args += ('from {} {} of {}'.format(child.__class__.__name__, i, classname),)
             raise
 
 
@@ -184,7 +184,7 @@ def assert_same_sub_schema(ob1, ob2, equal_almost=True, threshold=1e-10, exclude
                  the comparison
 
     '''
-    assert type(ob1) == type(ob2), 'type(%s) != type(%s)' % (type(ob1), type(ob2))
+    assert type(ob1) == type(ob2), 'type({}) != type({})'.format(type(ob1), type(ob2))
     classname = ob1.__class__.__name__
 
     if exclude is None:
@@ -199,7 +199,7 @@ def assert_same_sub_schema(ob1, ob2, equal_almost=True, threshold=1e-10, exclude
                                        exclude=exclude)
             # intercept exceptions and add more information
             except BaseException as exc:
-                exc.args += ('%s[%s]' % (classname, i),)
+                exc.args += ('{}[{}]'.format(classname, i),)
                 raise
         return
 
@@ -212,7 +212,7 @@ def assert_same_sub_schema(ob1, ob2, equal_almost=True, threshold=1e-10, exclude
                                                 '' % (classname, container, classname)
             continue
         else:
-            assert hasattr(ob2, container), '%s 1 has %s but not %s 2' % (classname, container,
+            assert hasattr(ob2, container), '{} 1 has {} but not {} 2'.format(classname, container,
                                                                           classname)
 
         sub1 = getattr(ob1, container)
@@ -228,7 +228,7 @@ def assert_same_sub_schema(ob1, ob2, equal_almost=True, threshold=1e-10, exclude
                                        threshold=threshold, exclude=exclude)
             # intercept exceptions and add more information
             except BaseException as exc:
-                exc.args += ('from %s[%s] of %s' % (container, i, classname),)
+                exc.args += ('from {}[{}] of {}'.format(container, i, classname),)
                 raise
 
     assert_same_attributes(ob1, ob2, equal_almost=equal_almost, threshold=threshold,
@@ -269,7 +269,7 @@ def assert_same_attributes(ob1, ob2, equal_almost=True, threshold=1e-10, exclude
                                            dtype=dtype)
             # intercept exceptions and add more information
             except BaseException as exc:
-                exc.args += ('from %s %s' % (classname, attrname),)
+                exc.args += ('from {} {}'.format(classname, attrname),)
                 raise
             assert ob1.dimensionality.string == ob2.dimensionality.string,\
                 'Units of %s %s are not the same: %s and %s' \
@@ -307,7 +307,7 @@ def assert_same_attributes(ob1, ob2, equal_almost=True, threshold=1e-10, exclude
                 assert_arrays_almost_equal(mag1, mag2, threshold=threshold, dtype=dtype)
             # intercept exceptions and add more information
             except BaseException as exc:
-                exc.args += ('from %s of %s' % (attrname, classname),)
+                exc.args += ('from {} of {}'.format(attrname, classname),)
                 raise
             # Compare dimensionalities
             dim1 = getattr(ob1, attrname).dimensionality.simplified
@@ -322,7 +322,7 @@ def assert_same_attributes(ob1, ob2, equal_almost=True, threshold=1e-10, exclude
                                            threshold=threshold, dtype=dtype)
             # intercept exceptions and add more information
             except BaseException as exc:
-                exc.args += ('from %s of %s' % (attrname, classname),)
+                exc.args += ('from {} of {}'.format(attrname, classname),)
                 raise
         else:
             # ~ print 'yep', getattr(ob1, attrname),  getattr(ob2, attrname)
@@ -421,7 +421,7 @@ def assert_sub_schema_is_lazy_loaded(ob):
                     assert_sub_schema_is_lazy_loaded(child)
                 # intercept exceptions and add more information
                 except BaseException as exc:
-                    exc.args += ('from %s %s of %s' % (container, i, classname),)
+                    exc.args += ('from {} {} of {}'.format(container, i, classname),)
                     raise
     else:
         assert ob.__class__ in proxyobjectlist, 'Data object must lazy %' % classname

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,6 @@ extras_require = {
     'stimfitio': ['stfio'],
 }
 
-if os.environ.get('TRAVIS') == 'true' and \
-        os.environ.get('TRAVIS_PYTHON_VERSION').startswith('2.6'):
-    install_requires.append('unittest2>=0.5.1')
-
 with open("neo/version.py") as fp:
     d = {}
     exec(fp.read(), d)
@@ -40,7 +36,8 @@ setup(
                 "neurophysiology file formats",
     long_description=long_description,
     license="BSD-3-Clause",
-    url='http://neuralensemble.org/neo',
+    url='https://neuralensemble.org/neo',
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
@@ -50,8 +47,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Scientific/Engineering']

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,10 @@
 [tox]
-envlist = py26,py32
+envlist = py27, py35, py36, py37
 [testenv]
-commands=nosetests
+commands=nosetests {posargs}
+deps =
+    # essential
+    numpy>=1.7.1,!=1.16.0
+    quantities>=0.9.0
+    # for running tests
+    nose>=1.1.2


### PR DESCRIPTION
Python 3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

It's also little used. Here's the pip installs for neo from PyPI for June 2019:

| category | percent | downloads |
|----------|--------:|----------:|
| 3.6      |  55.89% |     2,994 |
| 3.7      |  24.85% |     1,331 |
| 2.7      |  14.11% |       756 |
| 3.5      |   3.60% |       193 |
| null     |   1.31% |        70 |
| 3.4      |   0.22% |        12 |
| 3.3      |   0.02% |         1 |
| Total    |         |     5,357 |

Source: `pypistats python_minor neo --last-month # pip install pypistats`