### PR TITLE
Fixing `duplicate_with_new_data` function for ImageSequence objects

### DIFF
--- a/neo/core/basesignal.py
+++ b/neo/core/basesignal.py
@@ -141,6 +141,8 @@ class BaseSignal(DataObject):
         for attr in self._necessary_attrs:
             if attr[0] == "signal":
                 required_attributes["signal"] = signal
+            elif attr[0] == "image_data":
+                required_attributes["image_data"] = signal
             elif attr[0] == "t_start":
                 required_attributes["t_start"] = getattr(self, "t_start", 0.0 * pq.ms)
             else:


### PR DESCRIPTION
Running the function `imgseq.duplicate_with_new_data(imgseq.as_array())` fails because the signal attribute 'image_data' is returned as None by the `_get_required_attributes` function. Because the signal attribute for ImageSequence objects is not called 'signal' as assumed by the function an extra if statement needs to be added to make it work properly.