### PR TITLE
Improve ChannelIndex generation in legacy BlackRockIO

### DIFF
--- a/neo/io/blackrockio_v4.py
+++ b/neo/io/blackrockio_v4.py
@@ -1984,7 +1984,7 @@ class BlackrockIO(BaseIO):
             file_origin=self.filename)
 
         if index is not None:
-            chidx.index = index
+            chidx.index = np.array(index)
             chidx.name = "ChannelIndex {}".format(chidx.index)
         else:
             chidx.name = "ChannelIndex"

--- a/neo/io/blackrockio_v4.py
+++ b/neo/io/blackrockio_v4.py
@@ -1984,7 +1984,7 @@ class BlackrockIO(BaseIO):
             file_origin=self.filename)
 
         if index is not None:
-            chidx.index = np.array(index)
+            chidx.index = np.array(index, np.dtype('i'))
             chidx.name = "ChannelIndex {}".format(chidx.index)
         else:
             chidx.name = "ChannelIndex"


### PR DESCRIPTION
The legacy version of the BlackRockIO generates ChannelIndex objects with invalid `index` attribute. This prevents neo structures being read by this IO to be saved. This PR fixes this issue by making sure the `index` attribute is set properly.