### PR TITLE
Edit NeuralynxIO to include all valid samples from NCS files (analog signals)

### DIFF
--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -483,11 +483,7 @@ class NeuralynxRawIO(BaseRawIO):
             if self.use_cache:
                 self.add_in_cache(lost_indexes=lost_indexes)
 
-        gap_and_lost_indexes = np.unique(np.concatenate((gap_indexes, lost_indexes)))
-
-        gap_candidates = np.unique([0]
-                                   + [data0.size]
-                                   + (gap_and_lost_indexes + 1).tolist())  # linear
+        gap_candidates = np.unique(np.concatenate(([0], gap_indexes + 1, lost_indexes + 1, [data0.size])))
 
         gap_pairs = np.vstack([gap_candidates[:-1], gap_candidates[1:]]).T  # 2D (n_segments, 2)
 

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -483,9 +483,11 @@ class NeuralynxRawIO(BaseRawIO):
             if self.use_cache:
                 self.add_in_cache(lost_indexes=lost_indexes)
 
+	gap_and_lost_indexes = np.unique(np.concatenate((gap_indexes, lost_indexes)))
+
         gap_candidates = np.unique([0]
                                    + [data0.size]
-                                   + (lost_indexes + 1).tolist())  # linear
+                                   + (gap_and_lost_indexes + 1).tolist())  # linear
 
         gap_pairs = np.vstack([gap_candidates[:-1], gap_candidates[1:]]).T  # 2D (n_segments, 2)
 

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -483,7 +483,10 @@ class NeuralynxRawIO(BaseRawIO):
             if self.use_cache:
                 self.add_in_cache(lost_indexes=lost_indexes)
 
-        gap_candidates = np.unique(np.concatenate(([0], gap_indexes + 1, lost_indexes + 1, [data0.size])))
+        gap_candidates = np.unique(np.concatenate(([0],
+                                                   gap_indexes + 1,
+                                                   lost_indexes + 1,
+                                                   [data0.size])))
 
         gap_pairs = np.vstack([gap_candidates[:-1], gap_candidates[1:]]).T  # 2D (n_segments, 2)
 

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -483,7 +483,7 @@ class NeuralynxRawIO(BaseRawIO):
             if self.use_cache:
                 self.add_in_cache(lost_indexes=lost_indexes)
 
-	gap_and_lost_indexes = np.unique(np.concatenate((gap_indexes, lost_indexes)))
+        gap_and_lost_indexes = np.unique(np.concatenate((gap_indexes, lost_indexes)))
 
         gap_candidates = np.unique([0]
                                    + [data0.size]

--- a/neo/rawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio.py
@@ -485,7 +485,7 @@ class NeuralynxRawIO(BaseRawIO):
 
         gap_candidates = np.unique([0]
                                    + [data0.size]
-                                   + (lost_indexes + 1).tolist()) # linear
+                                   + (lost_indexes + 1).tolist())  # linear
 
         gap_pairs = np.vstack([gap_candidates[:-1], gap_candidates[1:]]).T  # 2D (n_segments, 2)
 


### PR DESCRIPTION
These edits relate to the treatment of records with <512 valid samples, with the goal of keeping all valid samples. In particular, they fix three cases where valid samples were previously discarded:

1. The last record of each segment, which almost always has <512 valid samples
2. Segments with only one record with 512 valid samples (sandwiched between records with <512 valid samples)
3. Segments consisting of only one record of <512 valid samples

test_neuralynxrawio.py runs OK.