### PR TITLE
[Update to PR #662] fix duplication of array_annotations into annotations

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -1190,8 +1190,6 @@ class NixIO(BaseIO):
                         values = ""
                 elif len(values) == 1:
                     values = values[0]
-                else:
-                    values = list(values)
                 if prop.definition == ARRAYANNOTATION:
                     if 'array_annotations' in neo_attrs:
                         neo_attrs['array_annotations'][prop.name] = values

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -1190,14 +1190,15 @@ class NixIO(BaseIO):
                         values = ""
                 elif len(values) == 1:
                     values = values[0]
-                elif prop.definition == ARRAYANNOTATION:
+                else:
+                    values = list(values)
+                if prop.definition == ARRAYANNOTATION:
                     if 'array_annotations' in neo_attrs:
                         neo_attrs['array_annotations'][prop.name] = values
                     else:
                         neo_attrs['array_annotations'] = {prop.name: values}
                 else:
-                    values = list(values)
-                neo_attrs[prop.name] = values
+                    neo_attrs[prop.name] = values
         # since the 'neo_name' NIX property becomes the actual object's name,
         # there's no reason to keep it in the annotations
         neo_attrs["name"] = stringify(neo_attrs.pop("neo_name", None))

--- a/neo/test/iotest/common_io_test.py
+++ b/neo/test/iotest/common_io_test.py
@@ -500,7 +500,7 @@ class BaseTestIO(object):
                 assert_neo_object_is_compliant(obj)
             # intercept exceptions and add more information
             except BaseException as exc:
-                exc.args += ('from %s' % os.path.basename(path))
+                exc.args += ('from %s' % os.path.basename(path), )
                 raise
 
     def test_readed_with_lazy_is_compliant(self):

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -787,6 +787,7 @@ class NixIOWriteTest(NixIOTest):
 
         asig = AnalogSignal(signal=self.rquant((19, 15), pq.mV),
                             sampling_rate=pq.Quantity(10, "Hz"))
+        asig.array_annotate(arr_ann=np.random.random((15,)))
         seg.analogsignals.append(asig)
         self.write_and_compare([block])
 
@@ -1495,6 +1496,19 @@ class NixIOReadTest(NixIOTest):
                     self.assertTrue(np.all(nix_ann == neo_ann.magnitude))
                     self.assertEqual(da.metadata.props['st_arr_ann'].unit,
                                      units_to_string(neo_ann.units))
+
+    def test_read_blocks_are_writable(self):
+        filename = os.path.join(self.tempdir, "testnixio_out.nix")
+        writer = NixIO(filename, "ow")
+
+        blocks = self.io.read_all_blocks()
+
+        try:
+            writer.write_all_blocks(blocks)
+        except Exception as exc:
+            self.fail('The following exception was raised when'
+                      + ' writing the blocks loaded with NixIO:\n'
+                      + str(exc))
 
 
 @unittest.skipUnless(HAVE_NIX, "Requires NIX")

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -787,7 +787,6 @@ class NixIOWriteTest(NixIOTest):
 
         asig = AnalogSignal(signal=self.rquant((19, 15), pq.mV),
                             sampling_rate=pq.Quantity(10, "Hz"))
-        asig.array_annotate(arr_ann=np.random.random((15,)))
         seg.analogsignals.append(asig)
         self.write_and_compare([block])
 


### PR DESCRIPTION
Handling Issue #748 
The issue arises from this part of the loading routine which adds properties which are an array_annotation to a corresponding nested dict within _neo_attrs_, but also adds them as a regular annotation, therefore creating a duplicate.

nixio.py line 1237-1244 (in method __nix_attr_to_neo_):
```
                elif prop.definition == ARRAYANNOTATION:
                    if 'array_annotations' in neo_attrs:
                        neo_attrs['array_annotations'][prop.name] = values
                    else:
                        neo_attrs['array_annotations'] = {prop.name: values}
                else:
                    values = list(values)
                neo_attrs[prop.name] = values
```

It seems that PR #662 intended not to duplicate the array_annotations, but the duplication was then introduced with the merge commit 0a4ccfae4aca7d854d3f1065bd8782136981f1ab
Please comment @Kleinjohann ?

The PR separates the properties again, to be either stored directly in _neo_attrs_, or in _neo_attrs['array_annotations']_ but not both.