### PR TITLE
[BUGFIX] Integer Overflow in `spike2rawio.py`

### DIFF
--- a/neo/rawio/spike2rawio.py
+++ b/neo/rawio/spike2rawio.py
@@ -608,10 +608,10 @@ def get_sample_interval(info, chan_info):
     Get sample interval for one channel
     """
     if info['system_id'] in [1, 2, 3, 4, 5]:  # Before version 5
-        sample_interval = (chan_info['divide'] * info['us_per_time'] *
+        sample_interval = (int(chan_info['divide']) * info['us_per_time'] *
                            info['time_per_adc']) * 1e-6
     else:
-        sample_interval = (chan_info['l_chan_dvd'] *
+        sample_interval = (int(chan_info['l_chan_dvd']) *
                            info['us_per_time'] * info['dtime_base'])
     return sample_interval
 


### PR DESCRIPTION
Due to the fact that the header data is read using numpy using numpys fixed size integer types, any computation on them without a cast results in computations on this fixed size types, which can result in over- or underflows.

This can cause a bug in the `get_sample_interval` function of `spike2rawio.py`, where multiple `int32` numbers are multiplied, which, if they are large enough, can result in an overflow.

This PR fixes this bug by casting the first operant to `int`, so the multiplication is performed on pythons arbitrary size integers.

As this function returns a float, another possible solution would be to cast this into a float type, or, as it is later multiplied by the float 10^-6, to move that division to the front of the equation, resulting the other multiplications to be executed as float.