### PR TITLE
Changes related to the `IO.read()` method

### DIFF
--- a/doc/source/core.rst
+++ b/doc/source/core.rst
@@ -117,13 +117,14 @@ These relationships are bi-directional, i.e. a child object can access its paren
 Here is an example showing these relationships in use::
 
     from neo.io import AxonIO
-    import urllib
+    import urllib.request
     url = "https://web.gin.g-node.org/NeuralEnsemble/ephy_testing_data/raw/master/axon/File_axon_3.abf"
     filename = './test.abf'
-    urllib.urlretrieve(url, filename)
+    urllib.request.urlretrieve(url, filename)
 
     r = AxonIO(filename=filename)
-    bl = r.read() # read the entire file > a Block
+    blocks = r.read() # read the entire file > a list of Blocks
+    bl = blocks[0]
     print(bl)
     print(bl.segments) # child access
     for seg in bl.segments:

--- a/neo/io/asciiimageio.py
+++ b/neo/io/asciiimageio.py
@@ -57,6 +57,9 @@ class AsciiImageIO(BaseIO):
         self.spatial_scale = spatial_scale
 
     def read(self, lazy=False, **kwargs):
+        """
+        Return all data from the file as a list of Blocks
+        """
         if lazy:
             raise ValueError('This IO module does not support lazy loading')
         return [self.read_block(lazy=lazy, **kwargs)]

--- a/neo/io/asciiimageio.py
+++ b/neo/io/asciiimageio.py
@@ -56,14 +56,6 @@ class AsciiImageIO(BaseIO):
         self.sampling_rate = sampling_rate
         self.spatial_scale = spatial_scale
 
-    def read(self, lazy=False, **kwargs):
-        """
-        Return all data from the file as a list of Blocks
-        """
-        if lazy:
-            raise ValueError('This IO module does not support lazy loading')
-        return [self.read_block(lazy=lazy, **kwargs)]
-
     def read_block(self, lazy=False, **kwargs):
 
         file = open(self.filename, 'r')

--- a/neo/io/baseio.py
+++ b/neo/io/baseio.py
@@ -112,6 +112,9 @@ class BaseIO:
 
     ######## General read/write methods #######################
     def read(self, lazy=False, **kargs):
+        """
+        Return all data from the file as a list of Blocks
+        """
         if lazy:
             assert self.support_lazy, 'This IO do not support lazy loading'
         if Block in self.readable_objects:

--- a/neo/io/baseio.py
+++ b/neo/io/baseio.py
@@ -115,8 +115,8 @@ class BaseIO:
         """
         Return all data from the file as a list of Blocks
         """
-        if lazy:
-            assert self.support_lazy, 'This IO do not support lazy loading'
+        if lazy and not self.support_lazy:
+            raise ValueError("This IO module does not support lazy loading")
         if Block in self.readable_objects:
             if (hasattr(self, 'read_all_blocks') and
                     callable(getattr(self, 'read_all_blocks'))):

--- a/neo/io/blkio.py
+++ b/neo/io/blkio.py
@@ -65,7 +65,7 @@ class BlkIO(BaseIO):
         Return all data from the file as a list of Blocks
         """
         if lazy:
-            raise ValueError('This IO module does not support lazy loadign')
+            raise ValueError('This IO module does not support lazy loading')
         return [self.read_block(lazy=lazy, units=self.units, sampling_rate=self.sampling_rate,
                                 spatial_scale=self.spatial_scale, **kwargs)]
 

--- a/neo/io/blkio.py
+++ b/neo/io/blkio.py
@@ -61,6 +61,9 @@ class BlkIO(BaseIO):
         self.spatial_scale = spatial_scale
 
     def read(self, lazy=False, **kwargs):
+        """
+        Return all data from the file as a list of Blocks
+        """
         if lazy:
             raise ValueError('This IO module does not support lazy loadign')
         return [self.read_block(lazy=lazy, units=self.units, sampling_rate=self.sampling_rate,

--- a/neo/io/brainwaredamio.py
+++ b/neo/io/brainwaredamio.py
@@ -115,7 +115,7 @@ class BrainwareDamIO(BaseIO):
         Reads raw data file "fname" generated with BrainWare
         '''
         assert not lazy, 'Do not support lazy'
-        return self.read_block(lazy=lazy)
+        return [self.read_block(lazy=lazy)]
 
     def read_block(self, lazy=False, **kargs):
         '''

--- a/neo/io/brainwaredamio.py
+++ b/neo/io/brainwaredamio.py
@@ -110,13 +110,6 @@ class BrainwareDamIO(BaseIO):
         self._filename = os.path.basename(filename)
         self._fsrc = None
 
-    def read(self, lazy=False, **kargs):
-        '''
-        Reads raw data file "fname" generated with BrainWare
-        '''
-        assert not lazy, 'Do not support lazy'
-        return [self.read_block(lazy=lazy)]
-
     def read_block(self, lazy=False, **kargs):
         '''
         Reads a block from the raw data file "fname" generated

--- a/neo/io/brainwaref32io.py
+++ b/neo/io/brainwaref32io.py
@@ -124,12 +124,6 @@ class BrainwareF32IO(BaseIO):
         self.__seg = None
         self.__spiketimes = None
 
-    def read(self, lazy=False, **kargs):
-        '''
-        Reads simple spike data file "fname" generated with BrainWare
-        '''
-        return [self.read_block(lazy=lazy, )]
-
     def read_block(self, lazy=False, **kargs):
         '''
         Reads a block from the simple spike data file "fname" generated

--- a/neo/io/brainwaref32io.py
+++ b/neo/io/brainwaref32io.py
@@ -128,7 +128,7 @@ class BrainwareF32IO(BaseIO):
         '''
         Reads simple spike data file "fname" generated with BrainWare
         '''
-        return self.read_block(lazy=lazy, )
+        return [self.read_block(lazy=lazy, )]
 
     def read_block(self, lazy=False, **kargs):
         '''

--- a/neo/io/brainwaresrcio.py
+++ b/neo/io/brainwaresrcio.py
@@ -222,7 +222,7 @@ class BrainwareSrcIO(BaseIO):
 
         If you wish to read more than one Block, please use read_all_blocks.
         """
-        return self.read_block(lazy=lazy, **kargs)
+        return [self.read_block(lazy=lazy, **kargs)]
 
     def read_block(self, lazy=False, **kargs):
         """

--- a/neo/io/brainwaresrcio.py
+++ b/neo/io/brainwaresrcio.py
@@ -215,15 +215,6 @@ class BrainwareSrcIO(BaseIO):
         self._lazy = False
         self._default_spiketrain = None
 
-    def read(self, lazy=False, **kargs):
-        """
-        Reads the first Block from the Spike ReCording file "filename"
-        generated with BrainWare.
-
-        If you wish to read more than one Block, please use read_all_blocks.
-        """
-        return [self.read_block(lazy=lazy, **kargs)]
-
     def read_block(self, lazy=False, **kargs):
         """
         Reads the first Block from the Spike ReCording file "filename"

--- a/neo/io/tiffio.py
+++ b/neo/io/tiffio.py
@@ -82,6 +82,9 @@ class TiffIO(BaseIO):
         self.spatial_scale = spatial_scale
 
     def read(self, lazy=False, **kwargs):
+        """
+        Return all data from the file as a list of Blocks
+        """
         if lazy:
             raise ValueError('This IO module does not support lazy loading')
         return [self.read_block(lazy=lazy, **kwargs)]

--- a/neo/io/tiffio.py
+++ b/neo/io/tiffio.py
@@ -81,14 +81,6 @@ class TiffIO(BaseIO):
         self.sampling_rate = sampling_rate
         self.spatial_scale = spatial_scale
 
-    def read(self, lazy=False, **kwargs):
-        """
-        Return all data from the file as a list of Blocks
-        """
-        if lazy:
-            raise ValueError('This IO module does not support lazy loading')
-        return [self.read_block(lazy=lazy, **kwargs)]
-
     def read_block(self, lazy=False, **kwargs):
         # to sort file
         def natural_sort(l):

--- a/neo/test/iotest/test_brainwaredamio.py
+++ b/neo/test/iotest/test_brainwaredamio.py
@@ -119,7 +119,7 @@ class BrainwareDamIOTestCase(BaseTestIO, unittest.TestCase):
             obj_single = obj_reader_single()
 
             try:
-                assert_same_sub_schema(obj_base, obj_single)
+                assert_same_sub_schema(obj_base, [obj_single])
             except BaseException as exc:
                 exc.args += ('from ' + os.path.basename(path),)
                 raise

--- a/neo/test/iotest/test_brainwaref32io.py
+++ b/neo/test/iotest/test_brainwaref32io.py
@@ -129,7 +129,7 @@ class BrainwareF32IOTestCase(BaseTestIO, unittest.TestCase):
             obj_single = obj_reader_single()
 
             try:
-                assert_same_sub_schema(obj_base, obj_single)
+                assert_same_sub_schema(obj_base, [obj_single])
             except BaseException as exc:
                 exc.args += ('from ' + os.path.basename(path),)
                 raise

--- a/neo/test/iotest/test_brainwaresrcio.py
+++ b/neo/test/iotest/test_brainwaresrcio.py
@@ -303,7 +303,7 @@ class BrainwareSrcIOTestCase(BaseTestIO, unittest.TestCase):
                 obj_next.append(obj_reader_next())
 
             try:
-                assert_same_sub_schema(obj_all[0], obj_base)
+                assert_same_sub_schema(obj_all, obj_base)
                 assert_same_sub_schema(obj_all[0], obj_single)
                 assert_same_sub_schema(obj_all, obj_next)
             except BaseException as exc:


### PR DESCRIPTION
- added docstring
- fixed incorrect example in docs
- fixed inconsistency in Brainware IOs - read() now returns a list of Blocks

Fixes #762