### PR TITLE
cut_block_by_epochs give a new Block now.

### DIFF
--- a/neo/test/test_utils.py
+++ b/neo/test/test_utils.py
@@ -651,5 +651,6 @@ class TestUtilsWithProxyObjects(BaseProxyTest):
                 assert_same_attributes(block3.segments[epoch_idx].epochs[0],
                                        sliced_epoch)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/neo/test/test_utils.py
+++ b/neo/test/test_utils.py
@@ -361,6 +361,7 @@ class TestUtilsWithoutProxyObjects(unittest.TestCase):
                                             [[16., 17.], [16.1, 17.1]]]) * pq.mV,
                         array_annotations={'spikenum': np.arange(1, 9)})
 
+        # test without resetting the time
         seg = Segment()
         seg2 = Segment(name='NoCut')
         seg.epochs = [epoch, epoch2]
@@ -369,12 +370,11 @@ class TestUtilsWithoutProxyObjects(unittest.TestCase):
         seg.irregularlysampledsignals = [irrsig]
         seg.spiketrains = [st]
 
-        block = Block()
-        block.segments = [seg, seg2]
-        block.create_many_to_one_relationship()
+        original_block = Block()
+        original_block.segments = [seg, seg2]
+        original_block.create_many_to_one_relationship()
 
-        # test without resetting the time
-        cut_block_by_epochs(block, properties={'pick': 'me'})
+        block = cut_block_by_epochs(original_block, properties={'pick': 'me'})
 
         assert_neo_object_is_compliant(block)
         self.assertEqual(len(block.segments), 3)
@@ -413,6 +413,7 @@ class TestUtilsWithoutProxyObjects(unittest.TestCase):
                                epoch2.time_slice(t_start=epoch.times[0],
                                                 t_stop=epoch.times[0] + epoch.durations[0]))
 
+        # test with resetting the time
         seg = Segment()
         seg2 = Segment(name='NoCut')
         seg.epochs = [epoch, epoch2]
@@ -421,12 +422,11 @@ class TestUtilsWithoutProxyObjects(unittest.TestCase):
         seg.irregularlysampledsignals = [irrsig]
         seg.spiketrains = [st]
 
-        block = Block()
-        block.segments = [seg, seg2]
-        block.create_many_to_one_relationship()
+        original_block = Block()
+        original_block.segments = [seg, seg2]
+        original_block.create_many_to_one_relationship()
 
-        # test with resetting the time
-        cut_block_by_epochs(block, properties={'pick': 'me'}, reset_time=True)
+        block = cut_block_by_epochs(original_block, properties={'pick': 'me'}, reset_time=True)
 
         assert_neo_object_is_compliant(block)
         self.assertEqual(len(block.segments), 3)
@@ -583,11 +583,11 @@ class TestUtilsWithProxyObjects(BaseProxyTest):
         loaded_st = proxy_st.load()
         loaded_anasig = proxy_anasig.load()
 
-        block = Block()
-        block.segments = [seg]
-        block.create_many_to_one_relationship()
+        original_block = Block()
+        original_block.segments = [seg]
+        original_block.create_many_to_one_relationship()
 
-        cut_block_by_epochs(block, properties={'pick': 'me'})
+        block = cut_block_by_epochs(original_block, properties={'pick': 'me'})
 
         assert_neo_object_is_compliant(block)
         self.assertEqual(len(block.segments), proxy_epoch.shape[0])
@@ -637,7 +637,7 @@ class TestUtilsWithProxyObjects(BaseProxyTest):
         # test correct loading and slicing of EpochProxy objects
         # (not tested above since we used the EpochProxy to cut the block)
 
-        cut_block_by_epochs(block2, properties={'pick': 'me instead'})
+        block3 = cut_block_by_epochs(block2, properties={'pick': 'me instead'})
 
         for epoch_idx in range(len(epoch)):
             sliced_epoch = loaded_epoch.time_slice(t_start=epoch.times[epoch_idx],
@@ -646,7 +646,10 @@ class TestUtilsWithProxyObjects(BaseProxyTest):
             has_epoch = len(sliced_epoch) > 0
 
             if has_epoch:
-                self.assertTrue(isinstance(block2.segments[epoch_idx].epochs[0],
+                self.assertTrue(isinstance(block3.segments[epoch_idx].epochs[0],
                                            Epoch))
-                assert_same_attributes(block2.segments[epoch_idx].epochs[0],
+                assert_same_attributes(block3.segments[epoch_idx].epochs[0],
                                        sliced_epoch)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/neo/utils.py
+++ b/neo/utils.py
@@ -473,8 +473,9 @@ def cut_block_by_epochs(block, properties=None, reset_time=False):
         raise TypeError(
             'block needs to be a Block, not %s' % type(block))
 
-    old_segments = copy.copy(block.segments)
-    for seg in old_segments:
+    new_block = neo.Block()
+
+    for seg in block.segments:
         epochs = _get_from_list(seg.epochs, prop=properties)
         if len(epochs) > 1:
             warnings.warn(
@@ -490,10 +491,11 @@ def cut_block_by_epochs(block, properties=None, reset_time=False):
         for epoch in epochs:
             new_segments = cut_segment_by_epoch(
                 seg, epoch=epoch, reset_time=reset_time)
-            block.segments += new_segments
+            new_block.segments.extend(new_segments)
 
-        block.segments.remove(seg)
-    block.create_many_to_one_relationship(force=True)
+    new_block.create_many_to_one_relationship(force=True)
+
+    return new_block
 
 
 def cut_segment_by_epoch(seg, epoch, reset_time=False):
@@ -530,10 +532,6 @@ def cut_segment_by_epoch(seg, epoch, reset_time=False):
     if not isinstance(seg, neo.Segment):
         raise TypeError(
             'Seg needs to be of type Segment, not %s' % type(seg))
-
-    if type(seg.parents[0]) != neo.Block:
-        raise ValueError(
-            'Segment has no block as parent. Can not cut segment.')
 
     if not isinstance(epoch, neo.Epoch):
         raise TypeError(


### PR DESCRIPTION
Now cut_block_by_epochs give a new block and don't do a inplace replacement of segments.
Similarly to cut_segment_by_epoch.

See #755 

@mdenker @JuliaSprenger : could you check this ?
I think you are originals authors no ?


