### PR TITLE
Make segment time evaluation compatible with ProxyObjects

### DIFF
--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -103,7 +103,12 @@ class Segment(Container):
         '''
         t_starts = [sig.t_start for sig in self.analogsignals +
                     self.spiketrains + self.irregularlysampledsignals]
-        t_starts += [e.times[0] for e in self.epochs + self.events if len(e.times) > 0]
+
+        for e in self.epochs + self.events:
+            if hasattr(e, 't_start'):  # in case of proxy objects
+                t_starts += [e.t_start]
+            elif len(e) > 0:
+                t_starts += [e.times[0]]
 
         # t_start is not defined if no children are present
         if len(t_starts) == 0:
@@ -120,7 +125,12 @@ class Segment(Container):
         '''
         t_stops = [sig.t_stop for sig in self.analogsignals +
                    self.spiketrains + self.irregularlysampledsignals]
-        t_stops += [e.times[-1] for e in self.epochs + self.events if len(e.times) > 0]
+
+        for e in self.epochs + self.events:
+            if hasattr(e, 't_stop'):  # in case of proxy objects
+                t_stops += [e.t_stop]
+            elif len(e) > 0:
+                t_stops += [e.times[-1]]
 
         # t_stop is not defined if no children are present
         if len(t_stops) == 0:


### PR DESCRIPTION
Currently segment `t_start` and `t_stop` evaluation of a Segment fails in case of EventProxy or EpochProxy objects being present as these don't provide `times` values. However, in contrast to Events or Epochs these objects come with `t_start` and `t_stop` attributes, that can be used instead for the time range calculation of the segment.
This PR extends the `t_start` and `t_stop` calculation of Segments to be compatible with EventProxy and EpochProxy objects.