### PR TITLE
 Fix: In openephysrawio.py get segment indices from folder exploration…

### DIFF
--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -257,14 +257,14 @@ class OpenEphysRawIO(BaseRawIO):
         self._generate_minimal_annotations()
         bl_ann = self.raw_annotations['blocks'][0]
         for seg_index, oe_index in enumerate(oe_indices):
-            seg_ann = bl_ann['segments'][oe_index]
+            seg_ann = bl_ann['segments'][seg_index]
             if len(info['continuous']) > 0:
                 fullname = os.path.join(self.dirname, info['continuous'][oe_index][0])
                 chan_info = read_file_header(fullname)
                 seg_ann['openephys_version'] = chan_info['version']
                 bl_ann['openephys_version'] = chan_info['version']
                 seg_ann['date_created'] = chan_info['date_created']
-                seg_ann['segment_index'] = oe_index + 1
+                seg_ann['openephys_segment_index'] = oe_index + 1
 
     def _segment_t_start(self, block_index, seg_index):
         # segment start/stop are difine by  continuous channels

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -81,7 +81,8 @@ class OpenEphysRawIO(BaseRawIO):
         self._sig_length = {}
         self._sig_timestamp0 = {}
         sig_channels = []
-        for seg_index in range(nb_segment):
+        seg_indices = sorted(list(info['continuous'].keys()))
+        for ix, seg_index in enumerate(seg_indices):
             self._sigs_memmap[seg_index] = {}
 
             all_sigs_length = []
@@ -115,7 +116,7 @@ class OpenEphysRawIO(BaseRawIO):
                     'Not continuous timestamps for {}. ' \
                     'Maybe because recording was paused/stopped.'.format(continuous_filename)
 
-                if seg_index == 0:
+                if ix == 0:
                     # add in channel list
                     sig_channels.append((ch_name, chan_id, chan_info['sampleRate'],
                                 'int16', 'V', chan_info['bitVolts'], 0., int(processor_id)))
@@ -227,7 +228,7 @@ class OpenEphysRawIO(BaseRawIO):
         # and message.events (text based)      --> event 1 not implemented yet
         event_channels = []
         self._events_memmap = {}
-        for seg_index in range(nb_segment):
+        for seg_index in seg_indices:
             if seg_index == 0:
                 event_filename = 'all_channels.events'
             else:
@@ -255,7 +256,7 @@ class OpenEphysRawIO(BaseRawIO):
         # Annotate some objects from coninuous files
         self._generate_minimal_annotations()
         bl_ann = self.raw_annotations['blocks'][0]
-        for seg_index in range(nb_segment):
+        for seg_index in seg_indices:
             seg_ann = bl_ann['segments'][seg_index]
             if len(info['continuous']) > 0:
                 fullname = os.path.join(self.dirname, info['continuous'][seg_index][0])

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -81,15 +81,15 @@ class OpenEphysRawIO(BaseRawIO):
         self._sig_length = {}
         self._sig_timestamp0 = {}
         sig_channels = []
-        seg_indices = sorted(list(info['continuous'].keys()))
-        for ix, seg_index in enumerate(seg_indices):
+        oe_indices = sorted(list(info['continuous'].keys()))
+        for seg_index, oe_index in enumerate(oe_indices):
             self._sigs_memmap[seg_index] = {}
 
             all_sigs_length = []
             all_first_timestamps = []
             all_last_timestamps = []
             all_samplerate = []
-            for chan_index, continuous_filename in enumerate(info['continuous'][seg_index]):
+            for chan_index, continuous_filename in enumerate(info['continuous'][oe_index]):
                 fullname = os.path.join(self.dirname, continuous_filename)
                 chan_info = read_file_header(fullname)
 
@@ -102,7 +102,7 @@ class OpenEphysRawIO(BaseRawIO):
                 filesize = os.stat(fullname).st_size
                 size = (filesize - HEADER_SIZE) // np.dtype(continuous_dtype).itemsize
                 data_chan = np.memmap(fullname, mode='r', offset=HEADER_SIZE,
-                                        dtype=continuous_dtype, shape=(size, ))
+                                      dtype=continuous_dtype, shape=(size, ))
                 self._sigs_memmap[seg_index][chan_index] = data_chan
 
                 all_sigs_length.append(data_chan.size * RECORD_SIZE)
@@ -116,7 +116,7 @@ class OpenEphysRawIO(BaseRawIO):
                     'Not continuous timestamps for {}. ' \
                     'Maybe because recording was paused/stopped.'.format(continuous_filename)
 
-                if ix == 0:
+                if seg_index == 0:
                     # add in channel list
                     sig_channels.append((ch_name, chan_id, chan_info['sampleRate'],
                                 'int16', 'V', chan_info['bitVolts'], 0., int(processor_id)))
@@ -170,9 +170,9 @@ class OpenEphysRawIO(BaseRawIO):
         if len(info['spikes']) > 0:
 
             self._spikes_memmap = {}
-            for seg_index in range(nb_segment):
+            for seg_index, oe_index in enumerate(oe_indices):
                 self._spikes_memmap[seg_index] = {}
-                for spike_filename in info['spikes'][seg_index]:
+                for spike_filename in info['spikes'][oe_index]:
                     fullname = os.path.join(self.dirname, spike_filename)
                     spike_info = read_file_header(fullname)
                     spikes_dtype = make_spikes_dtype(fullname)
@@ -228,11 +228,11 @@ class OpenEphysRawIO(BaseRawIO):
         # and message.events (text based)      --> event 1 not implemented yet
         event_channels = []
         self._events_memmap = {}
-        for seg_index in seg_indices:
-            if seg_index == 0:
+        for seg_index, oe_index in enumerate(oe_indices):
+            if oe_index == 0:
                 event_filename = 'all_channels.events'
             else:
-                event_filename = 'all_channels_{}.events'.format(seg_index + 1)
+                event_filename = 'all_channels_{}.events'.format(oe_index + 1)
 
             fullname = os.path.join(self.dirname, event_filename)
             event_info = read_file_header(fullname)
@@ -256,14 +256,15 @@ class OpenEphysRawIO(BaseRawIO):
         # Annotate some objects from coninuous files
         self._generate_minimal_annotations()
         bl_ann = self.raw_annotations['blocks'][0]
-        for seg_index in seg_indices:
-            seg_ann = bl_ann['segments'][seg_index]
+        for seg_index, oe_index in enumerate(oe_indices):
+            seg_ann = bl_ann['segments'][oe_index]
             if len(info['continuous']) > 0:
-                fullname = os.path.join(self.dirname, info['continuous'][seg_index][0])
+                fullname = os.path.join(self.dirname, info['continuous'][oe_index][0])
                 chan_info = read_file_header(fullname)
                 seg_ann['openephys_version'] = chan_info['version']
                 bl_ann['openephys_version'] = chan_info['version']
                 seg_ann['date_created'] = chan_info['date_created']
+                seg_ann['segment_index'] = oe_index + 1
 
     def _segment_t_start(self, block_index, seg_index):
         # segment start/stop are difine by  continuous channels


### PR DESCRIPTION
… instead of assuming continuous numbering

In the IO for OpenEPhys data, under certain conditions (eg. users record into the same directory, but later remove some segments) opening the folder becomes impossible.
This is because the code assumes the segments are continuously numbered, and they are loop through using` range(nb_segments)`..
This does not work when the user removes, after the fact, some recordings. In the proposed fix one would loop using the keys of the `info['continuous']` dictionary which are obtained by parsing the file names. This should be more robust.
I am happy to provide some data to test.