### PR TITLE
Enforce times of Events, Epochs, Spiketrains to be 1d

### DIFF
--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -92,7 +92,7 @@ class Epoch(DataObject):
         elif isinstance(times, (list, tuple)):
             times = np.array(times)
         if len(times.shape) > 1:
-            times = times.reshape(-1)
+            raise ValueError("Times array has more than 1 dimension")
         if isinstance(durations, (list, tuple)):
             durations = np.array(durations)
         if durations is None:

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -91,6 +91,8 @@ class Epoch(DataObject):
             times = np.array([]) * pq.s
         elif isinstance(times, (list, tuple)):
             times = np.array(times)
+        if len(times.shape) > 1:
+            times = times.reshape(-1)
         if isinstance(durations, (list, tuple)):
             durations = np.array(durations)
         if durations is None:

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -83,6 +83,8 @@ class Event(DataObject):
             times = np.array([]) * pq.s
         elif isinstance(times, (list, tuple)):
             times = np.array(times)
+        if len(times.shape) > 1:
+            times = times.reshape(-1)
         if labels is None:
             labels = np.array([], dtype='S')
         else:

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -84,7 +84,7 @@ class Event(DataObject):
         elif isinstance(times, (list, tuple)):
             times = np.array(times)
         if len(times.shape) > 1:
-            times = times.reshape(-1)
+            raise ValueError("Times array has more than 1 dimension")
         if labels is None:
             labels = np.array([], dtype='S')
         else:

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -278,9 +278,9 @@ class SpikeTrain(DataObject):
         # Construct Quantity from data
         obj = pq.Quantity(times, units=units, dtype=dtype, copy=copy).view(cls)
 
-        # spiktrains times always need to be 1-dimensional
+        # spiketrain times always need to be 1-dimensional
         if len(obj.shape) > 1:
-            obj = obj.reshape(-1)
+            raise ValueError("Spiketrain times array has more than 1 dimension")
 
         # if the dtype and units match, just copy the values here instead
         # of doing the much more expensive creation of a new Quantity

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -278,6 +278,10 @@ class SpikeTrain(DataObject):
         # Construct Quantity from data
         obj = pq.Quantity(times, units=units, dtype=dtype, copy=copy).view(cls)
 
+        # spiktrains times always need to be 1-dimensional
+        if len(obj.shape) > 1:
+            obj = obj.reshape(-1)
+
         # if the dtype and units match, just copy the values here instead
         # of doing the much more expensive creation of a new Quantity
         # using items() is orders of magnitude faster

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -142,6 +142,12 @@ class TestEpoch(unittest.TestCase):
         assert_arrays_equal(epc.array_annotations['index'], np.arange(10, 13))
         self.assertIsInstance(epc.array_annotations, ArrayDict)
 
+    def test_Epoch_times_is_1d(self):
+        data2d = np.array([1, 2, 3, 4]).reshape((4, -1))
+        durations = np.array([1, 1, 1, 1])
+        epc = Epoch(data2d * pq.s, durations=durations)
+        self.assertEqual(len(epc.shape), 1)
+
     def test_Epoch_creation_invalid_durations_labels(self):
         self.assertRaises(ValueError, Epoch, [1.1, 1.5, 1.7] * pq.ms,
                           durations=[20, 40, 60, 80] * pq.ns)

--- a/neo/test/coretest/test_epoch.py
+++ b/neo/test/coretest/test_epoch.py
@@ -142,11 +142,10 @@ class TestEpoch(unittest.TestCase):
         assert_arrays_equal(epc.array_annotations['index'], np.arange(10, 13))
         self.assertIsInstance(epc.array_annotations, ArrayDict)
 
-    def test_Epoch_times_is_1d(self):
+    def test_Epoch_invalid_times_dimension(self):
         data2d = np.array([1, 2, 3, 4]).reshape((4, -1))
         durations = np.array([1, 1, 1, 1])
-        epc = Epoch(data2d * pq.s, durations=durations)
-        self.assertEqual(len(epc.shape), 1)
+        self.assertRaises(ValueError, Epoch, times=data2d * pq.s, durations=durations)
 
     def test_Epoch_creation_invalid_durations_labels(self):
         self.assertRaises(ValueError, Epoch, [1.1, 1.5, 1.7] * pq.ms,

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -142,10 +142,9 @@ class TestEvent(unittest.TestCase):
         assert_arrays_equal(evt.array_annotations['index'], np.arange(10, 13))
         self.assertIsInstance(evt.array_annotations, ArrayDict)
 
-    def test_Event_times_is_1d(self):
+    def test_Event_invalid_times_dimension(self):
         data2d = np.array([1, 2, 3, 4]).reshape((4, -1))
-        evt = Event(data2d * pq.s)
-        self.assertEqual(len(evt.shape), 1)
+        self.assertRaises(ValueError, Event, times=data2d * pq.s)
 
     def test_Event_creation_invalid_labels(self):
         self.assertRaises(ValueError, Event, [1.1, 1.5, 1.7] * pq.ms,

--- a/neo/test/coretest/test_event.py
+++ b/neo/test/coretest/test_event.py
@@ -142,6 +142,11 @@ class TestEvent(unittest.TestCase):
         assert_arrays_equal(evt.array_annotations['index'], np.arange(10, 13))
         self.assertIsInstance(evt.array_annotations, ArrayDict)
 
+    def test_Event_times_is_1d(self):
+        data2d = np.array([1, 2, 3, 4]).reshape((4, -1))
+        evt = Event(data2d * pq.s)
+        self.assertEqual(len(evt.shape), 1)
+
     def test_Event_creation_invalid_labels(self):
         self.assertRaises(ValueError, Event, [1.1, 1.5, 1.7] * pq.ms,
                           labels=["A", "B"])

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -676,7 +676,7 @@ class TestConstructor(unittest.TestCase):
     def test__create_with_times_in_2d(self):
         # assert that times are reshaped to be always 1d
         data2d = np.array([1, 2, 3, 4]).reshape((4, -1))
-        train = SpikeTrain(data2d * pq.s, t_stop=10*pq.s)
+        train = SpikeTrain(data2d * pq.s, t_stop=10 * pq.s)
         self.assertEqual(len(train.shape), 1)
 
     def test_defaults(self):

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -673,11 +673,9 @@ class TestConstructor(unittest.TestCase):
         self.assertRaises(ValueError, SpikeTrain, times=np.arange(10), units='s', t_stop=4,
                           waveforms=np.ones((10, 6, 50)))
 
-    def test__create_with_times_in_2d(self):
-        # assert that times are reshaped to be always 1d
+    def test__create_with_invalid_times_dimension(self):
         data2d = np.array([1, 2, 3, 4]).reshape((4, -1))
-        train = SpikeTrain(data2d * pq.s, t_stop=10 * pq.s)
-        self.assertEqual(len(train.shape), 1)
+        self.assertRaises(ValueError, SpikeTrain, times=data2d * pq.s, t_stop=10 * pq.s)
 
     def test_defaults(self):
         # default recommended attributes

--- a/neo/test/coretest/test_spiketrain.py
+++ b/neo/test/coretest/test_spiketrain.py
@@ -673,6 +673,12 @@ class TestConstructor(unittest.TestCase):
         self.assertRaises(ValueError, SpikeTrain, times=np.arange(10), units='s', t_stop=4,
                           waveforms=np.ones((10, 6, 50)))
 
+    def test__create_with_times_in_2d(self):
+        # assert that times are reshaped to be always 1d
+        data2d = np.array([1, 2, 3, 4]).reshape((4, -1))
+        train = SpikeTrain(data2d * pq.s, t_stop=10*pq.s)
+        self.assertEqual(len(train.shape), 1)
+
     def test_defaults(self):
         # default recommended attributes
         train1 = SpikeTrain([3, 4, 5], units='sec', t_stop=10.0)


### PR DESCRIPTION
The dimensions of time arrays of Event, Epoch and Spiketrains are frequently assumed to be 1-dimensional, e.g. see #801, but this is never enforced.
This lead to inconsistent behaviour with the introduction of array_annotations, which are always matching the last dimension of a data object. In cases when one of the objects above was initialised with a 2-dimensional array containing data only along the first dimension, this leads to array_annotations always being forced to be of length 1 even though there is more than one sample contained.

This PR enforces the time arrays of Events, Epochs and Spiketrains to be 1-dimensional via reshaping and adds corresponding tests.