### PR TITLE
Fixes to make tests pass with Pegasus event files only directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ Thumbs.db
 ###################################
 neo/test/io/neurosharemergeio.py
 files_for_testing_neo
+/venv

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ Thumbs.db
 neo/test/io/neurosharemergeio.py
 files_for_testing_neo
 /venv
+/neo/test/resources

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -244,7 +244,7 @@ class NeuralynxRawIO(BaseRawIO):
                     ts0 = ts[0]
                     ts1 = ts[-1]
                 ts0 = min(ts0, ts[0])
-                ts1 = max(ts0, ts[-1])  # :FIXME: possible error, should be ts1
+                ts1 = max(ts1, ts[-1])
 
         # decide on segment and global start and stop times based on files available
         if self._timestamp_limits is None:
@@ -322,7 +322,7 @@ class NeuralynxRawIO(BaseRawIO):
     def _get_signal_t_start(self, block_index, seg_index, channel_indexes):
         return self._sigs_t_start[seg_index] - self.global_t_start
 
-    def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop, channel_indices):
+    def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop, channel_indexes):
         """
         Retrieve chunk of analog signal, a chunk being a set of contiguous samples.
 
@@ -336,7 +336,7 @@ class NeuralynxRawIO(BaseRawIO):
             sample index of first sample within segment to retrieve
         i_stop:
             sample index of last sample within segment to retrieve
-        channel_indices:
+        channel_indexes:
             list of channel indices to return data for
 
         RETURNS
@@ -353,11 +353,11 @@ class NeuralynxRawIO(BaseRawIO):
         sl0 = i_start % 512
         sl1 = sl0 + (i_stop - i_start)
 
-        if channel_indices is None:
-            channel_indices = slice(None)
+        if channel_indexes is None:
+            channel_indexes = slice(None)
 
-        channel_ids = self.header['signal_channels'][channel_indices]['id']
-        channel_names = self.header['signal_channels'][channel_indices]['name']
+        channel_ids = self.header['signal_channels'][channel_indexes]['id']
+        channel_names = self.header['signal_channels'][channel_indexes]['name']
 
         # create buffer for samples
         sigs_chunk = np.zeros((i_stop - i_start, len(channel_ids)), dtype='int16')

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -645,6 +645,9 @@ class NlxHeader(OrderedDict):
             txt_header = f.read(NlxHeader.HEADER_SIZE)
         txt_header = txt_header.strip(b'\x00').decode('latin-1')
 
+        # must start with 8 # characters
+        assert txt_header.startswith("########"),'Neuralynx files must start with 8 # characters.'
+
         # find keys
         info = NlxHeader()
         for k1, k2, type_ in NlxHeader.txt_header_keys:

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -10,8 +10,8 @@ NTT contains spikes and waveforms for tetrodes
 
 
 NCS can contains gaps that can be detected in inregularity
-in timestamps of data blocks. Each gap lead to one new segment.
-NCS files need to be read entirely to detect those gaps.... too bad....
+in timestamps of data blocks. Each gap leads to one new segment.
+Some NCS files may need to be read entirely to detect those gaps which can be slow.
 
 
 Author: Julia Sprenger, Carlos Canova, Samuel Garcia
@@ -34,17 +34,17 @@ BLOCK_SIZE = 512  # nb sample per signal block
 
 class NeuralynxRawIO(BaseRawIO):
     """"
-    Class for reading dataset recorded by Neuralynx.
+    Class for reading datasets recorded by Neuralynx.
 
     Examples:
         >>> reader = NeuralynxRawIO(dirname='Cheetah_v5.5.1/original_data')
         >>> reader.parse_header()
 
-            Inspect all file in the directory.
+            Inspect all files in the directory.
 
         >>> print(reader)
 
-            Display all informations about signal channels, units, segment size....
+            Display all information about signal channels, units, segment size....
     """
     extensions = ['nse', 'ncs', 'nev', 'ntt']
     rawmode = 'one-dir'
@@ -75,8 +75,8 @@ class NeuralynxRawIO(BaseRawIO):
         self._empty_nev = []
         self._empty_nse_ntt = []
 
-        # explore the directory looking for ncs, nev, nse and ntt
-        # And construct channels headers
+        # Explore the directory looking for ncs, nev, nse and ntt
+        # and construct channels headers.
         signal_annotations = []
         unit_annotations = []
         event_annotations = []
@@ -104,7 +104,7 @@ class NeuralynxRawIO(BaseRawIO):
 
                 chan_uid = (chan_name, chan_id)
                 if ext == 'ncs':
-                    # a signal channels
+                    # a signal channel
                     units = 'uV'
                     gain = info['bit_to_microVolt'][idx]
                     if info.get('input_inverted', False):
@@ -207,7 +207,7 @@ class NeuralynxRawIO(BaseRawIO):
             self._sigs_sampling_rate = sampling_rate[0]
 
         # read ncs files for gaps detection and nb_segment computation
-        self.read_ncs_files(self.ncs_filenames)
+        ncsBlocks = self.read_ncs_files(self.ncs_filenames)
 
         # timestamp limit in nev, nse
         # so need to scan all spike and event to
@@ -418,7 +418,13 @@ class NeuralynxRawIO(BaseRawIO):
 
     def read_ncs_files(self, ncs_filenames):
         """
-        Given a list of ncs files construct:
+<<<<<<< Updated upstream
+        Given a list of ncs files contrsuct:
+=======
+        Given a list of ncs files, return a dictionary of NcsBlocks indexed by channel uid.
+
+        :
+>>>>>>> Stashed changes
             * self._sigs_memmap = [ {} for seg_index in range(self._nb_segment) ]
             * self._sigs_t_start = []
             * self._sigs_t_stop = []
@@ -438,9 +444,9 @@ class NeuralynxRawIO(BaseRawIO):
         """
         # :TODO: Needs to account for gaps being different in different blocks of channels.
         if len(ncs_filenames) == 0:
-            self._nb_segment = 1
-            self._timestamp_limits = None
-            return
+            return NcsBlocks()
+
+
 
         good_delta = int(BLOCK_SIZE * 1e6 / self._sigs_sampling_rate)
         chan_uid0 = list(ncs_filenames.keys())[0]

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -108,7 +108,7 @@ class NeuralynxRawIO(BaseRawIO):
                     # a signal channels
                     units = 'uV'
                     gain = info['bit_to_microVolt'][idx]
-                    if info['input_inverted']:
+                    if info.get('input_inverted', False):
                         gain *= -1
                     offset = 0.
                     group_id = 0
@@ -166,7 +166,7 @@ class NeuralynxRawIO(BaseRawIO):
                         unit_id = '{}'.format(unit_id)
                         wf_units = 'uV'
                         wf_gain = info['bit_to_microVolt'][idx]
-                        if info['input_inverted']:
+                        if info.get('input_inverted',False):
                             wf_gain *= -1
                         wf_offset = 0.
                         wf_left_sweep = -1  # NOT KNOWN

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -11,7 +11,7 @@ NTT contains spikes and waveforms for tetrodes
 
 NCS can contains gaps that can be detected in inregularity
 in timestamps of data blocks. Each gap lead to one new segment.
-NCS files need to be read entirely to detect that gaps.... too bad....
+NCS files need to be read entirely to detect those gaps.... too bad....
 
 
 Author: Julia Sprenger, Carlos Canova, Samuel Garcia
@@ -419,7 +419,7 @@ class NeuralynxRawIO(BaseRawIO):
 
     def read_ncs_files(self, ncs_filenames):
         """
-        Given a list of ncs files contrsuct:
+        Given a list of ncs files construct:
             * self._sigs_memmap = [ {} for seg_index in range(self._nb_segment) ]
             * self._sigs_t_start = []
             * self._sigs_t_stop = []
@@ -437,6 +437,7 @@ class NeuralynxRawIO(BaseRawIO):
         gap_indexes can be given (when cached) to avoid full read.
 
         """
+        # :TODO: Needs to account for gaps being different in different blocks of channels.
         if len(ncs_filenames) == 0:
             self._nb_segment = 1
             self._timestamp_limits = None
@@ -462,6 +463,9 @@ class NeuralynxRawIO(BaseRawIO):
             timestamps0 = data0['timestamp']
             deltas0 = np.diff(timestamps0)
 
+            # :TODO: This algorithm needs to account for older style files which had a rounded
+            # :TODO: off sampling rate in the header.
+            #
             # It should be that:
             # gap_indexes, = np.nonzero(deltas0!=good_delta)
             # but for a file I have found many deltas0==15999, 16000, 16001 (for sampling at 32000)

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -630,7 +630,7 @@ def read_txt_header(filename):
     # find keys
     info = OrderedDict()
     for k1, k2, type_ in txt_header_keys:
-        pattern = r'-(?P<name>' + k1 + r') (?P<value>[\S ]*)'
+        pattern = r'-(?P<name>' + k1 + r')\s+(?P<value>[\S ]*)'
         matches = re.findall(pattern, txt_header)
         for match in matches:
             if k2 == '':

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -87,6 +87,7 @@ class NeuralynxRawIO(BaseRawIO):
 
             _, ext = os.path.splitext(filename)
             ext = ext[1:]  # remove dot
+            ext = ext.lower() # make lower case for comparisons
             if ext not in self.extensions:
                 continue
 

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -599,7 +599,7 @@ txt_header_keys = [
 header_pattern_dicts = {
     # Cheetah before version 5 and BML
     'bv5': dict(
-        datetime1_regex=r'## Time Opened \(m/d/y\): (?P<date>\S+)  At Time: (?P<time>\S+)',
+        datetime1_regex=r'## Time Opened: \(m/d/y\): (?P<date>\S+)  At Time: (?P<time>\S+)',
         filename_regex = r'## File Name: (?P<filename>\S+)',
         datetimeformat = '%m/%d/%Y %H:%M:%S.%f'),
     # Cheetah version 5 before and including v 5.6.4

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -97,7 +97,7 @@ class NeuralynxRawIO(BaseRawIO):
 
             _, ext = os.path.splitext(filename)
             ext = ext[1:]  # remove dot
-            ext = ext.lower() # make lower case for comparisons
+            ext = ext.lower()  # make lower case for comparisons
             if ext not in self.extensions:
                 continue
 
@@ -165,7 +165,8 @@ class NeuralynxRawIO(BaseRawIO):
                         self._empty_nse_ntt.append(filename)
                         data = np.zeros((0,), dtype=dtype)
                     else:
-                        data = np.memmap(filename, dtype=dtype, mode='r', offset=NlxHeader.HEADER_SIZE)
+                        data = np.memmap(filename, dtype=dtype, mode='r',
+                                         offset=NlxHeader.HEADER_SIZE)
 
                     self._spike_memmap[chan_uid] = data
 
@@ -178,7 +179,7 @@ class NeuralynxRawIO(BaseRawIO):
                         unit_id = '{}'.format(unit_id)
                         wf_units = 'uV'
                         wf_gain = info['bit_to_microVolt'][idx]
-                        if info.get('input_inverted',False):
+                        if info.get('input_inverted', False):
                             wf_gain *= -1
                         wf_offset = 0.
                         wf_left_sweep = -1  # NOT KNOWN
@@ -198,7 +199,8 @@ class NeuralynxRawIO(BaseRawIO):
                         data = np.zeros((0,), dtype=nev_dtype)
                         internal_ids = []
                     else:
-                        data = np.memmap(filename, dtype=nev_dtype, mode='r', offset=NlxHeader.HEADER_SIZE)
+                        data = np.memmap(filename, dtype=nev_dtype, mode='r',
+                                         offset=NlxHeader.HEADER_SIZE)
                         internal_ids = np.unique(data[['event_id', 'ttl_input']]).tolist()
                     for internal_event_id in internal_ids:
                         if internal_event_id not in self.internal_event_ids:
@@ -242,7 +244,7 @@ class NeuralynxRawIO(BaseRawIO):
                     ts0 = ts[0]
                     ts1 = ts[-1]
                 ts0 = min(ts0, ts[0])
-                ts1 = max(ts0, ts[-1]) # :FIXME: possible error, should be ts1
+                ts1 = max(ts0, ts[-1])  # :FIXME: possible error, should be ts1
 
         # decide on segment and global start and stop times based on files available
         if self._timestamp_limits is None:
@@ -575,8 +577,8 @@ class NeuralynxRawIO(BaseRawIO):
 
                 if chan_uid == chan_uid0:
                     ts0 = subdata[0]['timestamp']
-                    ts1 = subdata[-1]['timestamp'] \
-                            + np.uint64(BLOCK_SIZE / self._sigs_sampling_rate * 1e6)
+                    ts1 = subdata[-1]['timestamp'] +\
+                        np.uint64(BLOCK_SIZE / self._sigs_sampling_rate * 1e6)
                     self._timestamp_limits.append((ts0, ts1))
                     t_start = ts0 / 1e6
                     self._sigs_t_start.append(t_start)
@@ -584,6 +586,7 @@ class NeuralynxRawIO(BaseRawIO):
                     self._sigs_t_stop.append(t_stop)
                     length = subdata.size * BLOCK_SIZE
                     self._sigs_length.append(length)
+
 
 class NcsBlocks():
     """
@@ -596,6 +599,7 @@ class NcsBlocks():
     endBlocks = []
     sampFreqUsed = 0
     microsPerSampUsed = 0
+
 
 class NlxHeader(OrderedDict):
     """
@@ -670,13 +674,16 @@ class NlxHeader(OrderedDict):
     header_pattern_dicts = {
         # Cheetah before version 5 and BML
         'bv5': dict(
-            datetime1_regex=r'## Time Opened: \(m/d/y\): (?P<date>\S+)  At Time: (?P<time>\S+)',
+            datetime1_regex=r'## Time Opened: \(m/d/y\): (?P<date>\S+)'
+                            r'  At Time: (?P<time>\S+)',
             filename_regex=r'## File Name: (?P<filename>\S+)',
             datetimeformat='%m/%d/%Y %H:%M:%S.%f'),
         # Cheetah version 5 before and including v 5.6.4
         'bv5.6.4': dict(
-            datetime1_regex=r'## Time Opened \(m/d/y\): (?P<date>\S+)  \(h:m:s\.ms\) (?P<time>\S+)',
-            datetime2_regex=r'## Time Closed \(m/d/y\): (?P<date>\S+)  \(h:m:s\.ms\) (?P<time>\S+)',
+            datetime1_regex=r'## Time Opened \(m/d/y\): (?P<date>\S+)'
+                            r'  \(h:m:s\.ms\) (?P<time>\S+)',
+            datetime2_regex=r'## Time Closed \(m/d/y\): (?P<date>\S+)'
+                            r'  \(h:m:s\.ms\) (?P<time>\S+)',
             filename_regex=r'## File Name (?P<filename>\S+)',
             datetimeformat='%m/%d/%Y %H:%M:%S.%f'),
         # Cheetah after v 5.6.4 and default for others such as Pegasus
@@ -697,7 +704,8 @@ class NlxHeader(OrderedDict):
         txt_header = txt_header.strip(b'\x00').decode('latin-1')
 
         # must start with 8 # characters
-        assert txt_header.startswith("########"),'Neuralynx files must start with 8 # characters.'
+        assert txt_header.startswith("########"),\
+            'Neuralynx files must start with 8 # characters.'
 
         # find keys
         info = NlxHeader()
@@ -807,6 +815,7 @@ class NcsHeader():
     Representation of information in Ncs file headers, including exact
     recording type.
     """
+
 
 ncs_dtype = [('timestamp', 'uint64'), ('channel_id', 'uint32'), ('sample_rate', 'uint32'),
              ('nb_valid', 'uint32'), ('samples', 'int16', (BLOCK_SIZE,))]

--- a/neo/test/iotest/test_neuralynxio.py
+++ b/neo/test/iotest/test_neuralynxio.py
@@ -1,5 +1,5 @@
 """
-Tests of neo.io.blackrockio
+Tests of neo.io.neuralynxio.py
 """
 
 import time


### PR DESCRIPTION
This set of changes fixes a bug which prevented the Pegasus .Nev event only files from passing the test suite. 

It also allows filename extensions to be in any letter case. For the InputInverted header parameter to be missing, 
meaning not inverted. Checks for 8 hashes at the start of the header as a check on header contents. Allows
any whitespace between a header key and value. 

Internal changes are addition of a large number of explanatory comments and refactoring of the code to handle
the header into a separate class. Many of these in preparation for handling earlier versions of neuralynx file headers
and more flexible handling of segments withins .Ncs files. 