### PR TITLE
Vectorize AnalogSignal.time_index()

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -448,9 +448,9 @@ class AnalogSignal(BaseSignal):
             _pp(line)
 
     def time_index(self, t):
-        """Return the array index corresponding to the time `t`"""
+        """Return the array index (or indices) corresponding to the time (or times) `t`"""
         i = (t - self.t_start) * self.sampling_rate
-        i = int(np.rint(i.simplified.magnitude))
+        i = np.rint(i.simplified.magnitude).astype(np.int)
         return i
 
     def time_slice(self, t_start, t_stop):

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -742,6 +742,16 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.assertTrue(hasattr(self.signal1[9, 3], 'units'))
         self.assertRaises(IndexError, self.signal1.__getitem__, (99, 73))
 
+    def test__time_index(self):
+        # scalar arguments
+        self.assertEqual(self.signal2.time_index(2.0 * pq.s), 2)
+        self.assertEqual(self.signal2.time_index(1.99 * pq.s), 2)
+        self.assertEqual(self.signal2.time_index(2.01 * pq.s), 2)
+
+        # vector arguments
+        assert_array_equal(self.signal2.time_index([2.0, 0.99, 3.01] * pq.s), [2, 1, 3])
+        assert_array_equal(self.signal2.time_index([2.0] * pq.s), [2])
+
     def test__time_slice(self):
         t_start = 2 * pq.s
         t_stop = 4 * pq.s


### PR DESCRIPTION
This change allows the `AnalogSignal.time_index()` method to accept arrays of times, not just a scalar. If a scalar time is provided, the method returns a scalar index as before; if an array of times is provided, the method now returns an array of indices.

This is particularly useful with SpikeTrains:
```python
import neo
import quantities as pq

sig = neo.AnalogSignal(range(10)*pq.V, sampling_rate=1*pq.Hz)

st = neo.SpikeTrain([2, 4, 9]*pq.s, t_stop=10*pq.s)

indices = sig.time_index(st)  # previously would have needed to use something like
                              #   np.array([sig.time_index(t) for t in st])
                              # which scales poorly in comparison to the proposed
                              # solution when used on a large number of spikes

amplitudes = sig.as_quantity()[indices]
```