### PR TITLE
make ChannelIndex creation in RawIO more robust

### DIFF
--- a/neo/io/basefromrawio.py
+++ b/neo/io/basefromrawio.py
@@ -151,7 +151,8 @@ class BaseFromRaw(BaseIO):
                                                  channel_names=ch_names,
                                                  channel_ids=all_channels[ind_abs]['id'],
                                                  name='Channel group {}'.format(i),
-                                                 **chidx_annotations)
+                                                 )
+                neo_channel_index.annotations.update(chidx_annotations)
 
                 bl.channel_indexes.append(neo_channel_index)
 


### PR DESCRIPTION
This fixes the issue of getting a TypeError when loading a file with a RawIO, and an (array_)annotation is named like a ChannelIndex keyword argument, e.g., 'channel_names'. 
See the related Issue #786 