### PR TITLE
add micro Volt conversion and import missing package

### DIFF
--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -12,7 +12,7 @@ ineherits neo.rawio.
 
 import numpy as np
 import quantities as pq
-import loggging
+import logging
 
 from neo.core.baseneo import BaseNeo
 

--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -12,6 +12,7 @@ ineherits neo.rawio.
 
 import numpy as np
 import quantities as pq
+import loggging
 
 from neo.core.baseneo import BaseNeo
 
@@ -488,7 +489,7 @@ proxyobjectlist = [AnalogSignalProxy, SpikeTrainProxy, EventProxy,
 
 
 unit_convert = {'Volts': 'V', 'volts': 'V', 'Volt': 'V',
-                'volt': 'V', ' Volt': 'V', 'microV': 'V'}
+                'volt': 'V', ' Volt': 'V', 'microV': 'uV', 'µV': 'uV'}
 
 
 def ensure_signal_units(units):


### PR DESCRIPTION
When loading a new set of Spike2 files (from 2018), the IO couldn't handle the units 'µV'.
The changes add a corresponding conversion, fix a wrong conversion and a missing import, which was discovered while fixing this bug.