### PR TITLE
Support Empty Array Annotations in NixIO

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -854,7 +854,7 @@ class NixIO(BaseIO):
         if anasig.array_annotations:
             for k, v in anasig.array_annotations.items():
                 p = self._write_property(metadata, k, v)
-                p.definition = ARRAYANNOTATION
+                p.type = ARRAYANNOTATION
 
         self._signal_map[nix_name] = nixdas
 
@@ -992,7 +992,7 @@ class NixIO(BaseIO):
         if irsig.array_annotations:
             for k, v in irsig.array_annotations.items():
                 p = self._write_property(metadata, k, v)
-                p.definition = ARRAYANNOTATION
+                p.type = ARRAYANNOTATION
 
         self._signal_map[nix_name] = nixdas
 
@@ -1047,7 +1047,7 @@ class NixIO(BaseIO):
         if event.array_annotations:
             for k, v in event.array_annotations.items():
                 p = self._write_property(metadata, k, v)
-                p.definition = ARRAYANNOTATION
+                p.type = ARRAYANNOTATION
 
         nixgroup.multi_tags.append(nixmt)
 
@@ -1115,7 +1115,7 @@ class NixIO(BaseIO):
         if epoch.array_annotations:
             for k, v in epoch.array_annotations.items():
                 p = self._write_property(metadata, k, v)
-                p.definition = ARRAYANNOTATION
+                p.type = ARRAYANNOTATION
 
         nixgroup.multi_tags.append(nixmt)
 
@@ -1177,7 +1177,7 @@ class NixIO(BaseIO):
         if spiketrain.array_annotations:
             for k, v in spiketrain.array_annotations.items():
                 p = self._write_property(metadata, k, v)
-                p.definition = ARRAYANNOTATION
+                p.type = ARRAYANNOTATION
 
         if nixgroup:
             nixgroup.multi_tags.append(nixmt)
@@ -1390,7 +1390,7 @@ class NixIO(BaseIO):
                 if prop.definition in (DATEANNOTATION, TIMEANNOTATION,
                                        DATETIMEANNOTATION):
                     values = dt_from_nix(values, prop.definition)
-                if prop.definition == ARRAYANNOTATION:
+                if prop.type == ARRAYANNOTATION:
                     if 'array_annotations' in neo_attrs:
                         neo_attrs['array_annotations'][prop.name] = values
                     else:

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -418,7 +418,7 @@ class NixIOTest(unittest.TestCase):
             asig_md.create_property(arr_ann_name,
                                     arr_ann_val.magnitude.flatten())
             asig_md.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
-            asig_md.props[arr_ann_name].definition = 'ARRAYANNOTATION'
+            asig_md.props[arr_ann_name].type = 'ARRAYANNOTATION'
 
             for idx in range(10):
                 da_asig = blk.create_data_array(
@@ -452,7 +452,7 @@ class NixIOTest(unittest.TestCase):
             imgseq_md.create_property(arr_ann_name,
                                       arr_ann_val.magnitude.flatten())
             imgseq_md.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
-            imgseq_md.props[arr_ann_name].definition = 'ARRAYANNOTATION'
+            imgseq_md.props[arr_ann_name].type = 'ARRAYANNOTATION'
 
             for idx in range(10):
                 da_imgseq = blk.create_data_array(
@@ -485,7 +485,7 @@ class NixIOTest(unittest.TestCase):
             isig_md.create_property(arr_ann_name,
                                     arr_ann_val.magnitude.flatten())
             isig_md.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
-            isig_md.props[arr_ann_name].definition = 'ARRAYANNOTATION'
+            isig_md.props[arr_ann_name].type = 'ARRAYANNOTATION'
             for idx in range(7):
                 da_isig = blk.create_data_array(
                     "{}.{}".format(isig_name, idx),
@@ -527,7 +527,7 @@ class NixIOTest(unittest.TestCase):
             mtag_st_md.create_property(arr_ann_name,
                                        arr_ann_val.magnitude.flatten())
             mtag_st_md.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
-            mtag_st_md.props[arr_ann_name].definition = 'ARRAYANNOTATION'
+            mtag_st_md.props[arr_ann_name].type = 'ARRAYANNOTATION'
 
             waveforms = cls.rquant((10, 8, 5), 1)
             wfname = "{}.waveforms".format(mtag_st.name)
@@ -579,7 +579,7 @@ class NixIOTest(unittest.TestCase):
             mtag_ep.metadata.create_property(arr_ann_name,
                                              arr_ann_val.magnitude.flatten())
             mtag_ep.metadata.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
-            mtag_ep.metadata.props[arr_ann_name].definition = 'ARRAYANNOTATION'
+            mtag_ep.metadata.props[arr_ann_name].type = 'ARRAYANNOTATION'
 
             label_dim = mtag_ep.positions.append_set_dimension()
             label_dim.labels = cls.rsentence(5).split(" ")
@@ -612,7 +612,7 @@ class NixIOTest(unittest.TestCase):
             mtag_ev.metadata.create_property(arr_ann_name,
                                              arr_ann_val.magnitude.flatten())
             mtag_ev.metadata.props[arr_ann_name].unit = str(arr_ann_val.dimensionality)
-            mtag_ev.metadata.props[arr_ann_name].definition = 'ARRAYANNOTATION'
+            mtag_ev.metadata.props[arr_ann_name].type = 'ARRAYANNOTATION'
 
             label_dim = mtag_ev.positions.append_set_dimension()
             label_dim.labels = cls.rsentence(5).split(" ")

--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -1486,6 +1486,24 @@ class NixIOWriteTest(NixIOTest):
 
         # TODO: multi dimensional value (GH Issue #501)
 
+    def test_empty_array_annotations(self):
+        wblock = Block("block with spiketrain")
+        wseg = Segment()
+        wseg.spiketrains = [SpikeTrain(times=[] * pq.s, t_stop=1 * pq.s,
+                                       array_annotations={'empty': []})]
+        wblock.segments = [wseg]
+        self.writer.write_block(wblock)
+        try:
+            rblock = self.writer.read_block(neoname="block with spiketrain")
+        except Exception as exc:
+            self.fail('The following exception was raised when'
+                      + ' reading the block with an empty array annotation:\n'
+                      + str(exc))
+        rst = rblock.segments[0].spiketrains[0]
+        self.assertEqual(len(rst.array_annotations), 1)
+        self.assertIn('empty', rst.array_annotations.keys())
+        self.assertEqual(len(rst.array_annotations['empty']), 0)
+
     def test_write_proxyobjects(self):
 
         def generate_complete_block():


### PR DESCRIPTION
Currently, the `property.definition` attribute is used to tag both empty annotations and array annotations. This breaks down in the case of empty array annotations. 

I moved the array annotation tag to `property.type` which appeared to be unused as well, and I added a test with an empty array annotation. 

@achilleas-k is using the `property.type` attribute feasible / does that cause any other issues down the line? It only seems to work with `nixio<=1.5.0b3`.