### PR TITLE
Fix reading RealWave Spike2 channels and channels with unrecognized quantities

### DIFF
--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -20,6 +20,7 @@ from neo.core import (AnalogSignal,
                       Epoch, Event, SpikeTrain)
 from neo.core.dataobject import ArrayDict
 
+import logging
 
 class BaseProxy(BaseNeo):
     def __init__(self, array_annotations=None, **annotations):
@@ -115,7 +116,9 @@ class AnalogSignalProxy(BaseProxy):
                                                     np.all(sig_chans['offset'] == 0.)
 
         if support_raw_magnitude:
+            sig_chans['units'][0]
             str_units = ensure_signal_units(sig_chans['units'][0]).units.dimensionality.string
+            
             self._raw_units = pq.CompoundUnit('{}*{}'.format(sig_chans['gain'][0], str_units))
         else:
             self._raw_units = None
@@ -522,6 +525,7 @@ def ensure_signal_units(units):
         logging.warning('Units "{}" can not be converted to a quantity. Using dimensionless '
                         'instead'.format(units))
         units = ''
+        units = pq.Quantity(1, units)
     return units
 
 

--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -116,9 +116,7 @@ class AnalogSignalProxy(BaseProxy):
                                                     np.all(sig_chans['offset'] == 0.)
 
         if support_raw_magnitude:
-            sig_chans['units'][0]
             str_units = ensure_signal_units(sig_chans['units'][0]).units.dimensionality.string
-            
             self._raw_units = pq.CompoundUnit('{}*{}'.format(sig_chans['gain'][0], str_units))
         else:
             self._raw_units = None

--- a/neo/rawio/spike2rawio.py
+++ b/neo/rawio/spike2rawio.py
@@ -215,7 +215,7 @@ class Spike2RawIO(BaseRawIO):
                 elif chan_info['kind'] == 9:  # float32
                     gain = 1.
                     offset = 0.
-                    sig_dtype = 'int32'
+                    sig_dtype = 'float32'
                 group_id = 0
                 sig_channels.append((name, chan_id, sampling_rate, sig_dtype,
                                      units, gain, offset, group_id))


### PR DESCRIPTION
RealWave channels were read as int32 instead of float32. 

Furthermore, logging wasn't imported in proxzobjects.py. This caused an error when the units were not recognized. 