### PR TITLE
Fix for SpikeTrain consistency check encountering CompundUnits

### DIFF
--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -38,10 +38,13 @@ def check_has_dimensions_time(*values):
     '''
     errmsgs = []
     for value in values:
-        dim = value.dimensionality
-        if (len(dim) != 1 or list(dim.values())[0] != 1 or not isinstance(list(dim.keys())[0],
-                                                                          pq.UnitTime)):
-            errmsgs.append("value {} has dimensions {}, not [time]".format(value, dim.simplified))
+        dim = value.dimensionality.simplified
+        if (len(dim) != 1 or
+                list(dim.values())[0] != 1 or not
+                isinstance(list(dim.keys())[0], pq.UnitTime)):
+            errmsgs.append(
+                "value {} has dimensions {}, not [time]".format(
+                    value, dim))
     if errmsgs:
         raise ValueError("\n".join(errmsgs))
 

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -143,6 +143,12 @@ class Testcheck_has_dimensions_time(unittest.TestCase):
         check_has_dimensions_time(d)
         self.assertRaises(ValueError, check_has_dimensions_time, a, b, c, d)
 
+    # Regression test for #763
+    # This test ensures the function works for compound units
+    def test__check_has_dimensions_time_compound_unit(self):
+        a = np.arange(3) * pq.CompoundUnit("1/10*s")
+        check_has_dimensions_time(a)
+
 
 class Testcheck_time_in_range(unittest.TestCase):
     def test__check_time_in_range_empty_array(self):


### PR DESCRIPTION
This fixes #763 

An additional simplified statement makes sure that CompoundUnits are first simplified such that the "true" unit can be reliably extracted. Additional, a regression test based on #763 is implemented, which failed on the pervious build.