### PR TITLE
Add concatenate functionality for signal objects

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -664,6 +664,8 @@ class AnalogSignal(BaseSignal):
 
         Units, sampling_rate and number of signal traces must be the same
         for all signals. Otherwise a ValueError is raised.
+        Note that timestamps of concatenated signals might shift in oder to
+        align the sampling times of all signals.
 
         Parameters
         ----------

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -714,7 +714,8 @@ class AnalogSignal(BaseSignal):
         units, sr, shape = attribute_values[0]
 
         # find gaps between Analogsignals
-        combined_time_ranges = self._concatenate_time_ranges([(s.t_start, s.t_stop) for s in signals])
+        combined_time_ranges = self._concatenate_time_ranges(
+            [(s.t_start, s.t_stop) for s in signals])
         missing_time_ranges = self._invert_time_ranges(combined_time_ranges)
         if len(missing_time_ranges):
             diffs = np.diff(np.asarray(missing_time_ranges), axis=1)
@@ -759,7 +760,7 @@ class AnalogSignal(BaseSignal):
                 kwargs[name] = f'concatenation ({attr})'
 
         conc_signal = AnalogSignal(np.full(shape=shape, fill_value=padding, dtype=signals[0].dtype),
-                                   sampling_rate=sr,  t_start=t_start,  units=units, **kwargs)
+                                   sampling_rate=sr, t_start=t_start, units=units, **kwargs)
 
         if not overwrite:
             signals = signals[::-1]
@@ -783,10 +784,7 @@ class AnalogSignal(BaseSignal):
     def _invert_time_ranges(self, time_ranges):
         i = 0
         new_ranges = []
-        while i < len(time_ranges)-1:
-            new_ranges.append((time_ranges[i][1], time_ranges[i+1][0]))
+        while i < len(time_ranges) - 1:
+            new_ranges.append((time_ranges[i][1], time_ranges[i + 1][0]))
             i += 1
         return new_ranges
-
-
-

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -660,7 +660,7 @@ class AnalogSignal(BaseSignal):
 
     def concatenate(self, other, overwrite=True, padding=False):
         '''
-        Patch another signal to this one.
+        Combine this and another signal along the time axis.
 
         The signal objects are concatenated vertically
         (row-wise, :func:`np.vstack`). Patching can be

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -725,7 +725,8 @@ class AnalogSignal(BaseSignal):
                 if getattr(self, attr[0], None) != getattr(other, attr[0], None):
                     # if attr[0] in ['t_start','t_stop']:
                     #     continue
-                    raise MergeError("Cannot concatenate these two signals as the %s differ." % attr[0])
+                    raise MergeError(
+                        "Cannot concatenate these two signals as the %s differ." % attr[0])
 
         if hasattr(self, "lazy_shape"):
             if hasattr(other, "lazy_shape"):
@@ -740,8 +741,8 @@ class AnalogSignal(BaseSignal):
         if signal2.t_start > signal1.t_stop + signal1.sampling_period:
             if padding != False:
                 logger.warning('Signals will be padded using {}.'.format(padding))
-                pad_time = signal2.t_start-signal1.t_stop
-                n_pad_samples = int(((pad_time)*self.sampling_rate).rescale('dimensionless'))
+                pad_time = signal2.t_start - signal1.t_stop
+                n_pad_samples = int(((pad_time) * self.sampling_rate).rescale('dimensionless'))
                 if padding is True:
                     padding = np.NaN * self.units
                 if isinstance(padding, pq.Quantity):
@@ -752,7 +753,8 @@ class AnalogSignal(BaseSignal):
                 pad_data = np.full((n_pad_samples,) + signal1.shape[1:], padding)
 
                 # create new signal 1 with extended data, but keep array_annotations
-                signal_tmp = signal1.duplicate_with_new_data(np.vstack((signal1.magnitude, pad_data)))
+                signal_tmp = signal1.duplicate_with_new_data(
+                    np.vstack((signal1.magnitude, pad_data)))
                 signal_tmp.array_annotations = signal1.array_annotations
                 signal1 = signal_tmp
             else:
@@ -761,7 +763,7 @@ class AnalogSignal(BaseSignal):
 
         #  in case of overlapping signals slice according to overwrite parameter
         elif signal2.t_start < signal1.t_stop + signal1.sampling_period:
-            n_samples = int(((signal1.t_stop - signal2.t_start)*signal1.sampling_rate).simplified)
+            n_samples = int(((signal1.t_stop - signal2.t_start) * signal1.sampling_rate).simplified)
             logger.warning('Overwriting {} samples while concatenating signals.'.format(n_samples))
             if not overwrite:  # removing samples second signal
                 slice_t_start = signal1.t_stop + signal1.sampling_period

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -658,7 +658,7 @@ class AnalogSignal(BaseSignal):
 
         return rectified_signal
 
-    def patch(self, other, overwrite=True, padding=False):
+    def concatenate(self, other, overwrite=True, padding=False):
         '''
         Patch another signal to this one.
 
@@ -668,7 +668,7 @@ class AnalogSignal(BaseSignal):
         have to overlap by one sample in time, i.e.
         self.t_stop == other.t_start
         Note: Only common array annotations common to
-        both signals are attached to the patched signal.
+        both signals are attached to the concatenated signal.
 
         If the attributes of the two signal are not
         compatible, an Exception is raised.
@@ -725,16 +725,16 @@ class AnalogSignal(BaseSignal):
                 if getattr(self, attr[0], None) != getattr(other, attr[0], None):
                     # if attr[0] in ['t_start','t_stop']:
                     #     continue
-                    raise MergeError("Cannot patch these two signals as the %s differ." % attr[0])
+                    raise MergeError("Cannot concatenate these two signals as the %s differ." % attr[0])
 
         if hasattr(self, "lazy_shape"):
             if hasattr(other, "lazy_shape"):
                 if self.lazy_shape[-1] != other.lazy_shape[-1]:
-                    raise MergeError("Cannot patch signals as they contain"
+                    raise MergeError("Cannot concatenate signals as they contain"
                                      " different numbers of traces.")
                 merged_lazy_shape = (self.lazy_shape[0] + other.lazy_shape[0], self.lazy_shape[-1])
             else:
-                raise MergeError("Cannot patch a lazy object with a real object.")
+                raise MergeError("Cannot concatenate a lazy object with a real object.")
 
         #  in case of non-overlapping signals consider padding
         if signal2.t_start > signal1.t_stop + signal1.sampling_period:
@@ -762,7 +762,7 @@ class AnalogSignal(BaseSignal):
         #  in case of overlapping signals slice according to overwrite parameter
         elif signal2.t_start < signal1.t_stop + signal1.sampling_period:
             n_samples = int(((signal1.t_stop - signal2.t_start)*signal1.sampling_rate).simplified)
-            logger.warning('Overwriting {} samples while patching signals.'.format(n_samples))
+            logger.warning('Overwriting {} samples while concatenating signals.'.format(n_samples))
             if not overwrite:  # removing samples second signal
                 slice_t_start = signal1.t_stop + signal1.sampling_period
                 signal2 = signal2.time_slice(slice_t_start, None)
@@ -771,7 +771,7 @@ class AnalogSignal(BaseSignal):
                 signal1 = signal1.time_slice(None, slice_t_stop)
         else:
             assert signal2.t_start == signal1.t_stop + signal1.sampling_period, \
-                "Cannot patch signals with non-overlapping times"
+                "Cannot concatenate signals with non-overlapping times"
 
         stack = np.vstack((signal1.magnitude, signal2.magnitude))
 

--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -3,6 +3,7 @@ This module defines :class:`BaseNeo`, the abstract base class
 used by all :module:`neo.core` classes.
 """
 
+from copy import deepcopy
 from datetime import datetime, date, time, timedelta
 from decimal import Decimal
 import logging
@@ -107,6 +108,36 @@ def merge_annotations(A, *Bs):
                     merged[name] = "MERGE CONFLICT"  # temporary hack
     logger.debug("Merging annotations: A=%s Bs=%s merged=%s", A, Bs, merged)
     return merged
+
+def intersect_annotations(A, B):
+    """
+    Identify common entries in dictionaries A and B
+    and return these in a separate dictionary.
+
+    Entries have to share key as well as value to be
+    considered common.
+
+    Parameters
+    ----------
+    A, B : dict
+        Dictionaries to merge.
+    """
+
+    result = {}
+
+    for key in A.keys() & B.keys():
+        v1, v2 = A[key], B[key]
+        assert type(v1) == type(v2), 'type({}) {} != type({}) {}'.format(v1, type(v1),
+                                                                         v2, type(v2))
+        if isinstance(v1, dict) and v1 == v2:
+            result[key] = deepcopy(v1)
+        elif isinstance(v1, str) and v1 == v2:
+            result[key] = A[key]
+        elif isinstance(v1, list) and v1 == v2:
+            result[key] = deepcopy(v1)
+        elif isinstance(v1, np.ndarray) and all(v1 == v2):
+            result[key] = deepcopy(v1)
+    return result
 
 
 def _reference_name(class_name):

--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -109,6 +109,7 @@ def merge_annotations(A, *Bs):
     logger.debug("Merging annotations: A=%s Bs=%s merged=%s", A, Bs, merged)
     return merged
 
+
 def intersect_annotations(A, B):
     """
     Identify common entries in dictionaries A and B

--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -126,7 +126,7 @@ def intersect_annotations(A, B):
 
     result = {}
 
-    for key in A.keys() & B.keys():
+    for key in set(A.keys()) & set(B.keys()):
         v1, v2 = A[key], B[key]
         assert type(v1) == type(v2), 'type({}) {} != type({}) {}'.format(v1, type(v1),
                                                                          v2, type(v2))

--- a/neo/core/basesignal.py
+++ b/neo/core/basesignal.py
@@ -282,10 +282,12 @@ class BaseSignal(DataObject):
         # merge channel_index (move to ChannelIndex.merge()?)
         if self.channel_index and other.channel_index:
             signal.channel_index = ChannelIndex(index=np.arange(signal.shape[1]),
-                channel_ids=np.hstack(
-                    [self.channel_index.channel_ids, other.channel_index.channel_ids]),
-                channel_names=np.hstack(
-                    [self.channel_index.channel_names, other.channel_index.channel_names]))
+                                                channel_ids=np.hstack(
+                                                    [self.channel_index.channel_ids,
+                                                     other.channel_index.channel_ids]),
+                                                channel_names=np.hstack(
+                                                    [self.channel_index.channel_names,
+                                                     other.channel_index.channel_names]))
         else:
             signal.channel_index = ChannelIndex(index=np.arange(signal.shape[1]))
 
@@ -297,7 +299,6 @@ class BaseSignal(DataObject):
         original Signal between times t_start, t_stop.
         '''
         NotImplementedError('Needs to be implemented for subclasses.')
-
 
     def concatenate(self, other):
         '''
@@ -332,5 +333,3 @@ class BaseSignal(DataObject):
         '''
 
         NotImplementedError('Patching need to be implemented in sublcasses')
-
-

--- a/neo/core/basesignal.py
+++ b/neo/core/basesignal.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 import numpy as np
 import quantities as pq
 
-from neo.core.baseneo import BaseNeo, MergeError, merge_annotations
+from neo.core.baseneo import MergeError, merge_annotations
 from neo.core.dataobject import DataObject, ArrayDict
 from neo.core.channelindex import ChannelIndex
 
@@ -290,3 +290,47 @@ class BaseSignal(DataObject):
             signal.channel_index = ChannelIndex(index=np.arange(signal.shape[1]))
 
         return signal
+
+    def time_slice(self, t_start, t_stop):
+        '''
+        Creates a new AnalogSignal corresponding to the time slice of the
+        original Signal between times t_start, t_stop.
+        '''
+        NotImplementedError('Needs to be implemented for subclasses.')
+
+
+    def patch(self, other):
+        '''
+        Patch another signal to this one.
+
+        The signal objects are concatenated vertically
+        (row-wise, :func:`np.vstack`). Patching can be
+        used to combine signals across segments.
+        Note: Only array annotations common to
+        both signals are attached to the patched signal.
+
+        If the attributes of the two signal are not
+        compatible, an Exception is raised.
+
+        Required attributes of the signal are used.
+
+        Parameters
+        ----------
+        other : neo.BaseSignal
+            The object that is merged into this one.
+
+        Returns
+        -------
+        signal : neo.BaseSignal
+            Signal containing all non-overlapping samples of
+            both source signals.
+
+        Raises
+        ------
+        MergeError
+            If `other` object has incompatible attributes.
+        '''
+
+        NotImplementedError('Patching need to be implemented in sublcasses')
+
+

--- a/neo/core/basesignal.py
+++ b/neo/core/basesignal.py
@@ -299,7 +299,7 @@ class BaseSignal(DataObject):
         NotImplementedError('Needs to be implemented for subclasses.')
 
 
-    def patch(self, other):
+    def concatenate(self, other):
         '''
         Patch another signal to this one.
 
@@ -307,7 +307,7 @@ class BaseSignal(DataObject):
         (row-wise, :func:`np.vstack`). Patching can be
         used to combine signals across segments.
         Note: Only array annotations common to
-        both signals are attached to the patched signal.
+        both signals are attached to the concatenated signal.
 
         If the attributes of the two signal are not
         compatible, an Exception is raised.

--- a/neo/core/basesignal.py
+++ b/neo/core/basesignal.py
@@ -300,31 +300,29 @@ class BaseSignal(DataObject):
         '''
         NotImplementedError('Needs to be implemented for subclasses.')
 
-    def concatenate(self, other):
+    def concatenate(self, *signals):
         '''
-        Patch another signal to this one.
+        Concatenate multiple signals across time.
 
         The signal objects are concatenated vertically
-        (row-wise, :func:`np.vstack`). Patching can be
+        (row-wise, :func:`np.vstack`). Concatenation can be
         used to combine signals across segments.
-        Note: Only array annotations common to
+        Note: Only (array) annotations common to
         both signals are attached to the concatenated signal.
 
-        If the attributes of the two signal are not
+        If the attributes of the signals are not
         compatible, an Exception is raised.
-
-        Required attributes of the signal are used.
 
         Parameters
         ----------
-        other : neo.BaseSignal
-            The object that is merged into this one.
+        signals : multiple neo.BaseSignal objects
+            The objects that is concatenated with this one.
 
         Returns
         -------
         signal : neo.BaseSignal
             Signal containing all non-overlapping samples of
-            both source signals.
+            the source signals.
 
         Raises
         ------

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -31,7 +31,7 @@ else:
 import numpy as np
 import quantities as pq
 
-from neo.core.baseneo import BaseNeo, MergeError, merge_annotations
+from neo.core.baseneo import MergeError, merge_annotations, intersect_annotations
 from neo.core.basesignal import BaseSignal
 from neo.core.analogsignal import AnalogSignal
 from neo.core.channelindex import ChannelIndex
@@ -512,5 +512,84 @@ class IrregularlySampledSignal(BaseSignal):
                                                      other.channel_index.channel_names]))
         else:
             signal.channel_index = ChannelIndex(index=np.arange(signal.shape[1]))
+
+        return signal
+
+    def patch(self, other):
+        '''
+        Patch another signal to this one.
+
+        The signal objects are concatenated vertically
+        (row-wise, :func:`np.vstack`). Patching can be
+        used to combine signals across segments.
+        Note: Only array annotations common to
+        both signals are attached to the patched signal.
+
+        If the attributes of the two signal are not
+        compatible, an Exception is raised.
+
+        Required attributes of the signal are used.
+
+        Parameters
+        ----------
+        other : neo.BaseSignal
+            The object that is merged into this one.
+
+        Returns
+        -------
+        signal : neo.IrregularlySampledSignal
+            Signal containing all non-overlapping samples of
+            both source signals.
+
+        Raises
+        ------
+        MergeError
+            If `other` object has incompatible attributes.
+        '''
+
+        for attr in self._necessary_attrs:
+            if not (attr[0] in ['signal', 'times', 't_start', 't_stop', 'times']):
+                if getattr(self, attr[0], None) != getattr(other, attr[0], None):
+                    raise MergeError("Cannot patch these two signals as the %s differ." % attr[0])
+
+        if hasattr(self, "lazy_shape"):
+            if hasattr(other, "lazy_shape"):
+                if self.lazy_shape[-1] != other.lazy_shape[-1]:
+                    raise MergeError("Cannot patch signals as they contain"
+                                     " different numbers of traces.")
+                merged_lazy_shape = (self.lazy_shape[0] + other.lazy_shape[0], self.lazy_shape[-1])
+            else:
+                raise MergeError("Cannot patch a lazy object with a real object.")
+        if other.units != self.units:
+            other = other.rescale(self.units)
+
+        new_times = np.hstack((self.times, other.times))
+        sorting = np.argsort(new_times)
+        new_samples = np.vstack((self.magnitude, other.magnitude))
+
+        kwargs = {}
+        for name in ("name", "description", "file_origin"):
+            attr_self = getattr(self, name)
+            attr_other = getattr(other, name)
+            if attr_self == attr_other:
+                kwargs[name] = attr_self
+            else:
+                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
+        merged_annotations = merge_annotations(self.annotations, other.annotations)
+        kwargs.update(merged_annotations)
+
+        kwargs['array_annotations'] = intersect_annotations(self.array_annotations,
+                                                            other.array_annotations)
+        t_start = min(self.t_start, other.t_start)
+        t_stop = max(self.t_start, other.t_start)
+
+        signal = IrregularlySampledSignal(signal=new_samples[sorting], times=new_times[sorting],
+                                          units=self.units, dtype=self.dtype, copy=False,
+                                          t_start=t_start, t_stop=t_stop, **kwargs)
+        signal.segment = None
+        signal.channel_index = None
+
+        if hasattr(self, "lazy_shape"):
+            signal.lazy_shape = merged_lazy_shape
 
         return signal

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -515,7 +515,7 @@ class IrregularlySampledSignal(BaseSignal):
 
         return signal
 
-    def patch(self, other):
+    def concatenate(self, other):
         '''
         Patch another signal to this one.
 
@@ -523,7 +523,7 @@ class IrregularlySampledSignal(BaseSignal):
         (row-wise, :func:`np.vstack`). Patching can be
         used to combine signals across segments.
         Note: Only array annotations common to
-        both signals are attached to the patched signal.
+        both signals are attached to the concatenated signal.
 
         If the attributes of the two signal are not
         compatible, an Exception is raised.
@@ -550,16 +550,16 @@ class IrregularlySampledSignal(BaseSignal):
         for attr in self._necessary_attrs:
             if not (attr[0] in ['signal', 'times', 't_start', 't_stop', 'times']):
                 if getattr(self, attr[0], None) != getattr(other, attr[0], None):
-                    raise MergeError("Cannot patch these two signals as the %s differ." % attr[0])
+                    raise MergeError("Cannot concatenate these two signals as the %s differ." % attr[0])
 
         if hasattr(self, "lazy_shape"):
             if hasattr(other, "lazy_shape"):
                 if self.lazy_shape[-1] != other.lazy_shape[-1]:
-                    raise MergeError("Cannot patch signals as they contain"
+                    raise MergeError("Cannot concatenate signals as they contain"
                                      " different numbers of traces.")
                 merged_lazy_shape = (self.lazy_shape[0] + other.lazy_shape[0], self.lazy_shape[-1])
             else:
-                raise MergeError("Cannot patch a lazy object with a real object.")
+                raise MergeError("Cannot concatenate a lazy object with a real object.")
         if other.units != self.units:
             other = other.rescale(self.units)
 

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -515,9 +515,9 @@ class IrregularlySampledSignal(BaseSignal):
 
         return signal
 
-    def concatenate(self, other):
+    def concatenate(self, other, allow_overlap=False):
         '''
-        Patch another signal to this one.
+        Combine this and another signal along the time axis.
 
         The signal objects are concatenated vertically
         (row-wise, :func:`np.vstack`). Patching can be
@@ -534,6 +534,11 @@ class IrregularlySampledSignal(BaseSignal):
         ----------
         other : neo.BaseSignal
             The object that is merged into this one.
+        allow_overlap : bool
+            If false, overlapping samples between the two
+            signals are not permitted and an ValueError is raised.
+            If true, no check for overlapping samples is
+            performed and all samples are combined.
 
         Returns
         -------
@@ -581,6 +586,12 @@ class IrregularlySampledSignal(BaseSignal):
 
         kwargs['array_annotations'] = intersect_annotations(self.array_annotations,
                                                             other.array_annotations)
+
+        if not allow_overlap:
+            if max(self.t_start, other.t_start) <= min(self.t_stop, other.t_stop):
+                raise ValueError('Can not combine signals that overlap in time. Allow for '
+                                 'overlapping samples using the "no_overlap" parameter.')
+
         t_start = min(self.t_start, other.t_start)
         t_stop = max(self.t_start, other.t_start)
 

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -550,7 +550,8 @@ class IrregularlySampledSignal(BaseSignal):
         for attr in self._necessary_attrs:
             if not (attr[0] in ['signal', 'times', 't_start', 't_stop', 'times']):
                 if getattr(self, attr[0], None) != getattr(other, attr[0], None):
-                    raise MergeError("Cannot concatenate these two signals as the %s differ." % attr[0])
+                    raise MergeError(
+                        "Cannot concatenate these two signals as the %s differ." % attr[0])
 
         if hasattr(self, "lazy_shape"):
             if hasattr(other, "lazy_shape"):

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -370,18 +370,17 @@ class TestAnalogSignalProperties(unittest.TestCase):
     def test__pretty(self):
         for i, signal in enumerate(self.signals):
             prepr = pretty(signal)
-            targ = (
-                    ('AnalogSignal with %d channels of length %d; units %s; datatype %s \n'
+            targ = (('AnalogSignal with %d channels of length %d; units %s; datatype %s \n'
                      '' % (signal.shape[1], signal.shape[0],
                            signal.units.dimensionality.unicode, signal.dtype))
                     + ('annotations: %s\n' % signal.annotations)
-                    + ('sampling rate: {} {}\n'.format(float(signal.sampling_rate),
-                                                       signal.sampling_rate.dimensionality.unicode))
+                    + ('sampling rate: {} {}\n'.format(
+                        float(signal.sampling_rate),
+                        signal.sampling_rate.dimensionality.unicode))
                     + ('time: {} {} to {} {}'.format(float(signal.t_start),
                                                      signal.t_start.dimensionality.unicode,
                                                      float(signal.t_stop),
-                                                     signal.t_stop.dimensionality.unicode))
-            )
+                                                     signal.t_stop.dimensionality.unicode)))
             self.assertEqual(prepr, targ)
 
 
@@ -1648,8 +1647,9 @@ class TestAnalogSignalCombination(unittest.TestCase):
                                t_start=signal1.t_stop + 3 * signal1.sampling_period)
 
         result = signal1.concatenate(signal2, overwrite=False, padding=True)
-        assert_array_equal(np.array([0, 1, 2, 3, np.NaN, np.NaN, np.NaN, 4, 5, 6]).reshape((-1, 1)),
-                           result.magnitude)
+        assert_array_equal(
+            np.array([0, 1, 2, 3, np.NaN, np.NaN, np.NaN, 4, 5, 6]).reshape((-1, 1)),
+            result.magnitude)
 
     def test_concatenate_padding_quantity(self):
         signal1 = AnalogSignal([0, 1, 2, 3] * pq.V, sampling_rate=1 * pq.Hz)

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -371,16 +371,16 @@ class TestAnalogSignalProperties(unittest.TestCase):
         for i, signal in enumerate(self.signals):
             prepr = pretty(signal)
             targ = (
-                ('AnalogSignal with %d channels of length %d; units %s; datatype %s \n'
-                 '' % (signal.shape[1], signal.shape[0],
-                       signal.units.dimensionality.unicode, signal.dtype))
-                + ('annotations: %s\n' % signal.annotations)
-                + ('sampling rate: {} {}\n'.format(float(signal.sampling_rate),
-                                                   signal.sampling_rate.dimensionality.unicode))
-                + ('time: {} {} to {} {}'.format(float(signal.t_start),
-                                                 signal.t_start.dimensionality.unicode,
-                                                 float(signal.t_stop),
-                                                 signal.t_stop.dimensionality.unicode))
+                    ('AnalogSignal with %d channels of length %d; units %s; datatype %s \n'
+                     '' % (signal.shape[1], signal.shape[0],
+                           signal.units.dimensionality.unicode, signal.dtype))
+                    + ('annotations: %s\n' % signal.annotations)
+                    + ('sampling rate: {} {}\n'.format(float(signal.sampling_rate),
+                                                       signal.sampling_rate.dimensionality.unicode))
+                    + ('time: {} {} to {} {}'.format(float(signal.t_start),
+                                                     signal.t_start.dimensionality.unicode,
+                                                     float(signal.t_stop),
+                                                     signal.t_stop.dimensionality.unicode))
             )
             self.assertEqual(prepr, targ)
 
@@ -1291,6 +1291,7 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         assert_arrays_equal(rectified_signal.array_annotations['anno2'],
                             target_signal.array_annotations['anno2'])
 
+
 class TestAnalogSignalEquality(unittest.TestCase):
     def test__signals_with_different_data_complement_should_be_not_equal(self):
         signal1 = AnalogSignal(np.arange(55.0).reshape((11, 5)), units="mV",
@@ -1574,8 +1575,8 @@ class TestAnalogSignalCombination(unittest.TestCase):
         assert_arrays_equal(mergeddata24, targdata24)
 
     def test_concatenate_simple(self):
-        signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
-        signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
+        signal1 = AnalogSignal([0, 1, 2, 3] * pq.V, sampling_rate=1 * pq.Hz)
+        signal2 = AnalogSignal([4, 5, 6] * pq.V, sampling_rate=1 * pq.Hz,
                                t_start=signal1.t_stop + signal1.sampling_period)
 
         result = signal1.concatenate(signal2)
@@ -1584,8 +1585,8 @@ class TestAnalogSignalCombination(unittest.TestCase):
             self.assertEqual(getattr(signal1, attr[0], None), getattr(result, attr[0], None))
 
     def test_concatenate_inverse_signals(self):
-        signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
-        signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
+        signal1 = AnalogSignal([0, 1, 2, 3] * pq.V, sampling_rate=1 * pq.Hz)
+        signal2 = AnalogSignal([4, 5, 6] * pq.V, sampling_rate=1 * pq.Hz,
                                t_start=signal1.t_stop + signal1.sampling_period)
 
         result = signal2.concatenate(signal1)
@@ -1594,71 +1595,71 @@ class TestAnalogSignalCombination(unittest.TestCase):
             self.assertEqual(getattr(signal1, attr[0], None), getattr(result, attr[0], None))
 
     def test_concatenate_no_overlap(self):
-        signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
-        signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
-                               t_start=10*pq.s + signal1.sampling_period)
+        signal1 = AnalogSignal([0, 1, 2, 3] * pq.V, sampling_rate=1 * pq.Hz)
+        signal2 = AnalogSignal([4, 5, 6] * pq.V, sampling_rate=1 * pq.Hz,
+                               t_start=10 * pq.s + signal1.sampling_period)
 
         with self.assertRaises(MergeError):
             signal1.concatenate(signal2)
 
     def test_concatenate_multi_trace(self):
-        data1 = np.arange(4).reshape(2,2)
-        data2 = np.arange(4,8).reshape(2,2)
-        signal1 = AnalogSignal(data1*pq.V, sampling_rate=1*pq.Hz)
-        signal2 = AnalogSignal(data2*pq.V, sampling_rate=1*pq.Hz,
+        data1 = np.arange(4).reshape(2, 2)
+        data2 = np.arange(4, 8).reshape(2, 2)
+        signal1 = AnalogSignal(data1 * pq.V, sampling_rate=1 * pq.Hz)
+        signal2 = AnalogSignal(data2 * pq.V, sampling_rate=1 * pq.Hz,
                                t_start=signal1.t_stop + signal1.sampling_period)
 
         result = signal1.concatenate(signal2)
-        data_expected = np.array([[0,1],[2,3],[4,5],[6,7]])
+        data_expected = np.array([[0, 1], [2, 3], [4, 5], [6, 7]])
         assert_array_equal(data_expected, result.magnitude)
         for attr in signal1._necessary_attrs:
             self.assertEqual(getattr(signal1, attr[0], None), getattr(result, attr[0], None))
 
     def test_concatenate_overwrite_true(self):
-        signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
-        signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
+        signal1 = AnalogSignal([0, 1, 2, 3] * pq.V, sampling_rate=1 * pq.Hz)
+        signal2 = AnalogSignal([4, 5, 6] * pq.V, sampling_rate=1 * pq.Hz,
                                t_start=signal1.t_stop)
 
         result = signal1.concatenate(signal2, overwrite=True)
-        assert_array_equal(np.array([0,1,2,4,5,6]).reshape((-1, 1)), result.magnitude)
+        assert_array_equal(np.array([0, 1, 2, 4, 5, 6]).reshape((-1, 1)), result.magnitude)
 
     def test_concatenate_overwrite_false(self):
-        signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
-        signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
+        signal1 = AnalogSignal([0, 1, 2, 3] * pq.V, sampling_rate=1 * pq.Hz)
+        signal2 = AnalogSignal([4, 5, 6] * pq.V, sampling_rate=1 * pq.Hz,
                                t_start=signal1.t_stop)
 
         result = signal1.concatenate(signal2, overwrite=False)
-        assert_array_equal(np.array([0,1,2,3,5,6]).reshape((-1, 1)), result.magnitude)
+        assert_array_equal(np.array([0, 1, 2, 3, 5, 6]).reshape((-1, 1)), result.magnitude)
 
     def test_concatenate_padding_False(self):
-        signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
-        signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
-                               t_start=10*pq.s)
+        signal1 = AnalogSignal([0, 1, 2, 3] * pq.V, sampling_rate=1 * pq.Hz)
+        signal2 = AnalogSignal([4, 5, 6] * pq.V, sampling_rate=1 * pq.Hz,
+                               t_start=10 * pq.s)
 
         with self.assertRaises(MergeError):
             result = signal1.concatenate(signal2, overwrite=False, padding=False)
 
     def test_concatenate_padding_True(self):
-        signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
-        signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
+        signal1 = AnalogSignal([0, 1, 2, 3] * pq.V, sampling_rate=1 * pq.Hz)
+        signal2 = AnalogSignal([4, 5, 6] * pq.V, sampling_rate=1 * pq.Hz,
                                t_start=signal1.t_stop + 3 * signal1.sampling_period)
 
         result = signal1.concatenate(signal2, overwrite=False, padding=True)
-        assert_array_equal(np.array([0,1,2,3,np.NaN,np.NaN,np.NaN,4,5,6]).reshape((-1, 1)),
+        assert_array_equal(np.array([0, 1, 2, 3, np.NaN, np.NaN, np.NaN, 4, 5, 6]).reshape((-1, 1)),
                            result.magnitude)
 
     def test_concatenate_padding_quantity(self):
-        signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
-        signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
+        signal1 = AnalogSignal([0, 1, 2, 3] * pq.V, sampling_rate=1 * pq.Hz)
+        signal2 = AnalogSignal([4, 5, 6] * pq.V, sampling_rate=1 * pq.Hz,
                                t_start=signal1.t_stop + 3 * signal1.sampling_period)
 
         result = signal1.concatenate(signal2, overwrite=False, padding=-1 * pq.mV)
-        assert_array_equal(np.array([0,1,2,3,-1e-3,-1e-3,-1e-3,4,5,6]).reshape((-1, 1)),
+        assert_array_equal(np.array([0, 1, 2, 3, -1e-3, -1e-3, -1e-3, 4, 5, 6]).reshape((-1, 1)),
                            result.magnitude)
 
     def test_concatenate_padding_invalid(self):
-        signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
-        signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
+        signal1 = AnalogSignal([0, 1, 2, 3] * pq.V, sampling_rate=1 * pq.Hz)
+        signal2 = AnalogSignal([4, 5, 6] * pq.V, sampling_rate=1 * pq.Hz,
                                t_start=signal1.t_stop + 3 * signal1.sampling_period)
 
         with self.assertRaises(ValueError):
@@ -1671,14 +1672,14 @@ class TestAnalogSignalCombination(unittest.TestCase):
             result = signal1.concatenate(signal2, overwrite=False, padding=np.array([1, 2, 3]))
 
     def test_concatenate_array_annotations(self):
-        array_anno1 = {'first': ['a','b']}
-        array_anno2 = {'first': ['a','b'],
-                       'second': ['c','d']}
-        data1 = np.arange(4).reshape(2,2)
-        data2 = np.arange(4,8).reshape(2,2)
-        signal1 = AnalogSignal(data1*pq.V, sampling_rate=1*pq.Hz,
+        array_anno1 = {'first': ['a', 'b']}
+        array_anno2 = {'first': ['a', 'b'],
+                       'second': ['c', 'd']}
+        data1 = np.arange(4).reshape(2, 2)
+        data2 = np.arange(4, 8).reshape(2, 2)
+        signal1 = AnalogSignal(data1 * pq.V, sampling_rate=1 * pq.Hz,
                                array_annotations=array_anno1)
-        signal2 = AnalogSignal(data2*pq.V, sampling_rate=1*pq.Hz,
+        signal2 = AnalogSignal(data2 * pq.V, sampling_rate=1 * pq.Hz,
                                t_start=signal1.t_stop + signal1.sampling_period,
                                array_annotations=array_anno2)
 
@@ -1700,10 +1701,12 @@ class TestAnalogSignalCombination(unittest.TestCase):
         concatenated12 = self.signal1.concatenate(signal2)
 
         for attr in signal1._necessary_attrs:
-            self.assertEqual(getattr(signal1, attr[0], None), getattr(concatenated12, attr[0], None))
+            self.assertEqual(getattr(signal1, attr[0], None),
+                             getattr(concatenated12, attr[0], None))
 
         assert_array_equal(np.vstack((signal1.magnitude, signal2.magnitude)),
                            concatenated12.magnitude)
+
 
 class TestAnalogSignalFunctions(unittest.TestCase):
     def test__pickle_1d(self):

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -1573,104 +1573,104 @@ class TestAnalogSignalCombination(unittest.TestCase):
         assert_arrays_equal(mergeddata23, targdata23)
         assert_arrays_equal(mergeddata24, targdata24)
 
-    def test_patch_simple(self):
+    def test_concatenate_simple(self):
         signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
         signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
                                t_start=signal1.t_stop + signal1.sampling_period)
 
-        result = signal1.patch(signal2)
+        result = signal1.concatenate(signal2)
         assert_array_equal(np.arange(7).reshape((-1, 1)), result.magnitude)
         for attr in signal1._necessary_attrs:
             self.assertEqual(getattr(signal1, attr[0], None), getattr(result, attr[0], None))
 
-    def test_patch_inverse_signals(self):
+    def test_concatenate_inverse_signals(self):
         signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
         signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
                                t_start=signal1.t_stop + signal1.sampling_period)
 
-        result = signal2.patch(signal1)
+        result = signal2.concatenate(signal1)
         assert_array_equal(np.arange(7).reshape((-1, 1)), result.magnitude)
         for attr in signal1._necessary_attrs:
             self.assertEqual(getattr(signal1, attr[0], None), getattr(result, attr[0], None))
 
-    def test_patch_no_overlap(self):
+    def test_concatenate_no_overlap(self):
         signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
         signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
                                t_start=10*pq.s + signal1.sampling_period)
 
         with self.assertRaises(MergeError):
-            signal1.patch(signal2)
+            signal1.concatenate(signal2)
 
-    def test_patch_multi_trace(self):
+    def test_concatenate_multi_trace(self):
         data1 = np.arange(4).reshape(2,2)
         data2 = np.arange(4,8).reshape(2,2)
         signal1 = AnalogSignal(data1*pq.V, sampling_rate=1*pq.Hz)
         signal2 = AnalogSignal(data2*pq.V, sampling_rate=1*pq.Hz,
                                t_start=signal1.t_stop + signal1.sampling_period)
 
-        result = signal1.patch(signal2)
+        result = signal1.concatenate(signal2)
         data_expected = np.array([[0,1],[2,3],[4,5],[6,7]])
         assert_array_equal(data_expected, result.magnitude)
         for attr in signal1._necessary_attrs:
             self.assertEqual(getattr(signal1, attr[0], None), getattr(result, attr[0], None))
 
-    def test_patch_overwrite_true(self):
+    def test_concatenate_overwrite_true(self):
         signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
         signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
                                t_start=signal1.t_stop)
 
-        result = signal1.patch(signal2, overwrite=True)
+        result = signal1.concatenate(signal2, overwrite=True)
         assert_array_equal(np.array([0,1,2,4,5,6]).reshape((-1, 1)), result.magnitude)
 
-    def test_patch_overwrite_false(self):
+    def test_concatenate_overwrite_false(self):
         signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
         signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
                                t_start=signal1.t_stop)
 
-        result = signal1.patch(signal2, overwrite=False)
+        result = signal1.concatenate(signal2, overwrite=False)
         assert_array_equal(np.array([0,1,2,3,5,6]).reshape((-1, 1)), result.magnitude)
 
-    def test_patch_padding_False(self):
+    def test_concatenate_padding_False(self):
         signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
         signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
                                t_start=10*pq.s)
 
         with self.assertRaises(MergeError):
-            result = signal1.patch(signal2, overwrite=False, padding=False)
+            result = signal1.concatenate(signal2, overwrite=False, padding=False)
 
-    def test_patch_padding_True(self):
+    def test_concatenate_padding_True(self):
         signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
         signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
                                t_start=signal1.t_stop + 3 * signal1.sampling_period)
 
-        result = signal1.patch(signal2, overwrite=False, padding=True)
+        result = signal1.concatenate(signal2, overwrite=False, padding=True)
         assert_array_equal(np.array([0,1,2,3,np.NaN,np.NaN,np.NaN,4,5,6]).reshape((-1, 1)),
                            result.magnitude)
 
-    def test_patch_padding_quantity(self):
+    def test_concatenate_padding_quantity(self):
         signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
         signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
                                t_start=signal1.t_stop + 3 * signal1.sampling_period)
 
-        result = signal1.patch(signal2, overwrite=False, padding=-1*pq.mV)
+        result = signal1.concatenate(signal2, overwrite=False, padding=-1 * pq.mV)
         assert_array_equal(np.array([0,1,2,3,-1e-3,-1e-3,-1e-3,4,5,6]).reshape((-1, 1)),
                            result.magnitude)
 
-    def test_patch_padding_invalid(self):
+    def test_concatenate_padding_invalid(self):
         signal1 = AnalogSignal([0,1,2,3]*pq.V, sampling_rate=1*pq.Hz)
         signal2 = AnalogSignal([4,5,6]*pq.V, sampling_rate=1*pq.Hz,
                                t_start=signal1.t_stop + 3 * signal1.sampling_period)
 
         with self.assertRaises(ValueError):
-            result = signal1.patch(signal2, overwrite=False, padding=1)
+            result = signal1.concatenate(signal2, overwrite=False, padding=1)
         with self.assertRaises(ValueError):
-            result = signal1.patch(signal2, overwrite=False, padding=[1])
+            result = signal1.concatenate(signal2, overwrite=False, padding=[1])
         with self.assertRaises(ValueError):
-            result = signal1.patch(signal2, overwrite=False, padding='a')
+            result = signal1.concatenate(signal2, overwrite=False, padding='a')
         with self.assertRaises(ValueError):
-            result = signal1.patch(signal2, overwrite=False, padding=np.array([1,2,3]))
+            result = signal1.concatenate(signal2, overwrite=False, padding=np.array([1, 2, 3]))
 
-    def test_patch_array_annotations(self):
+    def test_concatenate_array_annotations(self):
         array_anno1 = {'first': ['a','b']}
         array_anno2 = {'first': ['a','b'],
                        'second': ['c','d']}
@@ -1682,13 +1682,13 @@ class TestAnalogSignalCombination(unittest.TestCase):
                                t_start=signal1.t_stop + signal1.sampling_period,
                                array_annotations=array_anno2)
 
-        result = signal1.patch(signal2)
+        result = signal1.concatenate(signal2)
         assert_array_equal(array_anno1.keys(), result.array_annotations.keys())
 
         for k in array_anno1.keys():
             assert_array_equal(np.asarray(array_anno1[k]), result.array_annotations[k])
 
-    def test_patch_complex(self):
+    def test_concatenate_complex(self):
         signal1 = self.signal1
         assert_neo_object_is_compliant(self.signal1)
 
@@ -1697,13 +1697,13 @@ class TestAnalogSignalCombination(unittest.TestCase):
                                array_annotations=self.arr_ann1,
                                t_start=signal1.t_stop + signal1.sampling_period)
 
-        patched12 = self.signal1.patch(signal2)
+        concatenated12 = self.signal1.concatenate(signal2)
 
         for attr in signal1._necessary_attrs:
-            self.assertEqual(getattr(signal1, attr[0], None), getattr(patched12, attr[0], None))
+            self.assertEqual(getattr(signal1, attr[0], None), getattr(concatenated12, attr[0], None))
 
         assert_array_equal(np.vstack((signal1.magnitude, signal2.magnitude)),
-                           patched12.magnitude)
+                           concatenated12.magnitude)
 
 class TestAnalogSignalFunctions(unittest.TestCase):
     def test__pickle_1d(self):

--- a/neo/test/coretest/test_base.py
+++ b/neo/test/coretest/test_base.py
@@ -20,7 +20,8 @@ else:
     HAVE_IPYTHON = True
 
 from neo.core.baseneo import (BaseNeo, _check_annotations,
-                              merge_annotations, merge_annotation)
+                              merge_annotations, merge_annotation,
+                              intersect_annotations)
 from neo.test.tools import assert_arrays_equal
 
 
@@ -1264,6 +1265,51 @@ class Test_pprint(unittest.TestCase):
         res = pretty(obj)
         targ = "BaseNeo name: '{}' description: '{}'".format(name, description)
         self.assertEqual(res, targ)
+
+
+class Test_intersect_annotations(unittest.TestCase):
+    '''
+    TestCase for intersect_annotations
+    '''
+
+    def setUp(self):
+        self.dict1 = {1:'1', 2:'2'}
+        self.dict2 = {1:'1'}
+        self.dict3 = {'list1': [1,2,3]}
+        self.dict4 = {'list1': [1,2,3], 'list2': [1,2,3]}
+        self.dict5 = {'list1': [1,2]}
+        self.dict6 = {'array1': np.array([1,2])}
+        self.dict7 = {'array1': np.array([1,2]), 'array2': np.array([1,2]),
+                      'array3': np.array([1,2,3])}
+
+        self.all_simple_dicts = [self.dict1, self.dict2, self.dict3,
+                          self.dict4, self.dict5, ]
+
+    def test_simple(self):
+        result = intersect_annotations(self.dict1, self.dict2)
+        self.assertDictEqual(self.dict2, result)
+
+    def test_intersect_self(self):
+        for d in self.all_simple_dicts:
+            result = intersect_annotations(d, d)
+            self.assertDictEqual(d, result)
+
+    def test_list(self):
+        result = intersect_annotations(self.dict3, self.dict4)
+        self.assertDictEqual(self.dict3, result)
+
+    def test_list_values(self):
+        result = intersect_annotations(self.dict4, self.dict5)
+        self.assertDictEqual({}, result)
+
+    def test_keys(self):
+        result = intersect_annotations(self.dict1, self.dict4)
+        self.assertDictEqual({}, result)
+
+    def test_arrays(self):
+        result = intersect_annotations(self.dict6, self.dict7)
+        self.assertEqual(self.dict6.keys(), result.keys())
+        np.testing.assert_array_equal([1,2], result['array1'])
 
 
 if __name__ == "__main__":

--- a/neo/test/coretest/test_base.py
+++ b/neo/test/coretest/test_base.py
@@ -1273,17 +1273,17 @@ class Test_intersect_annotations(unittest.TestCase):
     '''
 
     def setUp(self):
-        self.dict1 = {1:'1', 2:'2'}
-        self.dict2 = {1:'1'}
-        self.dict3 = {'list1': [1,2,3]}
-        self.dict4 = {'list1': [1,2,3], 'list2': [1,2,3]}
-        self.dict5 = {'list1': [1,2]}
-        self.dict6 = {'array1': np.array([1,2])}
-        self.dict7 = {'array1': np.array([1,2]), 'array2': np.array([1,2]),
-                      'array3': np.array([1,2,3])}
+        self.dict1 = {1: '1', 2: '2'}
+        self.dict2 = {1: '1'}
+        self.dict3 = {'list1': [1, 2, 3]}
+        self.dict4 = {'list1': [1, 2, 3], 'list2': [1, 2, 3]}
+        self.dict5 = {'list1': [1, 2]}
+        self.dict6 = {'array1': np.array([1, 2])}
+        self.dict7 = {'array1': np.array([1, 2]), 'array2': np.array([1, 2]),
+                      'array3': np.array([1, 2, 3])}
 
         self.all_simple_dicts = [self.dict1, self.dict2, self.dict3,
-                          self.dict4, self.dict5, ]
+                                 self.dict4, self.dict5, ]
 
     def test_simple(self):
         result = intersect_annotations(self.dict1, self.dict2)
@@ -1309,7 +1309,7 @@ class Test_intersect_annotations(unittest.TestCase):
     def test_arrays(self):
         result = intersect_annotations(self.dict6, self.dict7)
         self.assertEqual(self.dict6.keys(), result.keys())
-        np.testing.assert_array_equal([1,2], result['array1'])
+        np.testing.assert_array_equal([1, 2], result['array1'])
 
 
 if __name__ == "__main__":

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -240,12 +240,12 @@ class TestIrregularlySampledSignalProperties(unittest.TestCase):
             # see https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst#many
             # -changes-to-array-printing-disableable-with-the-new-legacy-printing-mode
             targ = (
-                '<IrregularlySampledSignal(array([[2.],\n       [4.],\n       [6.]]) * V '
-                '' + 'at times [1.1 1.5 1.7] s)>')
+                    '<IrregularlySampledSignal(array([[2.],\n       [4.],\n       [6.]]) * V '
+                    '' + 'at times [1.1 1.5 1.7] s)>')
         else:
             targ = (
-                '<IrregularlySampledSignal(array([[ 2.],\n       [ 4.],\n       [ 6.]]) '
-                '* V ' + 'at times [ 1.1  1.5  1.7] s)>')
+                    '<IrregularlySampledSignal(array([[ 2.],\n       [ 4.],\n       [ 6.]]) '
+                    '* V ' + 'at times [ 1.1  1.5  1.7] s)>')
         res = repr(sig)
         self.assertEqual(targ, res)
 
@@ -461,7 +461,7 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         length = self.signal1.shape[-1]
         params1 = {'test0': ['y{}'.format(i) for i in range(length)],
                    'test1': ['deeptest' for i in range(length)],
-                   'test2': [(-1)**i > 0 for i in range(length)]}
+                   'test2': [(-1) ** i > 0 for i in range(length)]}
         self.signal1.array_annotate(**params1)
         result = self.signal1.time_slice(None, None)
 
@@ -479,7 +479,7 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
                              == result.array_annotations['test2']))
 
         # Change annotations of result
-        params3 = {'test0': ['z{}'.format(i) for i in range(1, result.shape[-1]+1)]}
+        params3 = {'test0': ['z{}'.format(i) for i in range(1, result.shape[-1] + 1)]}
         result.array_annotate(**params3)
         result.array_annotations['test1'][0] = 'shallow2'
         self.assertFalse(all(self.signal1.array_annotations['test0']
@@ -493,12 +493,12 @@ class TestIrregularlySampledSignalArrayMethods(unittest.TestCase):
         result = self.signal1.time_slice(None, None)
 
         # Change values of original array
-        self.signal1[2] = 7.3*self.signal1.units
+        self.signal1[2] = 7.3 * self.signal1.units
 
         self.assertFalse(all(self.signal1 == result))
 
         # Change values of sliced array
-        result[3] = 9.5*result.units
+        result[3] = 9.5 * result.units
 
         self.assertFalse(all(self.signal1 == result))
 
@@ -945,50 +945,49 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
 
         self.assertRaises(MergeError, signal1.merge, signal3)
 
-
     def test_concatenate_simple(self):
-        signal1 = IrregularlySampledSignal(signal=[0,1,2,3]*pq.s, times=[1,10,11,20]*pq.s)
-        signal2 = IrregularlySampledSignal(signal=[4,5,6]*pq.s, times=[15,16,21]*pq.s)
+        signal1 = IrregularlySampledSignal(signal=[0, 1, 2, 3] * pq.s, times=[1, 10, 11, 20] * pq.s)
+        signal2 = IrregularlySampledSignal(signal=[4, 5, 6] * pq.s, times=[15, 16, 21] * pq.s)
 
         result = signal1.concatenate(signal2)
-        assert_array_equal(np.array([0,1,2,4,5,3,6]).reshape((-1, 1)), result.magnitude)
-        assert_array_equal(np.array([1,10,11,15,16,20,21]), result.times)
+        assert_array_equal(np.array([0, 1, 2, 4, 5, 3, 6]).reshape((-1, 1)), result.magnitude)
+        assert_array_equal(np.array([1, 10, 11, 15, 16, 20, 21]), result.times)
         for attr in signal1._necessary_attrs:
             if attr[0] == 'times':
                 continue
             self.assertEqual(getattr(signal1, attr[0], None), getattr(result, attr[0], None))
 
     def test_concatenate_no_overlap(self):
-        signal1 = IrregularlySampledSignal(signal=[0,1,2,3]*pq.s, times=range(4)*pq.s)
-        signal2 = IrregularlySampledSignal(signal=[4,5,6]*pq.s, times=range(4,7)*pq.s)
+        signal1 = IrregularlySampledSignal(signal=[0, 1, 2, 3] * pq.s, times=range(4) * pq.s)
+        signal2 = IrregularlySampledSignal(signal=[4, 5, 6] * pq.s, times=range(4, 7) * pq.s)
 
         result = signal1.concatenate(signal2)
         assert_array_equal(np.arange(7).reshape((-1, 1)), result.magnitude)
         assert_array_equal(np.arange(7), result.times)
 
     def test_concatenate_multi_trace(self):
-        data1 = np.arange(4).reshape(2,2)
-        data2 = np.arange(4,8).reshape(2,2)
+        data1 = np.arange(4).reshape(2, 2)
+        data2 = np.arange(4, 8).reshape(2, 2)
         n1 = len(data1)
         n2 = len(data2)
-        signal1 = IrregularlySampledSignal(signal=data1*pq.s, times=range(n1)*pq.s)
-        signal2 = IrregularlySampledSignal(signal=data2*pq.s, times=range(n1, n1+n2)*pq.s)
+        signal1 = IrregularlySampledSignal(signal=data1 * pq.s, times=range(n1) * pq.s)
+        signal2 = IrregularlySampledSignal(signal=data2 * pq.s, times=range(n1, n1 + n2) * pq.s)
 
         result = signal1.concatenate(signal2)
-        data_expected = np.array([[0,1],[2,3],[4,5],[6,7]])
+        data_expected = np.array([[0, 1], [2, 3], [4, 5], [6, 7]])
         assert_array_equal(data_expected, result.magnitude)
 
     def test_concatenate_array_annotations(self):
-        array_anno1 = {'first': ['a','b']}
-        array_anno2 = {'first': ['a','b'],
-                       'second': ['c','d']}
-        data1 = np.arange(4).reshape(2,2)
-        data2 = np.arange(4,8).reshape(2,2)
+        array_anno1 = {'first': ['a', 'b']}
+        array_anno2 = {'first': ['a', 'b'],
+                       'second': ['c', 'd']}
+        data1 = np.arange(4).reshape(2, 2)
+        data2 = np.arange(4, 8).reshape(2, 2)
         n1 = len(data1)
         n2 = len(data2)
-        signal1 = IrregularlySampledSignal(signal=data1*pq.s, times=range(n1)*pq.s,
+        signal1 = IrregularlySampledSignal(signal=data1 * pq.s, times=range(n1) * pq.s,
                                            array_annotations=array_anno1)
-        signal2 = IrregularlySampledSignal(signal=data2*pq.s, times=range(n1, n1+n2)*pq.s,
+        signal2 = IrregularlySampledSignal(signal=data2 * pq.s, times=range(n1, n1 + n2) * pq.s,
                                            array_annotations=array_anno2)
 
         result = signal1.concatenate(signal2)

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -239,12 +239,10 @@ class TestIrregularlySampledSignalProperties(unittest.TestCase):
         if np.__version__.split(".")[:2] > ['1', '13']:
             # see https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst#many
             # -changes-to-array-printing-disableable-with-the-new-legacy-printing-mode
-            targ = (
-                    '<IrregularlySampledSignal(array([[2.],\n       [4.],\n       [6.]]) * V '
+            targ = ('<IrregularlySampledSignal(array([[2.],\n       [4.],\n       [6.]]) * V '
                     '' + 'at times [1.1 1.5 1.7] s)>')
         else:
-            targ = (
-                    '<IrregularlySampledSignal(array([[ 2.],\n       [ 4.],\n       [ 6.]]) '
+            targ = ('<IrregularlySampledSignal(array([[ 2.],\n       [ 4.],\n       [ 6.]]) '
                     '* V ' + 'at times [ 1.1  1.5  1.7] s)>')
         res = repr(sig)
         self.assertEqual(targ, res)
@@ -946,7 +944,8 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         self.assertRaises(MergeError, signal1.merge, signal3)
 
     def test_concatenate_simple(self):
-        signal1 = IrregularlySampledSignal(signal=[0, 1, 2, 3] * pq.s, times=[1, 10, 11, 14] * pq.s)
+        signal1 = IrregularlySampledSignal(signal=[0, 1, 2, 3] * pq.s,
+                                           times=[1, 10, 11, 14] * pq.s)
         signal2 = IrregularlySampledSignal(signal=[4, 5, 6] * pq.s, times=[15, 16, 21] * pq.s)
 
         result = signal1.concatenate(signal2)
@@ -977,8 +976,8 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         signal2 = IrregularlySampledSignal(signal=[4, 5, 6] * pq.s, times=range(2, 5) * pq.s)
 
         result = signal1.concatenate(signal2, allow_overlap=True)
-        assert_array_equal(np.array([0,1,2,4,3,5,6]).reshape((-1, 1)), result.magnitude)
-        assert_array_equal(np.array([0,1,2,2,3,3,4]), result.times)
+        assert_array_equal(np.array([0, 1, 2, 4, 3, 5, 6]).reshape((-1, 1)), result.magnitude)
+        assert_array_equal(np.array([0, 1, 2, 2, 3, 3, 4]), result.times)
 
     def test_concatenate_multi_trace(self):
         data1 = np.arange(4).reshape(2, 2)

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -946,6 +946,58 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         self.assertRaises(MergeError, signal1.merge, signal3)
 
 
+    def test_patch_simple(self):
+        signal1 = IrregularlySampledSignal(signal=[0,1,2,3]*pq.s, times=[1,10,11,20]*pq.s)
+        signal2 = IrregularlySampledSignal(signal=[4,5,6]*pq.s, times=[15,16,21]*pq.s)
+
+        result = signal1.patch(signal2)
+        assert_array_equal(np.array([0,1,2,4,5,3,6]).reshape((-1, 1)), result.magnitude)
+        assert_array_equal(np.array([1,10,11,15,16,20,21]), result.times)
+        for attr in signal1._necessary_attrs:
+            if attr[0] == 'times':
+                continue
+            self.assertEqual(getattr(signal1, attr[0], None), getattr(result, attr[0], None))
+
+    def test_patch_no_overlap(self):
+        signal1 = IrregularlySampledSignal(signal=[0,1,2,3]*pq.s, times=range(4)*pq.s)
+        signal2 = IrregularlySampledSignal(signal=[4,5,6]*pq.s, times=range(4,7)*pq.s)
+
+        result = signal1.patch(signal2)
+        assert_array_equal(np.arange(7).reshape((-1, 1)), result.magnitude)
+        assert_array_equal(np.arange(7), result.times)
+
+    def test_patch_multi_trace(self):
+        data1 = np.arange(4).reshape(2,2)
+        data2 = np.arange(4,8).reshape(2,2)
+        n1 = len(data1)
+        n2 = len(data2)
+        signal1 = IrregularlySampledSignal(signal=data1*pq.s, times=range(n1)*pq.s)
+        signal2 = IrregularlySampledSignal(signal=data2*pq.s, times=range(n1, n1+n2)*pq.s)
+
+        result = signal1.patch(signal2)
+        data_expected = np.array([[0,1],[2,3],[4,5],[6,7]])
+        assert_array_equal(data_expected, result.magnitude)
+
+    def test_patch_array_annotations(self):
+        array_anno1 = {'first': ['a','b']}
+        array_anno2 = {'first': ['a','b'],
+                       'second': ['c','d']}
+        data1 = np.arange(4).reshape(2,2)
+        data2 = np.arange(4,8).reshape(2,2)
+        n1 = len(data1)
+        n2 = len(data2)
+        signal1 = IrregularlySampledSignal(signal=data1*pq.s, times=range(n1)*pq.s,
+                                           array_annotations=array_anno1)
+        signal2 = IrregularlySampledSignal(signal=data2*pq.s, times=range(n1, n1+n2)*pq.s,
+                                           array_annotations=array_anno2)
+
+        result = signal1.patch(signal2)
+        assert_array_equal(array_anno1.keys(), result.array_annotations.keys())
+
+        for k in array_anno1.keys():
+            assert_array_equal(np.asarray(array_anno1[k]), result.array_annotations[k])
+
+
 class TestAnalogSignalFunctions(unittest.TestCase):
     def test__pickle(self):
         signal1 = IrregularlySampledSignal(np.arange(10.0) / 100 * pq.s, np.arange(10.0),

--- a/neo/test/coretest/test_irregularysampledsignal.py
+++ b/neo/test/coretest/test_irregularysampledsignal.py
@@ -946,11 +946,11 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         self.assertRaises(MergeError, signal1.merge, signal3)
 
 
-    def test_patch_simple(self):
+    def test_concatenate_simple(self):
         signal1 = IrregularlySampledSignal(signal=[0,1,2,3]*pq.s, times=[1,10,11,20]*pq.s)
         signal2 = IrregularlySampledSignal(signal=[4,5,6]*pq.s, times=[15,16,21]*pq.s)
 
-        result = signal1.patch(signal2)
+        result = signal1.concatenate(signal2)
         assert_array_equal(np.array([0,1,2,4,5,3,6]).reshape((-1, 1)), result.magnitude)
         assert_array_equal(np.array([1,10,11,15,16,20,21]), result.times)
         for attr in signal1._necessary_attrs:
@@ -958,15 +958,15 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
                 continue
             self.assertEqual(getattr(signal1, attr[0], None), getattr(result, attr[0], None))
 
-    def test_patch_no_overlap(self):
+    def test_concatenate_no_overlap(self):
         signal1 = IrregularlySampledSignal(signal=[0,1,2,3]*pq.s, times=range(4)*pq.s)
         signal2 = IrregularlySampledSignal(signal=[4,5,6]*pq.s, times=range(4,7)*pq.s)
 
-        result = signal1.patch(signal2)
+        result = signal1.concatenate(signal2)
         assert_array_equal(np.arange(7).reshape((-1, 1)), result.magnitude)
         assert_array_equal(np.arange(7), result.times)
 
-    def test_patch_multi_trace(self):
+    def test_concatenate_multi_trace(self):
         data1 = np.arange(4).reshape(2,2)
         data2 = np.arange(4,8).reshape(2,2)
         n1 = len(data1)
@@ -974,11 +974,11 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         signal1 = IrregularlySampledSignal(signal=data1*pq.s, times=range(n1)*pq.s)
         signal2 = IrregularlySampledSignal(signal=data2*pq.s, times=range(n1, n1+n2)*pq.s)
 
-        result = signal1.patch(signal2)
+        result = signal1.concatenate(signal2)
         data_expected = np.array([[0,1],[2,3],[4,5],[6,7]])
         assert_array_equal(data_expected, result.magnitude)
 
-    def test_patch_array_annotations(self):
+    def test_concatenate_array_annotations(self):
         array_anno1 = {'first': ['a','b']}
         array_anno2 = {'first': ['a','b'],
                        'second': ['c','d']}
@@ -991,7 +991,7 @@ class TestIrregularlySampledSignalCombination(unittest.TestCase):
         signal2 = IrregularlySampledSignal(signal=data2*pq.s, times=range(n1, n1+n2)*pq.s,
                                            array_annotations=array_anno2)
 
-        result = signal1.patch(signal2)
+        result = signal1.concatenate(signal2)
         assert_array_equal(array_anno1.keys(), result.array_annotations.keys())
 
         for k in array_anno1.keys():


### PR DESCRIPTION
This PR adds patch methods for AnalogSignals and IrregularlySampledSignals. Patching allows to combine signals along the time axis, so potentially across different Segments. The behaviour for IrregularlySampledSignal and AnalogSignals differs slightly, as for AnalogSignals overlapping sampling points are not possible in contrast to IrregularlySampledSignals, where all samples can just be combined irrespective of temporal overlaps. For AnalogSignals, the prioritized sampled can be specified using the `overwrite` keyword.

This feature can be for AnalogSignals extended to also handle padding during patching, therefore providing a solution to #820.