### PR TITLE
Add resample and decimate utility methods for Analog and IrregularlysampledSignals

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -24,10 +24,11 @@ from __future__ import absolute_import, division, print_function
 import logging
 
 try:
-    SCIPY_AVAIL = True
     import scipy.signal
-except ImportError:
-    SCIPY_AVAIL = False
+except ImportError as err:
+    HAVE_SCIPY = False
+else:
+    HAVE_SCIPY = True
 
 import numpy as np
 import quantities as pq
@@ -546,7 +547,7 @@ class AnalogSignal(BaseSignal):
             self[i:j, :] = signal
             return self
 
-    def decimate(self, downsampling_factor, **kwargs):
+    def downsample(self, downsampling_factor, **kwargs):
         """
         Downsample the data of a signal.
         This function is a wrapper of scipy.signal.decimate and accepts the same set of keyword arguments,
@@ -565,7 +566,7 @@ class AnalogSignal(BaseSignal):
             The original :class:`AnalogSignal` is not modified.
         """
 
-        if not SCIPY_AVAIL:
+        if not HAVE_SCIPY:
             raise ImportError('Decimating requires availability of scipy.signal')
 
         # Resampling is only permitted along the time axis (axis=0)
@@ -581,7 +582,7 @@ class AnalogSignal(BaseSignal):
 
         return downsampled_signal
 
-    def resample_regularly(self, sample_count, **kwargs):
+    def resample(self, sample_count, **kwargs):
         """
         Resample the data points of the signal.
         This function is a wrapper of scipy.signal.resample and accepts the same set of keyword arguments,
@@ -600,7 +601,7 @@ class AnalogSignal(BaseSignal):
             The original :class:`AnalogSignal` is not modified.
         """
 
-        if not SCIPY_AVAIL:
+        if not HAVE_SCIPY:
             raise ImportError('Resampling requires availability of scipy.signal')
 
         # Resampling is only permitted along the time axis (axis=0)

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -23,6 +23,12 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
+try:
+    SCIPY_AVAIL = True
+    import scipy.signal
+except ImportError:
+    SCIPY_AVAIL = False
+
 import numpy as np
 import quantities as pq
 
@@ -539,3 +545,77 @@ class AnalogSignal(BaseSignal):
         else:
             self[i:j, :] = signal
             return self
+
+    def decimate(self, downsampling_factor, **kwargs):
+        """
+        Downsample the data of a signal.
+        This function is a wrapper of scipy.signal.decimate and accepts the same set of keyword arguments,
+        except for specifying the axis of resampling, which is fixed to the first axis here.
+
+        Parameters:
+        -----------
+        downsampling_factor: integer
+            Factor used for decimation of samples. Scipy recommends to call decimate multiple times for downsampling
+            factors higher than 13 when using IIR downsampling (default).
+
+        Returns:
+        --------
+        downsampled_signal: :class:`AnalogSignal`
+            New instance of a :class:`AnalogSignal` object containing the resampled data points.
+            The original :class:`AnalogSignal` is not modified.
+        """
+
+        if not SCIPY_AVAIL:
+            raise ImportError('Decimating requires availability of scipy.signal')
+
+        # Resampling is only permitted along the time axis (axis=0)
+        if 'axis' in kwargs:
+            kwargs.pop('axis')
+
+        downsampled_data = scipy.signal.decimate(self.magnitude, downsampling_factor, axis=0, **kwargs)
+        downsampled_signal = self.duplicate_with_new_data(downsampled_data)
+
+        # since the number of channels stays the same, we can also copy array annotations here
+        downsampled_signal.array_annotations = self.array_annotations.copy()
+        downsampled_signal.sampling_rate = self.sampling_rate / downsampling_factor
+
+        return downsampled_signal
+
+    def resample_regularly(self, sample_count, **kwargs):
+        """
+        Resample the data points of the signal.
+        This function is a wrapper of scipy.signal.resample and accepts the same set of keyword arguments,
+        except for specifying the axis of resampling which is fixed to the first axis here, and the sample positions. .
+
+        Parameters:
+        -----------
+        sample_count: integer
+            Number of desired samples. The resulting signal starts at the same sample as the original and is sampled
+            regularly.
+
+        Returns:
+        --------
+        resampled_signal: :class:`AnalogSignal`
+            New instance of a :class:`AnalogSignal` object containing the resampled data points.
+            The original :class:`AnalogSignal` is not modified.
+        """
+
+        if not SCIPY_AVAIL:
+            raise ImportError('Resampling requires availability of scipy.signal')
+
+        # Resampling is only permitted along the time axis (axis=0)
+        if 'axis' in kwargs:
+            kwargs.pop('axis')
+        if 't' in kwargs:
+            kwargs.pop('t')
+
+        resampled_data, resampled_times = scipy.signal.resample(self.magnitude, sample_count, t=self.times, axis=0,
+                                                                **kwargs)
+
+        resampled_signal = self.duplicate_with_new_data(resampled_data)
+        resampled_signal.sampling_rate = (sample_count / self.shape[0]) * self.sampling_rate
+
+        # since the number of channels stays the same, we can also copy array annotations here
+        resampled_signal.array_annotations = self.array_annotations.copy()
+
+        return resampled_signal

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -551,7 +551,8 @@ class AnalogSignal(BaseSignal):
         """
         Downsample the data of a signal.
         This function is a wrapper of scipy.signal.decimate and accepts the same set of keyword
-        arguments, except for specifying the axis of resampling, which is fixed to the first axis here.
+        arguments, except for specifying the axis of resampling, which is fixed to the first axis
+        here.
 
         Parameters:
         -----------

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -550,14 +550,14 @@ class AnalogSignal(BaseSignal):
     def downsample(self, downsampling_factor, **kwargs):
         """
         Downsample the data of a signal.
-        This function is a wrapper of scipy.signal.decimate and accepts the same set of keyword arguments,
-        except for specifying the axis of resampling, which is fixed to the first axis here.
+        This function is a wrapper of scipy.signal.decimate and accepts the same set of keyword
+        arguments, except for specifying the axis of resampling, which is fixed to the first axis here.
 
         Parameters:
         -----------
         downsampling_factor: integer
-            Factor used for decimation of samples. Scipy recommends to call decimate multiple times for downsampling
-            factors higher than 13 when using IIR downsampling (default).
+            Factor used for decimation of samples. Scipy recommends to call decimate multiple times
+            for downsampling factors higher than 13 when using IIR downsampling (default).
 
         Returns:
         --------
@@ -573,7 +573,8 @@ class AnalogSignal(BaseSignal):
         if 'axis' in kwargs:
             kwargs.pop('axis')
 
-        downsampled_data = scipy.signal.decimate(self.magnitude, downsampling_factor, axis=0, **kwargs)
+        downsampled_data = scipy.signal.decimate(self.magnitude, downsampling_factor, axis=0,
+                                                 **kwargs)
         downsampled_signal = self.duplicate_with_new_data(downsampled_data)
 
         # since the number of channels stays the same, we can also copy array annotations here
@@ -585,14 +586,15 @@ class AnalogSignal(BaseSignal):
     def resample(self, sample_count, **kwargs):
         """
         Resample the data points of the signal.
-        This function is a wrapper of scipy.signal.resample and accepts the same set of keyword arguments,
-        except for specifying the axis of resampling which is fixed to the first axis here, and the sample positions. .
+        This function is a wrapper of scipy.signal.resample and accepts the same set of keyword
+        arguments, except for specifying the axis of resampling which is fixed to the first axis
+        here, and the sample positions. .
 
         Parameters:
         -----------
         sample_count: integer
-            Number of desired samples. The resulting signal starts at the same sample as the original and is sampled
-            regularly.
+            Number of desired samples. The resulting signal starts at the same sample as the
+            original and is sampled regularly.
 
         Returns:
         --------
@@ -610,8 +612,8 @@ class AnalogSignal(BaseSignal):
         if 't' in kwargs:
             kwargs.pop('t')
 
-        resampled_data, resampled_times = scipy.signal.resample(self.magnitude, sample_count, t=self.times, axis=0,
-                                                                **kwargs)
+        resampled_data, resampled_times = scipy.signal.resample(self.magnitude, sample_count,
+                                                                t=self.times, axis=0, **kwargs)
 
         resampled_signal = self.duplicate_with_new_data(resampled_data)
         resampled_signal.sampling_rate = (sample_count / self.shape[0]) * self.sampling_rate

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -550,7 +550,9 @@ class AnalogSignal(BaseSignal):
     def downsample(self, downsampling_factor, **kwargs):
         """
         Downsample the data of a signal.
-        This function is a wrapper of scipy.signal.decimate and accepts the same set of keyword
+        This method reduces the number of samples of the AnalogSignal to a fraction of the
+        original number of samples, defined by `downsampling_factor`.
+        This method is a wrapper of scipy.signal.decimate and accepts the same set of keyword
         arguments, except for specifying the axis of resampling, which is fixed to the first axis
         here.
 
@@ -565,6 +567,10 @@ class AnalogSignal(BaseSignal):
         downsampled_signal: :class:`AnalogSignal`
             New instance of a :class:`AnalogSignal` object containing the resampled data points.
             The original :class:`AnalogSignal` is not modified.
+
+        Note:
+        -----
+        For resampling the signal with a fixed number of samples, see `resample` method.
         """
 
         if not HAVE_SCIPY:
@@ -587,7 +593,9 @@ class AnalogSignal(BaseSignal):
     def resample(self, sample_count, **kwargs):
         """
         Resample the data points of the signal.
-        This function is a wrapper of scipy.signal.resample and accepts the same set of keyword
+        This method interpolates the signal and returns a new signal with a fixed number of
+        samples defined by `sample_count`.
+        This method is a wrapper of scipy.signal.resample and accepts the same set of keyword
         arguments, except for specifying the axis of resampling which is fixed to the first axis
         here, and the sample positions. .
 
@@ -602,6 +610,10 @@ class AnalogSignal(BaseSignal):
         resampled_signal: :class:`AnalogSignal`
             New instance of a :class:`AnalogSignal` object containing the resampled data points.
             The original :class:`AnalogSignal` is not modified.
+
+        Note:
+        -----
+        For reducing the number of samples to a fraction of the original, see `downsample` method
         """
 
         if not HAVE_SCIPY:

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -24,11 +24,13 @@ the old object.
 from __future__ import absolute_import, division, print_function
 
 from copy import deepcopy, copy
+
 try:
-    SCIPY_AVAIL = True
     import scipy.signal
-except ImportError:
-    SCIPY_AVAIL = False
+except ImportError as err:
+    HAVE_SCIPY = False
+else:
+    HAVE_SCIPY = True
 
 import numpy as np
 import quantities as pq
@@ -353,7 +355,7 @@ class IrregularlySampledSignal(BaseSignal):
         else:
             raise NotImplementedError
 
-    def resample(self, at=None, interpolation=None):
+    def resample_irregularly(self, at=None, interpolation=None):
         '''
         Resample the signal, returning either an :class:`AnalogSignal` object
         or another :class:`IrregularlySampledSignal` object.
@@ -369,7 +371,7 @@ class IrregularlySampledSignal(BaseSignal):
         # further interpolation methods could be added
         raise NotImplementedError
 
-    def resample_regularly(self, sample_count, **kwargs):
+    def resample(self, sample_count, **kwargs):
         """
         Resample the data points of the signal.
         This function is a wrapper of scipy.signal.resample and accepts the same set of keyword arguments,
@@ -388,7 +390,7 @@ class IrregularlySampledSignal(BaseSignal):
             The original :class:`AnalogSignal` is not modified.
         """
 
-        if not SCIPY_AVAIL:
+        if not HAVE_SCIPY:
             raise ImportError('Resampling requires availability of scipy.signal')
 
         # Resampling is only permitted along the time axis (axis=0)

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -24,11 +24,18 @@ the old object.
 from __future__ import absolute_import, division, print_function
 
 from copy import deepcopy, copy
+try:
+    SCIPY_AVAIL = True
+    import scipy.signal
+except ImportError:
+    SCIPY_AVAIL = False
+
 import numpy as np
 import quantities as pq
 
 from neo.core.baseneo import BaseNeo, MergeError, merge_annotations
 from neo.core.basesignal import BaseSignal
+from neo.core.analogsignal import AnalogSignal
 from neo.core.channelindex import ChannelIndex
 from neo.core.dataobject import DataObject
 
@@ -361,6 +368,46 @@ class IrregularlySampledSignal(BaseSignal):
         '''
         # further interpolation methods could be added
         raise NotImplementedError
+
+    def resample_regularly(self, sample_count, **kwargs):
+        """
+        Resample the data points of the signal.
+        This function is a wrapper of scipy.signal.resample and accepts the same set of keyword arguments,
+        except for specifying the axis of resampling which is fixed to the first axis here, and the sample positions. .
+
+        Parameters:
+        -----------
+        sample_count: integer
+            Number of desired samples. The resulting signal starts at the same sample as the original and is sampled
+            regularly.
+
+        Returns:
+        --------
+        resampled_signal: :class:`AnalogSignal`
+            New instance of a :class:`AnalogSignal` object containing the resampled data points.
+            The original :class:`AnalogSignal` is not modified.
+        """
+
+        if not SCIPY_AVAIL:
+            raise ImportError('Resampling requires availability of scipy.signal')
+
+        # Resampling is only permitted along the time axis (axis=0)
+        if 'axis' in kwargs:
+            kwargs.pop('axis')
+        if 't' in kwargs:
+            kwargs.pop('t')
+
+        resampled_data, resampled_times = scipy.signal.resample(self.magnitude, sample_count, t=self.times.magnitude,
+                                                                axis=0, **kwargs)
+
+        new_sampling_rate = (sample_count - 1) / ((resampled_times[-1] - resampled_times[0]) * self.times.units)
+        resampled_signal = AnalogSignal(resampled_data, units=self.units, dtype=self.dtype, t_start=self.t_start,
+                                        sampling_rate=new_sampling_rate,
+                                        array_annotations=self.array_annotations.copy(), **self.annotations.copy())
+
+        # since the number of channels stays the same, we can also copy array annotations here
+        resampled_signal.array_annotations = self.array_annotations.copy()
+        return resampled_signal
 
     def time_slice(self, t_start, t_stop):
         '''

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -355,33 +355,18 @@ class IrregularlySampledSignal(BaseSignal):
         else:
             raise NotImplementedError
 
-    def resample_irregularly(self, at=None, interpolation=None):
-        '''
-        Resample the signal, returning either an :class:`AnalogSignal` object
-        or another :class:`IrregularlySampledSignal` object.
-
-        Arguments:
-            :at: either a :class:`Quantity` array containing the times at
-                 which samples should be created (times must be within the
-                 signal duration, there is no extrapolation), a sampling rate
-                 with dimensions (1/Time) or a sampling interval
-                 with dimensions (Time).
-            :interpolation: one of: None, 'linear'
-        '''
-        # further interpolation methods could be added
-        raise NotImplementedError
-
     def resample(self, sample_count, **kwargs):
         """
         Resample the data points of the signal.
-        This function is a wrapper of scipy.signal.resample and accepts the same set of keyword arguments,
-        except for specifying the axis of resampling which is fixed to the first axis here, and the sample positions. .
+        This function is a wrapper of scipy.signal.resample and accepts the same set of keyword
+        arguments, except for specifying the axis of resampling which is fixed to the first axis
+        here, and the sample positions. .
 
         Parameters:
         -----------
         sample_count: integer
-            Number of desired samples. The resulting signal starts at the same sample as the original and is sampled
-            regularly.
+            Number of desired samples. The resulting signal starts at the same sample as the
+            original and is sampled regularly.
 
         Returns:
         --------
@@ -399,13 +384,16 @@ class IrregularlySampledSignal(BaseSignal):
         if 't' in kwargs:
             kwargs.pop('t')
 
-        resampled_data, resampled_times = scipy.signal.resample(self.magnitude, sample_count, t=self.times.magnitude,
+        resampled_data, resampled_times = scipy.signal.resample(self.magnitude, sample_count,
+                                                                t=self.times.magnitude,
                                                                 axis=0, **kwargs)
 
-        new_sampling_rate = (sample_count - 1) / ((resampled_times[-1] - resampled_times[0]) * self.times.units)
-        resampled_signal = AnalogSignal(resampled_data, units=self.units, dtype=self.dtype, t_start=self.t_start,
+        new_sampling_rate = (sample_count - 1) / self.duration
+        resampled_signal = AnalogSignal(resampled_data, units=self.units, dtype=self.dtype,
+                                        t_start=self.t_start,
                                         sampling_rate=new_sampling_rate,
-                                        array_annotations=self.array_annotations.copy(), **self.annotations.copy())
+                                        array_annotations=self.array_annotations.copy(),
+                                        **self.annotations.copy())
 
         # since the number of channels stays the same, we can also copy array annotations here
         resampled_signal.array_annotations = self.array_annotations.copy()

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -358,6 +358,8 @@ class IrregularlySampledSignal(BaseSignal):
     def resample(self, sample_count, **kwargs):
         """
         Resample the data points of the signal.
+        This method interpolates the signal and returns a new signal with a fixed number of
+        samples defined by `sample_count`.
         This function is a wrapper of scipy.signal.resample and accepts the same set of keyword
         arguments, except for specifying the axis of resampling which is fixed to the first axis
         here, and the sample positions. .

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -1168,7 +1168,7 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
     @unittest.skipUnless(HAVE_SCIPY, "requires Scipy")
     def test_downsample(self):
         # generate signal long enough for decimating
-        data = np.sin(np.arange(1500)/30).reshape(500, 3) * pq.mV
+        data = np.sin(np.arange(1500) / 30).reshape(500, 3) * pq.mV
         signal = AnalogSignal(data, sampling_rate=30000 * pq.Hz)
 
         # test decimation using different decimation factors
@@ -1178,15 +1178,16 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
             result = signal.downsample(factor)
 
             self.assertEqual(np.ceil(signal.shape[0] / factor), result.shape[0])
-            self.assertEqual(signal.shape[-1], result.shape[-1])  # preserve number of recording traces
-            self.assertAlmostEqual(signal.sampling_rate, factor*result.sampling_rate)
+            self.assertEqual(signal.shape[-1],
+                             result.shape[-1])  # preserve number of recording traces
+            self.assertAlmostEqual(signal.sampling_rate, factor * result.sampling_rate)
             # only comparing center values due to border effects
             np.testing.assert_allclose(desired[3:-3], result.magnitude[3:-3], rtol=0.05, atol=0.1)
 
     @unittest.skipUnless(HAVE_SCIPY, "requires Scipy")
     def test_resample_less_samples(self):
         # generate signal long enough for resampling
-        data = np.sin(np.arange(1500)/30).reshape(3, 500).T * pq.mV
+        data = np.sin(np.arange(1500) / 30).reshape(3, 500).T * pq.mV
         signal = AnalogSignal(data, sampling_rate=30000 * pq.Hz)
 
         # test resampling using different numbers of desired samples
@@ -1197,49 +1198,53 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
             result = signal.resample(sample_count)
 
             self.assertEqual(sample_count, result.shape[0])
-            self.assertEqual(signal.shape[-1], result.shape[-1])  # preserve number of recording traces
-            self.assertAlmostEqual(sample_count/signal.shape[0] * signal.sampling_rate, result.sampling_rate)
+            self.assertEqual(signal.shape[-1],
+                             result.shape[-1])  # preserve number of recording traces
+            self.assertAlmostEqual(sample_count / signal.shape[0] * signal.sampling_rate,
+                                   result.sampling_rate)
             # only comparing center values due to border effects
             np.testing.assert_allclose(desired[3:-3], result.magnitude[3:-3], rtol=0.05, atol=0.1)
 
     @unittest.skipUnless(HAVE_SCIPY, "requires Scipy")
     def test_resample_more_samples(self):
         # generate signal long enough for resampling
-        data = np.sin(np.arange(1500)/100).T * pq.mV
+        data = np.sin(np.arange(1500) / 100).T * pq.mV
         signal = AnalogSignal(data, sampling_rate=30000 * pq.Hz)
 
         # test resampling using different numbers of desired samples
         factor = 2
-        sample_count = factor*signal.shape[0]
-        desired = np.interp(np.arange(sample_count)/factor, np.arange(signal.shape[0]),
-                            signal.magnitude.flatten()).reshape(-1,1)
+        sample_count = factor * signal.shape[0]
+        desired = np.interp(np.arange(sample_count) / factor, np.arange(signal.shape[0]),
+                            signal.magnitude.flatten()).reshape(-1, 1)
         result = signal.resample(sample_count)
 
         self.assertEqual(sample_count, result.shape[0])
         self.assertEqual(signal.shape[-1], result.shape[-1])  # preserve number of recording traces
-        self.assertAlmostEqual(sample_count/signal.shape[0] * signal.sampling_rate, result.sampling_rate)
+        self.assertAlmostEqual(sample_count / signal.shape[0] * signal.sampling_rate,
+                               result.sampling_rate)
         # only comparing center values due to border effects
         np.testing.assert_allclose(desired[10:-10], result.magnitude[10:-10], rtol=0.0, atol=0.1)
 
     @unittest.skipUnless(HAVE_SCIPY, "requires Scipy")
     def test_compare_resample_and_downsample(self):
         # generate signal long enough for resampling
-        data = np.sin(np.arange(1500)/30).reshape(3, 500).T * pq.mV
+        data = np.sin(np.arange(1500) / 30).reshape(3, 500).T * pq.mV
         signal = AnalogSignal(data, sampling_rate=30000 * pq.Hz)
 
         # test resampling using different numbers of desired samples
         sample_counts = [10, 100, 250]
         for sample_count in sample_counts:
-            downsampling_factor = int(signal.shape[0]/sample_count)
-            assert downsampling_factor == signal.shape[0]/sample_count, 'Downsampling factor needs to be integer.'
+            downsampling_factor = int(signal.shape[0] / sample_count)
             desired = signal.downsample(downsampling_factor=downsampling_factor)
             result = signal.resample(sample_count)
 
             self.assertEqual(desired.shape[0], result.shape[0])
-            self.assertEqual(desired.shape[-1], result.shape[-1])  # preserve number of recording traces
+            self.assertEqual(desired.shape[-1],
+                             result.shape[-1])  # preserve number of recording traces
             self.assertAlmostEqual(desired.sampling_rate, result.sampling_rate)
             # only comparing center values due to border effects
-            np.testing.assert_allclose(desired.magnitude[3:-3], result.magnitude[3:-3], rtol=0.05, atol=0.1)
+            np.testing.assert_allclose(desired.magnitude[3:-3], result.magnitude[3:-3], rtol=0.05,
+                                       atol=0.1)
 
 
 class TestAnalogSignalEquality(unittest.TestCase):

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -23,6 +23,13 @@ except ImportError as err:
 else:
     HAVE_IPYTHON = True
 
+try:
+    import scipy
+except ImportError:
+    HAVE_SCIPY = False
+else:
+    HAVE_SCIPY = True
+
 from neo.core.irregularlysampledsignal import IrregularlySampledSignal
 from neo.core import Segment, ChannelIndex
 from neo.core.baseneo import MergeError
@@ -352,8 +359,8 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
     def test_mean_interpolation_NotImplementedError(self):
         self.assertRaises(NotImplementedError, self.signal1.mean, True)
 
-    def test_resample_NotImplementedError(self):
-        self.assertRaises(NotImplementedError, self.signal1.resample, True)
+    def test_resample_irregularly_NotImplementedError(self):
+        self.assertRaises(NotImplementedError, self.signal1.resample_irregularly, True)
 
     def test__rescale_same(self):
         result = self.signal1.copy()
@@ -710,10 +717,11 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         self.assertIs(result.segment, self.signal1.segment)
         self.assertIs(result.channel_index, self.signal1.channel_index)
 
-    def test_resample_regularly(self):
+    @unittest.skipUnless(HAVE_SCIPY, "requires Scipy")
+    def test_resample(self):
         factors = [1, 2, 10]
         for factor in factors:
-            result = self.signal1.resample_regularly(self.signal1.shape[0]*factor)
+            result = self.signal1.resample(self.signal1.shape[0]*factor)
             np.testing.assert_allclose(self.signal1.magnitude, result.magnitude[::factor], rtol=1e-7, atol=0)
 
 

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -359,9 +359,6 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
     def test_mean_interpolation_NotImplementedError(self):
         self.assertRaises(NotImplementedError, self.signal1.mean, True)
 
-    def test_resample_irregularly_NotImplementedError(self):
-        self.assertRaises(NotImplementedError, self.signal1.resample_irregularly, True)
-
     def test__rescale_same(self):
         result = self.signal1.copy()
         result = result.rescale(pq.mV)

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -718,8 +718,9 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
     def test_resample(self):
         factors = [1, 2, 10]
         for factor in factors:
-            result = self.signal1.resample(self.signal1.shape[0]*factor)
-            np.testing.assert_allclose(self.signal1.magnitude, result.magnitude[::factor], rtol=1e-7, atol=0)
+            result = self.signal1.resample(self.signal1.shape[0] * factor)
+            np.testing.assert_allclose(self.signal1.magnitude, result.magnitude[::factor],
+                                       rtol=1e-7, atol=0)
 
 
 class TestIrregularlySampledSignalCombination(unittest.TestCase):

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -710,6 +710,12 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         self.assertIs(result.segment, self.signal1.segment)
         self.assertIs(result.channel_index, self.signal1.channel_index)
 
+    def test_resample_regularly(self):
+        factors = [1, 2, 10]
+        for factor in factors:
+            result = self.signal1.resample_regularly(self.signal1.shape[0]*factor)
+            np.testing.assert_allclose(self.signal1.magnitude, result.magnitude[::factor], rtol=1e-7, atol=0)
+
 
 class TestIrregularlySampledSignalCombination(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
In the context of #526 it might be useful to add utility functions for adjusting the time sampling of `AnalogSignals` and `IrregularlySampledSignals`. This PR is wrapping the two scipy functions `decimate` and `resample` to provide a mechanism for decimating and resampling within Neo and adds some tests with it.

There is one issue coming with this PR: Scipy itself is not a Neo dependency yet, even though it is used in a couple of places for specific IOs. Here, I the new utility methods can only be used in case of scipy being available and will raise an ImportError if this is not the case.

Note: As scipy is not available in the Travis test setup, the new tests fail. Should we include scipy in the test environment / requirements for Neo or is this introducing too strong dependencies? Alternatively, these utility functions might be included in [elephant](https://github.com/neuralensemble/elephant), with the drawback ob being less visible to the users.

