### PR TITLE
added EDR3 header

### DIFF
--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -458,7 +458,7 @@ def parse_axon_soup(filename):
             f.seek(sections['StringsSection']['uBlockIndex'] * BLOCKSIZE)
             big_string = f.read(sections['StringsSection']['uBytes'])
             goodstart = -1
-            for key in [b'AXENGN', b'clampex', b'Clampex',
+            for key in [b'AXENGN', b'clampex', b'Clampex', b'EDR3',
                         b'CLAMPEX', b'axoscope', b'AxoScope', b'Clampfit']:
                 # goodstart = big_string.lower().find(key)
                 goodstart = big_string.find(b'\x00' + key)

--- a/neo/test/iotest/test_axonio.py
+++ b/neo/test/iotest/test_axonio.py
@@ -15,15 +15,16 @@ from neo.test.iotest.common_io_test import BaseTestIO
 
 
 class TestAxonIO(BaseTestIO, unittest.TestCase):
-    files_to_test = ['File_axon_1.abf',
-                     'File_axon_2.abf',
-                     'File_axon_3.abf',
-                     'File_axon_4.abf',
-                     'File_axon_5.abf',
-                     'File_axon_6.abf',
-                     'File_axon_7.abf',
-
-                     ]
+    files_to_test = [
+        'File_axon_1.abf',
+        'File_axon_2.abf',
+        'File_axon_3.abf',
+        'File_axon_4.abf',
+        'File_axon_5.abf',
+        'File_axon_6.abf',
+        'File_axon_7.abf',
+        'test_file_edr3.abf',
+    ]
     files_to_download = files_to_test
     ioclass = AxonIO
 

--- a/neo/test/rawiotest/test_axonrawio.py
+++ b/neo/test/rawiotest/test_axonrawio.py
@@ -20,6 +20,7 @@ class TestAxonRawIO(BaseTestRawIO, unittest.TestCase, ):
         'File_axon_5.abf',  # V.20
         'File_axon_6.abf',  # V.20
         'File_axon_7.abf',  # V2.6
+        'test_file_edr3.abf',  # EDR3
     ]
     files_to_download = entities_to_test
 


### PR DESCRIPTION
Hello,

A while ago, we switch equipment and I started getting the following error while trying to read any new ABF files:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.7/site-packages/neo-0.8.0.dev0-py3.7.egg/neo/io/axonio.py", line 45, in __init__
    BaseFromRaw.__init__(self, filename)
  File "/usr/lib/python3.7/site-packages/neo-0.8.0.dev0-py3.7.egg/neo/io/basefromrawio.py", line 81, in __init__
    self.parse_header()
  File "/usr/lib/python3.7/site-packages/neo-0.8.0.dev0-py3.7.egg/neo/rawio/baserawio.py", line 151, in parse_header
    self._parse_header()
  File "/usr/lib/python3.7/site-packages/neo-0.8.0.dev0-py3.7.egg/neo/rawio/axonrawio.py", line 62, in _parse_header
    info = self._axon_info = parse_axon_soup(self.filename)
  File "/usr/lib/python3.7/site-packages/neo-0.8.0.dev0-py3.7.egg/neo/rawio/axonrawio.py", line 468, in parse_axon_soup
    'This file does not contain clampex, axoscope or clampfit in the header'
AssertionError: This file does not contain clampex, axoscope or clampfit in the header
```

The issue was that the EDR3 header was not in the list of proposed headers (axengn, clampex, axoscope or clampfit). If anybody has the same issue, this is the solution that I found.