### PR TITLE
NIXIO Python 3.6 code cleanup

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -32,9 +32,8 @@ import quantities as pq
 import numpy as np
 
 from .baseio import BaseIO
-from ..core import (Block, Segment, ChannelIndex, AnalogSignal,
-                    IrregularlySampledSignal, Epoch, Event, SpikeTrain,
-                    ImageSequence, Unit)
+from ..core import (Block, Segment, ChannelIndex, AnalogSignal, IrregularlySampledSignal, Epoch,
+                    Event, SpikeTrain, ImageSequence, Unit)
 from ..io.proxyobjects import BaseProxy
 from ..version import version as neover
 
@@ -156,8 +155,7 @@ class NixIO(BaseIO):
     is_readable = True
     is_writable = True
 
-    supported_objects = [Block, Segment, ChannelIndex,
-                         AnalogSignal, IrregularlySampledSignal,
+    supported_objects = [Block, Segment, ChannelIndex, AnalogSignal, IrregularlySampledSignal,
                          Epoch, Event, SpikeTrain, Unit]
     readable_objects = [Block]
     writeable_objects = [Block]
@@ -288,9 +286,7 @@ class NixIO(BaseIO):
     def _nix_to_neo_block(self, nix_block):
         neo_attrs = self._nix_attr_to_neo(nix_block)
         neo_block = Block(**neo_attrs)
-        neo_block.rec_datetime = datetime.fromtimestamp(
-            nix_block.created_at
-        )
+        neo_block.rec_datetime = datetime.fromtimestamp(nix_block.created_at)
 
         # descend into Groups
         for grp in nix_block.groups:
@@ -333,9 +329,7 @@ class NixIO(BaseIO):
     def _nix_to_neo_segment(self, nix_group):
         neo_attrs = self._nix_attr_to_neo(nix_group)
         neo_segment = Segment(**neo_attrs)
-        neo_segment.rec_datetime = datetime.fromtimestamp(
-            nix_group.created_at
-        )
+        neo_segment.rec_datetime = datetime.fromtimestamp(nix_group.created_at)
         self._neo_map[nix_group.name] = neo_segment
 
         # this will probably get all the DAs anyway, but if we change any part
@@ -393,15 +387,13 @@ class NixIO(BaseIO):
         if len(channels):
             chan_names = list(c["name"] for c in channels
                               if "name" in c and c["name"] is not None)
-            chan_ids = list(c["channel_id"] for c in channels
-                            if "channel_id" in c)
+            chan_ids = list(c["channel_id"] for c in channels if "channel_id" in c)
             if chan_names:
                 neo_attrs["channel_names"] = chan_names
             if chan_ids:
                 neo_attrs["channel_ids"] = chan_ids
             if "coordinates" in channels[0]:
-                neo_attrs["coordinates"] = list(c["coordinates"]
-                                                for c in channels)
+                neo_attrs["coordinates"] = list(c["coordinates"] for c in channels)
 
         neo_chx = ChannelIndex(**neo_attrs)
         self._neo_map[nix_source.name] = neo_chx
@@ -451,8 +443,7 @@ class NixIO(BaseIO):
         signaldata = np.array([d[:] for d in nix_da_group]).transpose()
         signaldata = create_quantity(signaldata, unit)
         timedim = self._get_time_dimension(nix_da_group[0])
-        sampling_period = create_quantity(timedim.sampling_interval,
-                                          timedim.unit)
+        sampling_period = create_quantity(timedim.sampling_interval, timedim.unit)
         # t_start should have been added to neo_attrs via the NIX
         # object's metadata. This may not be present since in older
         # versions, we didn't store t_start in the metadata when it
@@ -464,10 +455,8 @@ class NixIO(BaseIO):
         else:
             t_start = create_quantity(timedim.offset, timedim.unit)
 
-        neo_signal = AnalogSignal(
-            signal=signaldata, sampling_period=sampling_period,
-            t_start=t_start, **neo_attrs
-        )
+        neo_signal = AnalogSignal(signal=signaldata, sampling_period=sampling_period,
+                                  t_start=t_start, **neo_attrs)
         self._neo_map[neo_attrs["nix_name"]] = neo_signal
         # all DAs reference the same sources
         srcnames = list(src.name for src in nix_da_group[0].sources)
@@ -535,9 +524,7 @@ class NixIO(BaseIO):
         timedim = self._get_time_dimension(nix_da_group[0])
         times = create_quantity(timedim.ticks, timedim.unit)
 
-        neo_signal = IrregularlySampledSignal(
-            signal=signaldata, times=times, **neo_attrs
-        )
+        neo_signal = IrregularlySampledSignal(signal=signaldata, times=times, **neo_attrs)
         self._neo_map[neo_attrs["nix_name"]] = neo_signal
         # all DAs reference the same sources
         srcnames = list(src.name for src in nix_da_group[0].sources)
@@ -551,8 +538,7 @@ class NixIO(BaseIO):
         neo_attrs = self._nix_attr_to_neo(nix_mtag)
         time_unit = nix_mtag.positions.unit
         times = create_quantity(nix_mtag.positions, time_unit)
-        labels = np.array(nix_mtag.positions.dimensions[0].labels,
-                          dtype="U")
+        labels = np.array(nix_mtag.positions.dimensions[0].labels, dtype="U")
         neo_event = Event(times=times, labels=labels, **neo_attrs)
         self._neo_map[nix_mtag.name] = neo_event
         return neo_event
@@ -561,16 +547,13 @@ class NixIO(BaseIO):
         neo_attrs = self._nix_attr_to_neo(nix_mtag)
         time_unit = nix_mtag.positions.unit
         times = create_quantity(nix_mtag.positions, time_unit)
-        durations = create_quantity(nix_mtag.extents,
-                                    nix_mtag.extents.unit)
+        durations = create_quantity(nix_mtag.extents, nix_mtag.extents.unit)
 
         if len(nix_mtag.positions.dimensions[0].labels) > 0:
-            labels = np.array(nix_mtag.positions.dimensions[0].labels,
-                              dtype="U")
+            labels = np.array(nix_mtag.positions.dimensions[0].labels, dtype="U")
         else:
             labels = None
-        neo_epoch = Epoch(times=times, durations=durations, labels=labels,
-                          **neo_attrs)
+        neo_epoch = Epoch(times=times, durations=durations, labels=labels, **neo_attrs)
         self._neo_map[nix_mtag.name] = neo_epoch
         return neo_epoch
 
@@ -585,14 +568,12 @@ class NixIO(BaseIO):
             wftime = self._get_time_dimension(wfda)
             neo_spiketrain.waveforms = create_quantity(wfda, wfda.unit)
             interval_units = wftime.unit
-            neo_spiketrain.sampling_period = create_quantity(
-                wftime.sampling_interval, interval_units
-            )
+            neo_spiketrain.sampling_period = create_quantity(wftime.sampling_interval,
+                                                             interval_units)
             left_sweep_units = wftime.unit
             if "left_sweep" in wfda.metadata:
-                neo_spiketrain.left_sweep = create_quantity(
-                    wfda.metadata["left_sweep"], left_sweep_units
-                )
+                neo_spiketrain.left_sweep = create_quantity(wfda.metadata["left_sweep"],
+                                                            left_sweep_units)
         self._neo_map[nix_mtag.name] = neo_spiketrain
 
         srcnames = list(src.name for src in nix_mtag.sources)
@@ -645,9 +626,7 @@ class NixIO(BaseIO):
             del self.nix_file.sections[nix_name]
 
         nixblock = self.nix_file.create_block(nix_name, "neo.block")
-        nixblock.metadata = self.nix_file.create_section(
-            nix_name, "neo.block.metadata"
-        )
+        nixblock.metadata = self.nix_file.create_section(nix_name, "neo.block.metadata")
         metadata = nixblock.metadata
         neoname = block.name if block.name is not None else ""
         metadata["neo_name"] = neoname
@@ -688,9 +667,8 @@ class NixIO(BaseIO):
             nix_name = f"neo.channelindex.{self._generate_nix_name()}"
             chx.annotate(nix_name=nix_name)
         nixsource = nixblock.create_source(nix_name, "neo.channelindex")
-        nixsource.metadata = nixblock.metadata.create_section(
-            nix_name, "neo.channelindex.metadata"
-        )
+        nixsource.metadata = nixblock.metadata.create_section(nix_name,
+                                                              "neo.channelindex.metadata")
 
         metadata = nixsource.metadata
         neoname = chx.name if chx.name is not None else ""
@@ -708,9 +686,8 @@ class NixIO(BaseIO):
         for idx, channel in enumerate(chx.index):
             channame = f"{nix_name}.ChannelIndex{idx}"
             nixchan = nixsource.create_source(channame, "neo.channelindex")
-            nixchan.metadata = nixsource.metadata.create_section(
-                nixchan.name, "neo.channelindex.metadata"
-            )
+            nixchan.metadata = nixsource.metadata.create_section(nixchan.name,
+                                                                 "neo.channelindex.metadata")
             nixchan.definition = nixsource.definition
             chanmd = nixchan.metadata
             chanmd["index"] = int(channel)
@@ -746,9 +723,8 @@ class NixIO(BaseIO):
             segment.annotate(nix_name=nix_name)
 
         nixgroup = nixblock.create_group(nix_name, "neo.segment")
-        nixgroup.metadata = nixblock.metadata.create_section(
-            nix_name, "neo.segment.metadata"
-        )
+        nixgroup.metadata = nixblock.metadata.create_section(nix_name,
+                                                             "neo.segment.metadata")
         metadata = nixgroup.metadata
         neoname = segment.name if segment.name is not None else ""
         metadata["neo_name"] = neoname
@@ -815,13 +791,11 @@ class NixIO(BaseIO):
             data = np.transpose(anasig[:].magnitude)
 
         parentmd = nixgroup.metadata if nixgroup else nixblock.metadata
-        metadata = parentmd.create_section(nix_name,
-                                           "neo.analogsignal.metadata")
+        metadata = parentmd.create_section(nix_name, "neo.analogsignal.metadata")
         nixdas = list()
         for idx, row in enumerate(data):
             daname = f"{nix_name}.{idx}"
-            da = nixblock.create_data_array(daname, "neo.analogsignal",
-                                            data=row)
+            da = nixblock.create_data_array(daname, "neo.analogsignal", data=row)
             da.metadata = metadata
             da.definition = anasig.description
             da.unit = units_to_string(anasig.units)
@@ -887,14 +861,12 @@ class NixIO(BaseIO):
             data = np.transpose(imgseq[:].magnitude)
 
         parentmd = nixgroup.metadata if nixgroup else nixblock.metadata
-        metadata = parentmd.create_section(nix_name,
-                                           "neo.imagesequence.metadata")
+        metadata = parentmd.create_section(nix_name, "neo.imagesequence.metadata")
 
         nixdas = list()
         for idx, row in enumerate(data):
             daname = f"{nix_name}.{idx}"
-            da = nixblock.create_data_array(daname, "neo.imagesequence",
-                                            data=row)
+            da = nixblock.create_data_array(daname, "neo.imagesequence", data=row)
 
             da.metadata = metadata
             da.definition = imgseq.description
@@ -957,15 +929,11 @@ class NixIO(BaseIO):
             data = np.transpose(irsig[:].magnitude)
 
         parentmd = nixgroup.metadata if nixgroup else nixblock.metadata
-        metadata = parentmd.create_section(
-            nix_name, "neo.irregularlysampledsignal.metadata"
-        )
+        metadata = parentmd.create_section(nix_name, "neo.irregularlysampledsignal.metadata")
         nixdas = list()
         for idx, row in enumerate(data):
             daname = f"{nix_name}.{idx}"
-            da = nixblock.create_data_array(
-                daname, "neo.irregularlysampledsignal", data=row
-            )
+            da = nixblock.create_data_array(daname, "neo.irregularlysampledsignal", data=row)
             da.metadata = metadata
             da.definition = irsig.description
             da.unit = units_to_string(irsig.units)
@@ -1017,16 +985,11 @@ class NixIO(BaseIO):
         times = event.times.magnitude
         units = units_to_string(event.times.units)
         labels = event.labels
-        timesda = nixblock.create_data_array(
-            f"{nix_name}.times", "neo.event.times", data=times
-        )
+        timesda = nixblock.create_data_array(f"{nix_name}.times", "neo.event.times", data=times)
         timesda.unit = units
-        nixmt = nixblock.create_multi_tag(nix_name, "neo.event",
-                                          positions=timesda)
+        nixmt = nixblock.create_multi_tag(nix_name, "neo.event", positions=timesda)
 
-        nixmt.metadata = nixgroup.metadata.create_section(
-            nix_name, "neo.event.metadata"
-        )
+        nixmt.metadata = nixgroup.metadata.create_section(nix_name, "neo.event.metadata")
         metadata = nixmt.metadata
 
         labeldim = timesda.append_set_dimension()
@@ -1078,23 +1041,16 @@ class NixIO(BaseIO):
         durations = epoch.durations.magnitude
         dunits = units_to_string(epoch.durations.units)
 
-        timesda = nixblock.create_data_array(
-            f"{nix_name}.times", "neo.epoch.times", data=times
-        )
+        timesda = nixblock.create_data_array(f"{nix_name}.times", "neo.epoch.times", data=times)
         timesda.unit = tunits
-        nixmt = nixblock.create_multi_tag(nix_name, "neo.epoch",
-                                          positions=timesda)
+        nixmt = nixblock.create_multi_tag(nix_name, "neo.epoch", positions=timesda)
 
-        durada = nixblock.create_data_array(
-            f"{nix_name}.durations", "neo.epoch.durations",
-            data=durations
-        )
+        durada = nixblock.create_data_array(f"{nix_name}.durations", "neo.epoch.durations",
+                                            data=durations)
         durada.unit = dunits
         nixmt.extents = durada
 
-        nixmt.metadata = nixgroup.metadata.create_section(
-            nix_name, "neo.epoch.metadata"
-        )
+        nixmt.metadata = nixgroup.metadata.create_section(nix_name, "neo.epoch.metadata")
         metadata = nixmt.metadata
 
         labeldim = timesda.append_set_dimension()
@@ -1146,16 +1102,13 @@ class NixIO(BaseIO):
         tunits = units_to_string(spiketrain.times.units)
         waveforms = spiketrain.waveforms
 
-        timesda = nixblock.create_data_array(f"{nix_name}.times",
-                                             "neo.spiketrain.times",
+        timesda = nixblock.create_data_array(f"{nix_name}.times", "neo.spiketrain.times",
                                              data=times)
         timesda.unit = tunits
-        nixmt = nixblock.create_multi_tag(nix_name, "neo.spiketrain",
-                                          positions=timesda)
+        nixmt = nixblock.create_multi_tag(nix_name, "neo.spiketrain", positions=timesda)
 
         parentmd = nixgroup.metadata if nixgroup else nixblock.metadata
-        nixmt.metadata = parentmd.create_section(nix_name,
-                                                 "neo.spiketrain.metadata")
+        nixmt.metadata = parentmd.create_section(nix_name, "neo.spiketrain.metadata")
         metadata = nixmt.metadata
 
         neoname = spiketrain.name if spiketrain.name is not None else ""
@@ -1178,31 +1131,23 @@ class NixIO(BaseIO):
 
         if waveforms is not None:
             wfdata = list(wf.magnitude for wf in
-                          list(wfgroup for wfgroup in
-                               spiketrain.waveforms))
+                          list(wfgroup for wfgroup in spiketrain.waveforms))
             wfunits = units_to_string(spiketrain.waveforms.units)
-            wfda = nixblock.create_data_array(
-                f"{nix_name}.waveforms", "neo.waveforms",
-                data=wfdata
-            )
+            wfda = nixblock.create_data_array(f"{nix_name}.waveforms", "neo.waveforms",
+                                              data=wfdata)
             wfda.unit = wfunits
-            wfda.metadata = nixmt.metadata.create_section(
-                wfda.name, "neo.waveforms.metadata"
-            )
+            wfda.metadata = nixmt.metadata.create_section(wfda.name, "neo.waveforms.metadata")
             nixmt.create_feature(wfda, nix.LinkType.Indexed)
             # TODO: Move time dimension first for PR #457
             # https://github.com/NeuralEnsemble/python-neo/pull/457
             wfda.append_set_dimension()
             wfda.append_set_dimension()
-            wftime = wfda.append_sampled_dimension(
-                spiketrain.sampling_period.magnitude.item()
-            )
+            wftime = wfda.append_sampled_dimension(spiketrain.sampling_period.magnitude.item())
             wftime.unit = units_to_string(spiketrain.sampling_period.units)
             wftime.label = "time"
 
             if spiketrain.left_sweep is not None:
-                self._write_property(wfda.metadata, "left_sweep",
-                                     spiketrain.left_sweep)
+                self._write_property(wfda.metadata, "left_sweep", spiketrain.left_sweep)
 
     def _write_unit(self, neounit, nixchxsource):
         """
@@ -1218,11 +1163,9 @@ class NixIO(BaseIO):
         else:
             nix_name = f"neo.unit.{self._generate_nix_name()}"
             neounit.annotate(nix_name=nix_name)
-        nixunitsource = nixchxsource.create_source(nix_name,
-                                                   "neo.unit")
-        nixunitsource.metadata = nixchxsource.metadata.create_section(
-            nix_name, "neo.unit.metadata"
-        )
+        nixunitsource = nixchxsource.create_source(nix_name, "neo.unit")
+        nixunitsource.metadata = nixchxsource.metadata.create_section(nix_name,
+                                                                      "neo.unit.metadata")
         metadata = nixunitsource.metadata
         neoname = neounit.name if neounit.name is not None else ""
         metadata["neo_name"] = neoname
@@ -1381,8 +1324,7 @@ class NixIO(BaseIO):
                         values = ""
                 elif len(values) == 1:
                     values = values[0]
-                if prop.definition in (DATEANNOTATION, TIMEANNOTATION,
-                                       DATETIMEANNOTATION):
+                if prop.definition in (DATEANNOTATION, TIMEANNOTATION, DATETIMEANNOTATION):
                     values = dt_from_nix(values, prop.definition)
                 if prop.definition == ARRAYANNOTATION:
                     if 'array_annotations' in neo_attrs:
@@ -1498,8 +1440,7 @@ class NixIO(BaseIO):
         """
         Closes the open nix file and resets maps.
         """
-        if (hasattr(self, "nix_file")
-                and self.nix_file and self.nix_file.is_open()):
+        if (hasattr(self, "nix_file") and self.nix_file and self.nix_file.is_open()):
             self.nix_file.close()
             self.nix_file = None
             self._neo_map = None

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -21,10 +21,7 @@ Neo: https://github.com/G-Node/python-neo/wiki
 
 
 from datetime import date, time, datetime
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 from collections import OrderedDict
 import itertools
 from uuid import uuid4
@@ -48,10 +45,6 @@ try:
 except ImportError:
     HAVE_NIX = False
 
-try:
-    string_types = basestring
-except NameError:
-    string_types = str
 
 datetime_types = (date, time, datetime)
 
@@ -1320,7 +1313,7 @@ class NixIO(BaseIO):
             value, annotype = dt_to_nix(v)
             prop = section.create_property(name, value)
             prop.definition = annotype
-        elif isinstance(v, string_types):
+        elif isinstance(v, str):
             if len(v):
                 section.create_property(name, v)
             else:
@@ -1343,7 +1336,7 @@ class NixIO(BaseIO):
                     unit = str(v.dimensionality)
             else:
                 for item in v:
-                    if isinstance(item, string_types):
+                    if isinstance(item, str):
                         item = item
                     elif isinstance(item, pq.Quantity):
                         unit = str(item.dimensionality)

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -1441,15 +1441,15 @@ class NixIO(BaseIO):
 
         try:
             check_unique(blocks)
-        except ValueError as ve:
-            raise ValueError(f"{errmsg} in Blocks {ve}")
+        except ValueError as exc:
+            raise ValueError(f"{errmsg} in Blocks") from exc
 
         for blk in blocks:
             try:
                 # Segments
                 check_unique(blk.segments)
-            except ValueError as ve:
-                raise ValueError(f"{errmsg} at Block '{blk.name}' > segments > {ve}")
+            except ValueError as exc:
+                raise ValueError(f"{errmsg} at Block '{blk.name}' > segments") from exc
 
             # collect all signals in all segments
             signals = []
@@ -1466,33 +1466,29 @@ class NixIO(BaseIO):
             try:
                 # AnalogSignals and IrregularlySampledSignals
                 check_unique(signals)
-            except ValueError as ve:
-                raise ValueError(f"{errmsg} in Signal names of Block '{blk.name}' {ve}")
+            except ValueError as exc:
+                raise ValueError(f"{errmsg} in Signal names of Block '{blk.name}'") from exc
 
             try:
                 # Events, Epochs, and SpikeTrains
                 check_unique(eests)
-            except ValueError as ve:
+            except ValueError as exc:
                 raise ValueError(
-                    f"{errmsg} in Event, Epoch, and Spiketrain names of Block '{blk.name}' {ve}"
-                )
+                    f"{errmsg} in Event, Epoch, and Spiketrain names of Block '{blk.name}'"
+                ) from exc
 
             try:
                 # ChannelIndexes
                 check_unique(blk.channel_indexes)
-            except ValueError as ve:
-                raise ValueError(
-                    f"{errmsg} in ChannelIndex names of Block '{blk.name}' {ve}"
-                )
+            except ValueError as exc:
+                raise ValueError(f"{errmsg} in ChannelIndex names of Block '{blk.name}'") from exc
 
             for chx in blk.channel_indexes:
                 try:
                     check_unique(chx.units)
-                except ValueError as ve:
-                    raise ValueError(
-                        f"{errmsg} in Unit names of Block '{blk.name}' > "
-                        f"ChannelIndex '{chx.name}' {ve}"
-                    )
+                except ValueError as exc:
+                    raise ValueError(f"{errmsg} in Unit names of Block '{blk.name}' > "
+                                     f"ChannelIndex '{chx.name}'") from exc
 
         # names are OK: assign annotations
         for o in allobjs:

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -134,18 +134,17 @@ def check_nix_version():
         nixver = Version(nixverstr)
     except ValueError:
         warnings.warn(
-            "Could not understand NIX Python version {}. "
-            "The NixIO requires version {} of the Python package for NIX. "
-            "The IO may not work correctly.".format(nixverstr,
-                                                    str(MIN_NIX_VER))
+            f"Could not understand NIX Python version {nixverstr}. "
+            f"The NixIO requires version {MIN_NIX_VER} of the Python package for NIX. "
+            "The IO may not work correctly."
         )
         return
 
     if nixver < MIN_NIX_VER:
         raise Exception(
             "NIX version not supported. "
-            "The NixIO requires version {} or higher of the Python package "
-            "for NIX. Found version {}".format(str(MIN_NIX_VER), nixverstr)
+            f"The NixIO requires version {MIN_NIX_VER} or higher of the Python package "
+            f"for NIX. Found version {nixverstr}"
         )
 
 
@@ -183,9 +182,9 @@ class NixIO(BaseIO):
         elif mode == "ow":
             filemode = nix.FileMode.Overwrite
         else:
-            raise ValueError("Invalid mode specified '{}'. "
+            raise ValueError(f"Invalid mode specified '{mode}'. "
                              "Valid modes: 'ro' (ReadOnly)', 'rw' (ReadWrite),"
-                             " 'ow' (Overwrite).".format(mode))
+                             " 'ow' (Overwrite).")
         self.nix_file = nix.File.open(self.filename, filemode)
 
         if self.nix_file.mode == nix.FileMode.ReadOnly:
@@ -268,9 +267,7 @@ class NixIO(BaseIO):
                     nix_block = blk
                     break
             else:
-                raise KeyError(
-                    "Block with Neo name '{}' does not exist".format(neoname)
-                )
+                raise KeyError(f"Block with Neo name '{neoname}' does not exist")
         else:
             index = self._block_read_counter
             if index >= len(self.nix_file.blocks):
@@ -639,7 +636,7 @@ class NixIO(BaseIO):
         if "nix_name" in block.annotations:
             nix_name = block.annotations["nix_name"]
         else:
-            nix_name = "neo.block.{}".format(self._generate_nix_name())
+            nix_name = f"neo.block.{self._generate_nix_name()}"
             block.annotate(nix_name=nix_name)
 
         if nix_name in self.nix_file.blocks:
@@ -688,7 +685,7 @@ class NixIO(BaseIO):
         if "nix_name" in chx.annotations:
             nix_name = chx.annotations["nix_name"]
         else:
-            nix_name = "neo.channelindex.{}".format(self._generate_nix_name())
+            nix_name = f"neo.channelindex.{self._generate_nix_name()}"
             chx.annotate(nix_name=nix_name)
         nixsource = nixblock.create_source(nix_name, "neo.channelindex")
         nixsource.metadata = nixblock.metadata.create_section(
@@ -709,7 +706,7 @@ class NixIO(BaseIO):
             coordinates = [coordinates]
 
         for idx, channel in enumerate(chx.index):
-            channame = "{}.ChannelIndex{}".format(nix_name, idx)
+            channame = f"{nix_name}.ChannelIndex{idx}"
             nixchan = nixsource.create_source(channame, "neo.channelindex")
             nixchan.metadata = nixsource.metadata.create_section(
                 nixchan.name, "neo.channelindex.metadata"
@@ -745,7 +742,7 @@ class NixIO(BaseIO):
         if "nix_name" in segment.annotations:
             nix_name = segment.annotations["nix_name"]
         else:
-            nix_name = "neo.segment.{}".format(self._generate_nix_name())
+            nix_name = f"neo.segment.{self._generate_nix_name()}"
             segment.annotate(nix_name=nix_name)
 
         nixgroup = nixblock.create_group(nix_name, "neo.segment")
@@ -796,15 +793,15 @@ class NixIO(BaseIO):
         if "nix_name" in anasig.annotations:
             nix_name = anasig.annotations["nix_name"]
         else:
-            nix_name = "neo.analogsignal.{}".format(self._generate_nix_name())
+            nix_name = f"neo.analogsignal.{self._generate_nix_name()}"
             anasig.annotate(nix_name=nix_name)
 
-        if "{}.0".format(nix_name) in nixblock.data_arrays and nixgroup:
+        if f"{nix_name}.0" in nixblock.data_arrays and nixgroup:
             # AnalogSignal is in multiple Segments.
             # Append DataArrays to Group and return.
             dalist = list()
             for idx in itertools.count():
-                daname = "{}.{}".format(nix_name, idx)
+                daname = f"{nix_name}.{idx}"
                 if daname in nixblock.data_arrays:
                     dalist.append(nixblock.data_arrays[daname])
                 else:
@@ -822,7 +819,7 @@ class NixIO(BaseIO):
                                            "neo.analogsignal.metadata")
         nixdas = list()
         for idx, row in enumerate(data):
-            daname = "{}.{}".format(nix_name, idx)
+            daname = f"{nix_name}.{idx}"
             da = nixblock.create_data_array(daname, "neo.analogsignal",
                                             data=row)
             da.metadata = metadata
@@ -869,14 +866,14 @@ class NixIO(BaseIO):
         if "nix_name" in imgseq.annotations:
             nix_name = imgseq.annotations["nix_name"]
         else:
-            nix_name = "neo.imagesequence.{}".format(self._generate_nix_name())
+            nix_name = f"neo.imagesequence.{self._generate_nix_name()}"
             imgseq.annotate(nix_name=nix_name)
 
-        if "{}.0".format(nix_name) in nixblock.data_arrays and nixgroup:
+        if f"{nix_name}.0" in nixblock.data_arrays and nixgroup:
 
             dalist = list()
             for idx in itertools.count():
-                daname = "{}.{}".format(nix_name, idx)
+                daname = f"{nix_name}.{idx}"
                 if daname in nixblock.data_arrays:
                     dalist.append(nixblock.data_arrays[daname])
                 else:
@@ -895,7 +892,7 @@ class NixIO(BaseIO):
 
         nixdas = list()
         for idx, row in enumerate(data):
-            daname = "{}.{}".format(nix_name, idx)
+            daname = f"{nix_name}.{idx}"
             da = nixblock.create_data_array(daname, "neo.imagesequence",
                                             data=row)
 
@@ -938,17 +935,15 @@ class NixIO(BaseIO):
         if "nix_name" in irsig.annotations:
             nix_name = irsig.annotations["nix_name"]
         else:
-            nix_name = "neo.irregularlysampledsignal.{}".format(
-                self._generate_nix_name()
-            )
+            nix_name = f"neo.irregularlysampledsignal.{self._generate_nix_name()}"
             irsig.annotate(nix_name=nix_name)
 
-        if "{}.0".format(nix_name) in nixblock.data_arrays and nixgroup:
+        if f"{nix_name}.0" in nixblock.data_arrays and nixgroup:
             # IrregularlySampledSignal is in multiple Segments.
             # Append DataArrays to Group and return.
             dalist = list()
             for idx in itertools.count():
-                daname = "{}.{}".format(nix_name, idx)
+                daname = f"{nix_name}.{idx}"
                 if daname in nixblock.data_arrays:
                     dalist.append(nixblock.data_arrays[daname])
                 else:
@@ -967,7 +962,7 @@ class NixIO(BaseIO):
         )
         nixdas = list()
         for idx, row in enumerate(data):
-            daname = "{}.{}".format(nix_name, idx)
+            daname = f"{nix_name}.{idx}"
             da = nixblock.create_data_array(
                 daname, "neo.irregularlysampledsignal", data=row
             )
@@ -1007,7 +1002,7 @@ class NixIO(BaseIO):
         if "nix_name" in event.annotations:
             nix_name = event.annotations["nix_name"]
         else:
-            nix_name = "neo.event.{}".format(self._generate_nix_name())
+            nix_name = f"neo.event.{self._generate_nix_name()}"
             event.annotate(nix_name=nix_name)
 
         if nix_name in nixblock.multi_tags:
@@ -1023,7 +1018,7 @@ class NixIO(BaseIO):
         units = units_to_string(event.times.units)
         labels = event.labels
         timesda = nixblock.create_data_array(
-            "{}.times".format(nix_name), "neo.event.times", data=times
+            f"{nix_name}.times", "neo.event.times", data=times
         )
         timesda.unit = units
         nixmt = nixblock.create_multi_tag(nix_name, "neo.event",
@@ -1067,7 +1062,7 @@ class NixIO(BaseIO):
         if "nix_name" in epoch.annotations:
             nix_name = epoch.annotations["nix_name"]
         else:
-            nix_name = "neo.epoch.{}".format(self._generate_nix_name())
+            nix_name = f"neo.epoch.{self._generate_nix_name()}"
             epoch.annotate(nix_name=nix_name)
 
         if nix_name in nixblock.multi_tags:
@@ -1084,14 +1079,14 @@ class NixIO(BaseIO):
         dunits = units_to_string(epoch.durations.units)
 
         timesda = nixblock.create_data_array(
-            "{}.times".format(nix_name), "neo.epoch.times", data=times
+            f"{nix_name}.times", "neo.epoch.times", data=times
         )
         timesda.unit = tunits
         nixmt = nixblock.create_multi_tag(nix_name, "neo.epoch",
                                           positions=timesda)
 
         durada = nixblock.create_data_array(
-            "{}.durations".format(nix_name), "neo.epoch.durations",
+            f"{nix_name}.durations", "neo.epoch.durations",
             data=durations
         )
         durada.unit = dunits
@@ -1135,7 +1130,7 @@ class NixIO(BaseIO):
         if "nix_name" in spiketrain.annotations:
             nix_name = spiketrain.annotations["nix_name"]
         else:
-            nix_name = "neo.spiketrain.{}".format(self._generate_nix_name())
+            nix_name = f"neo.spiketrain.{self._generate_nix_name()}"
             spiketrain.annotate(nix_name=nix_name)
 
         if nix_name in nixblock.multi_tags and nixgroup:
@@ -1151,7 +1146,7 @@ class NixIO(BaseIO):
         tunits = units_to_string(spiketrain.times.units)
         waveforms = spiketrain.waveforms
 
-        timesda = nixblock.create_data_array("{}.times".format(nix_name),
+        timesda = nixblock.create_data_array(f"{nix_name}.times",
                                              "neo.spiketrain.times",
                                              data=times)
         timesda.unit = tunits
@@ -1187,7 +1182,7 @@ class NixIO(BaseIO):
                                spiketrain.waveforms))
             wfunits = units_to_string(spiketrain.waveforms.units)
             wfda = nixblock.create_data_array(
-                "{}.waveforms".format(nix_name), "neo.waveforms",
+                f"{nix_name}.waveforms", "neo.waveforms",
                 data=wfdata
             )
             wfda.unit = wfunits
@@ -1221,7 +1216,7 @@ class NixIO(BaseIO):
         if "nix_name" in neounit.annotations:
             nix_name = neounit.annotations["nix_name"]
         else:
-            nix_name = "neo.unit.{}".format(self._generate_nix_name())
+            nix_name = f"neo.unit.{self._generate_nix_name()}"
             neounit.annotate(nix_name=nix_name)
         nixunitsource = nixchxsource.create_source(nix_name,
                                                    "neo.unit")
@@ -1447,15 +1442,14 @@ class NixIO(BaseIO):
         try:
             check_unique(blocks)
         except ValueError as ve:
-            raise ValueError("{} in Blocks {}".format(errmsg, ve))
+            raise ValueError(f"{errmsg} in Blocks {ve}")
 
         for blk in blocks:
             try:
                 # Segments
                 check_unique(blk.segments)
             except ValueError as ve:
-                raise ValueError("{} at Block '{}' > segments > "
-                                 "{}".format(errmsg, blk.name, ve))
+                raise ValueError(f"{errmsg} at Block '{blk.name}' > segments > {ve}")
 
             # collect all signals in all segments
             signals = []
@@ -1473,18 +1467,14 @@ class NixIO(BaseIO):
                 # AnalogSignals and IrregularlySampledSignals
                 check_unique(signals)
             except ValueError as ve:
-                raise ValueError(
-                    "{} in Signal names "
-                    "of Block '{}' {}".format(errmsg, blk.name, ve)
-                )
+                raise ValueError(f"{errmsg} in Signal names of Block '{blk.name}' {ve}")
 
             try:
                 # Events, Epochs, and SpikeTrains
                 check_unique(eests)
             except ValueError as ve:
                 raise ValueError(
-                    "{} in Event, Epoch, and Spiketrain names "
-                    "of Block '{}' {}".format(errmsg, blk.name, ve)
+                    f"{errmsg} in Event, Epoch, and Spiketrain names of Block '{blk.name}' {ve}"
                 )
 
             try:
@@ -1492,8 +1482,7 @@ class NixIO(BaseIO):
                 check_unique(blk.channel_indexes)
             except ValueError as ve:
                 raise ValueError(
-                    "{} in ChannelIndex names "
-                    "of Block '{}' {}".format(errmsg, blk.name, ve)
+                    f"{errmsg} in ChannelIndex names of Block '{blk.name}' {ve}"
                 )
 
             for chx in blk.channel_indexes:
@@ -1501,9 +1490,8 @@ class NixIO(BaseIO):
                     check_unique(chx.units)
                 except ValueError as ve:
                     raise ValueError(
-                        "{} in Unit names of Block "
-                        "'{}' > ChannelIndex '{}' {}".format(errmsg, blk.name,
-                                                             chx.name, ve)
+                        f"{errmsg} in Unit names of Block '{blk.name}' > "
+                        f"ChannelIndex '{chx.name}' {ve}"
                     )
 
         # names are OK: assign annotations


### PR DESCRIPTION
Since Python 3.6 is the minimum supported version and in the interest of Consistent string formatting (Issue #857), I've cleaned up some of the code in the NIXIO.

- F-strings are used for all string formatting.
- Removed all Python 2 specific code and exceptions.
- Used `raise ... from` for exception chaining ([PEP 3134](https://www.python.org/dev/peps/pep-3134/)).
- Unfold lines for readability when they fit into 99 chars (the project setting).

I'd also like to add type hints (in another PR).  I think they're very useful, both for the module internally but also for anyone using them outside the library for type linting and they have no effect for anyone not using them.