### PR TITLE
Add function to take the absolute value of analogsignals

### DIFF
--- a/doc/source/authors.rst
+++ b/doc/source/authors.rst
@@ -51,6 +51,7 @@ and may not be the current affiliation of a contributor.
 * Christian Kothe
 * rishidhingra@github
 * Hugo van Kemenade
+* Aitor Morales-Gregorio [13]
 
 1. Centre de Recherche en Neuroscience de Lyon, CNRS UMR5292 - INSERM U1028 - Universite Claude Bernard Lyon 1
 2. Unité de Neuroscience, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -635,3 +635,31 @@ class AnalogSignal(BaseSignal):
         resampled_signal.array_annotations = self.array_annotations.copy()
 
         return resampled_signal
+
+    def rectify(self, **kwargs):
+        """
+        Rectify the signal.
+        This method rectifies the signal by taking the absolute value.
+        This method is a wrapper of numpy.absolute() and accepts the same set of keyword
+        arguments.
+
+        Returns:
+        --------
+        resampled_signal: :class:`AnalogSignal`
+            New instance of a :class:`AnalogSignal` object containing the rectified data points.
+            The original :class:`AnalogSignal` is not modified.
+
+        """
+
+        # Use numpy to get the absolute value of the signal
+        rectified_data = np.absolute(self.magnitude, **kwargs)
+
+        rectified_signal = self.duplicate_with_new_data(rectified_data)
+
+        # the sampling rate stays constant
+        rectified_signal.sampling_rate = self.sampling_rate
+
+        # since the number of channels stays the same, we can also copy array annotations here
+        rectified_signal.array_annotations = self.array_annotations.copy()
+
+        return rectified_signal

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -1246,6 +1246,37 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
             np.testing.assert_allclose(desired.magnitude[3:-3], result.magnitude[3:-3], rtol=0.05,
                                        atol=0.1)
 
+    def test_rectify(self):
+        # generate signal long enough for testing the rectification
+        data = np.sin(np.arange(1500) / 30).reshape(500, 3)
+        target_data = np.abs(data)
+
+        array_anno = {'anno1': [0, 1, 2], 'anno2': ['C', 'P', 'F']}
+
+        signal = AnalogSignal(data*pq.mV,
+                              sampling_rate=30000 * pq.Hz,
+                              units=pq.mV,
+                              array_annotations=array_anno)
+
+        target_signal = AnalogSignal(target_data*pq.mV,
+                                     sampling_rate=30000 * pq.Hz,
+                                     units=pq.mV,
+                                     array_annotations=array_anno)
+
+        # Use the rectify method
+        rectified_signal = signal.rectify()
+
+        # Assert that nothing changed
+        assert_arrays_equal(rectified_signal.magnitude, target_signal.magnitude)
+        self.assertEqual(rectified_signal.sampling_rate,
+                         target_signal.sampling_rate)
+        self.assertEqual(rectified_signal.units, target_signal.units)
+        self.assertEqual(rectified_signal.annotations,
+                         target_signal.annotations)
+        assert_arrays_equal(rectified_signal.array_annotations['anno1'],
+                            target_signal.array_annotations['anno1'])
+        assert_arrays_equal(rectified_signal.array_annotations['anno2'],
+                            target_signal.array_annotations['anno2'])
 
 class TestAnalogSignalEquality(unittest.TestCase):
     def test__signals_with_different_data_complement_should_be_not_equal(self):

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -1253,12 +1253,12 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
 
         array_anno = {'anno1': [0, 1, 2], 'anno2': ['C', 'P', 'F']}
 
-        signal = AnalogSignal(data*pq.mV,
+        signal = AnalogSignal(data * pq.mV,
                               sampling_rate=30000 * pq.Hz,
                               units=pq.mV,
                               array_annotations=array_anno)
 
-        target_signal = AnalogSignal(target_data*pq.mV,
+        target_signal = AnalogSignal(target_data * pq.mV,
                                      sampling_rate=30000 * pq.Hz,
                                      units=pq.mV,
                                      array_annotations=array_anno)


### PR DESCRIPTION
Dear all,

I have implemented an addtional function for the analogsignal class that should allow taking the absolute value of an analogsignal object without losing the annotations.

I have gone for a PR directly because I am indeed using this function already, it is working as expected. I thought it would be useful to have it available as a method.

Let me know your thoughts on it, or if something needs to be corrected.

Best,
Aitor