### PR TITLE
BF: use numpy.testing.SkipTest instead of unittest.SkipTest

### DIFF
--- a/neo/test/iotest/common_io_test.py
+++ b/neo/test/iotest/common_io_test.py
@@ -29,6 +29,8 @@ try:
 except ImportError:
     import unittest
 
+from numpy.testing import SkipTest
+
 from neo.core import Block, Segment
 from neo.test.tools import (assert_same_sub_schema,
                             assert_neo_object_is_compliant,
@@ -122,7 +124,7 @@ class BaseTestIO(object):
 
         ''' % self.ioclass.__name__
         if not self.use_network:
-            raise unittest.SkipTest("Requires download of data from the web")
+            raise SkipTest("Requires download of data from the web")
 
         url = url_for_tests + self.shortname
         try:


### PR DESCRIPTION
For some (not yet 100% clear reason) raising unittest.SkipTest caused
an error instead of a test being skipped while building the Debian
package with nose 1.3.7-4

Just wanted to share even though I don't fully grasp the reason.  I will also adopt this patch for Debian package (unfortunately pretty much all tests get skipped now :-/)