### PR TITLE
AxographRawIO: Handle recoverable errors, support files written by axographio package

### DIFF
--- a/neo/rawio/axographrawio.py
+++ b/neo/rawio/axographrawio.py
@@ -826,14 +826,15 @@ class AxographRawIO(BaseRawIO):
                     # verify times are spaced regularly
                     diffs = np.diff(array)
                     increment = np.median(diffs)
-                    max_frac_step_deviation = np.max(np.abs(diffs/increment-1))
+                    max_frac_step_deviation = np.max(np.abs(
+                        diffs / increment - 1))
                     tolerance = 1e-3
                     if max_frac_step_deviation > tolerance:
                         self.logger.debug('largest proportional deviation '
                                           'from median step size in the first '
-                                          'column exceeds the tolerance of ' +
-                                          str(tolerance) + ': ' +
-                                          str(max_frac_step_deviation))
+                                          'column exceeds the tolerance '
+                                          'of ' + str(tolerance) + ':'
+                                          ' ' + str(max_frac_step_deviation))
                         raise ValueError('first data column (assumed to be '
                                          'time) is not regularly spaced')
 

--- a/neo/rawio/axographrawio.py
+++ b/neo/rawio/axographrawio.py
@@ -1334,9 +1334,15 @@ class StructFile(BufferedReader):
         Calculate the number of bytes corresponding to the format string, read
         in that number of bytes, and unpack them according to the format string
         """
-        return unpack(
-            self.byte_order + fmt,
-            self.read(calcsize(self.byte_order + fmt)))
+        try:
+            return unpack(
+                self.byte_order + fmt,
+                self.read(calcsize(self.byte_order + fmt)))
+        except Exception as e:
+            if e.args[0].startswith('unpack requires a buffer of'):
+                raise EOFError(e)
+            else:
+                raise
 
     def read_string(self):
         """

--- a/neo/test/iotest/test_axographio.py
+++ b/neo/test/iotest/test_axographio.py
@@ -143,8 +143,8 @@ class TestAxographIO(BaseTestIO, unittest.TestCase):
 
         sig = blk.segments[0].analogsignals[0][:5]
         arr = sig.as_array('mV')
-        target = np.array([[ 0.000000],
-                           [ 9.999833],
+        target = np.array([[0.000000],
+                           [9.999833],
                            [19.998667],
                            [29.995500],
                            [39.989334]], dtype=np.float32)
@@ -167,8 +167,8 @@ class TestAxographIO(BaseTestIO, unittest.TestCase):
 
         sig = blk.segments[0].analogsignals[0][:5]
         arr = sig.as_array('mV')
-        target = np.array([[ 0.000000],
-                           [ 9.999833],
+        target = np.array([[0.000000],
+                           [9.999833],
                            [19.998667],
                            [29.995500],
                            [39.989334]], dtype=np.float32)
@@ -191,8 +191,8 @@ class TestAxographIO(BaseTestIO, unittest.TestCase):
 
         sig = blk.segments[0].analogsignals[0][:5]
         arr = sig.as_array('mV')
-        target = np.array([[ 0.000000],
-                           [ 9.999833],
+        target = np.array([[0.000000],
+                           [9.999833],
                            [19.998667],
                            [29.995500],
                            [39.989334]], dtype=np.float32)

--- a/neo/test/rawiotest/test_axographrawio.py
+++ b/neo/test/rawiotest/test_axographrawio.py
@@ -17,6 +17,9 @@ class TestAxographRawIO(BaseTestRawIO, unittest.TestCase):
         'File_axograph.axgd',       # version 6 file
         'episodic.axgd',
         'events_and_epochs.axgx',
+        'written-by-axographio-with-linearsequence.axgx',
+        'written-by-axographio-without-linearsequence.axgx',
+        'corrupt-comment.axgx',
     ]
     entities_to_test = files_to_download
 


### PR DESCRIPTION
``AxographRawIO`` should now be able to recover from unexpected end-of-file errors and text decoding errors if they occur when parsing sections of the header containing non-essential metadata. Warnings are logged in these cases, but the process should not fatally stall.

Previously, support for some AxoGraph files written by the independent [axographio](https://pypi.org/project/axographio/) Python package was missing. This has now been added. Namely, files written in the latest format version with a time vector (rather than a ``t_start, sampling_period`` pair using ``axographio.linearsequence``; these were already supported) can now be read.

Additionally, the reader will now check that time vectors are uniformly sampled, rather than just assuming they are.

Tests were added for all new functionality. 