### PR TITLE
Can't use exact comparison for floating point.

### DIFF
--- a/neo/rawio/spike2rawio.py
+++ b/neo/rawio/spike2rawio.py
@@ -127,7 +127,12 @@ class Spike2RawIO(BaseRawIO):
                     # detect gaps
                     inter_block_sizes = data_blocks['start_time'][1:] - \
                         data_blocks['end_time'][:-1]
-                    gaps_block_ind, = np.nonzero(inter_block_sizes > interval)
+                    # Due to rounding errors, have to check if the value is larger
+                    # which means its not close and larger
+                    gaps_block_ind, = np.nonzero(np.logical_and(
+                        inter_block_sizes > interval,
+                        np.logical_not(np.isclose(inter_block_sizes, interval))
+                    ))
                     all_gaps_block_ind[chan_id] = gaps_block_ind
 
         # find t_start/t_stop for each seg based on gaps indexe


### PR DESCRIPTION
We found a bug where an `assert` [here](https://github.com/NeuralEnsemble/python-neo/blob/master/neo/rawio/spike2rawio.py#L153) was hit because of an incorrect floating point comparison. 

Specifically, without the fix, it did an exact comparison to a floating point value, but for floating points, you need to use `np.isclose()`. Hence the assert failed, because this comparison was incorrect.

If you try to run with the [attached ](https://drive.google.com/file/d/15WhILxaz-OwURLjcKWpvdYvjDvQQ0qOS/view?usp=sharing) file it will raise this assert.

This seems to fix the issue, but we are not sure why the comparison is performed in the first place, so we don't know if it is a correct fix.