### PR TITLE
fix for v9 SON files

### DIFF
--- a/neo/core/channelindex.py
+++ b/neo/core/channelindex.py
@@ -178,7 +178,7 @@ class ChannelIndex(Container):
             channel_ids = np.array([], dtype='i')
 
         # Store recommended attributes
-        self.channel_names = np.array(channel_names)
+        self.channel_names = np.array(channel_names, dtype='S')
         self.channel_ids = np.array(channel_ids)
         self.index = np.array(index)
         self.coordinates = coordinates

--- a/neo/core/channelindex.py
+++ b/neo/core/channelindex.py
@@ -178,7 +178,7 @@ class ChannelIndex(Container):
             channel_ids = np.array([], dtype='i')
 
         # Store recommended attributes
-        self.channel_names = np.array(channel_names, dtype='S')
+        self.channel_names = np.array(channel_names)
         self.channel_ids = np.array(channel_ids)
         self.index = np.array(index)
         self.coordinates = coordinates

--- a/neo/test/iotest/test_spike2io.py
+++ b/neo/test/iotest/test_spike2io.py
@@ -18,6 +18,7 @@ class TestSpike2IO(BaseTestIO, unittest.TestCase, ):
         'File_spike2_3.smr',
         '130322-1LY.smr',  # this is for bug 182
         'multi_sampling.smr',  # this is for bug 466
+        'Two-mice-bigfile-test000.smr',  # SONv9 file
     ]
     files_to_download = files_to_test
 

--- a/neo/test/rawiotest/test_spike2rawio.py
+++ b/neo/test/rawiotest/test_spike2rawio.py
@@ -13,6 +13,7 @@ class TestSpike2RawIO(BaseTestRawIO, unittest.TestCase, ):
         'File_spike2_3.smr',
         '130322-1LY.smr',  # this is for bug 182
         'multi_sampling.smr',  # this is for bug 466
+        'Two-mice-bigfile-test000.smr',  # SONv9 file
     ]
     entities_to_test = files_to_download
 


### PR DESCRIPTION
In the CED documentation for the SON library, it says:

> In version 9 and above files, if pos is of type TDOF, the disk offset is pos*DISKBLOCK. In version 8 and previous files, the disk offset is pos. 

this PR fixes the offsets for v9 files, and fixes #818 