### PR TITLE
(WIP) update neuralynx io

### DIFF
--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -147,7 +147,7 @@ class BaseRawIO:
 
         """
         self._parse_header()
-        self._group_signal_channel_characteristics()
+        # self._group_signal_channel_characteristics()
 
     def source_name(self):
         """Return fancy name of file source"""

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -147,7 +147,7 @@ class BaseRawIO:
 
         """
         self._parse_header()
-        # self._group_signal_channel_characteristics()
+        self._group_signal_channel_characteristics()
 
     def source_name(self):
         """Return fancy name of file source"""

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -603,8 +603,8 @@ class NeuralynxRawIO(BaseRawIO):
             # gap indices are detected by dt > good_delta (thus pointing to rows)
             gap_indices = np.where(np.diff(data['timestamp']) > good_delta)[0]  # row (block) indices
             for g in gap_indices:
-                assert (data['timestamp'][g+1] - data['timestamp'][g]) <= max_gap_duration_to_fill * 1e6, 'found a big gap, what should we do???'
-
+                if data['timestamp'][g+1] - data['timestamp'][g] <= max_gap_duration_to_fill * 1e6:  #, 'found a big gap, what should we do???'
+                    print(f'WARNING - big gap filled {data["timestamp"][g+1] - data["timestamp"][g]} - {ncs_info["filenames"][i]}')
             # Get the intervals of continuous data (pointing to 'ts_norm' or the orignal (broken) data
             data_starts = np.concatenate([np.zeros(1), gap_indices+1]).astype('int')
             data_stops = np.concatenate([gap_indices, [data['timestamp'].size-1]]).astype('int')


### PR DESCRIPTION
Add info about inversion
Commented not-used lines in `read_txt_header`
In `read_txt_header` writes None to 'recording_opened' or 'recording_closed' if either breaks

TODO:
deal with ring buffer errors
deal with data of different lenghts (dsp)

follow up on #819 
Data which cannot be read by current IO (or explaining the issues) are [here](https://gin.g-node.org/TRuikes/ephy_testing_data/src/master/neuralynx/examples_breaking_data)