### PR TITLE
Attempt to remedy CircleCI timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,12 @@ jobs:
       # run tests!
       - run:
           name: run tests
+          no_output_timeout: 20m
           command: |
             . venv/bin/activate
-            nosetests -v --with-coverage --cover-package=neo
+            nosetests -v --with-coverage --cover-package=neo --debug=neo.test
+      # note that we use --debug to get output while downloading files
+      # without this, CircleCI tends to time out because there's no output for a long time
 
       - run:
           name: coveralls

--- a/neo/test/rawiotest/tools.py
+++ b/neo/test/rawiotest/tools.py
@@ -8,6 +8,8 @@ import tempfile
 
 from urllib.request import urlopen
 
+logger = logging.getLogger("neo.test")
+
 
 def can_use_network():
     """
@@ -57,7 +59,7 @@ def download_test_file(filename, localdir, url):
     distantfile = url + '/' + filename
 
     if not os.path.exists(localfile):
-        logging.info('Downloading %s here %s', distantfile, localfile)
+        logger.info('Downloading %s here %s', distantfile, localfile)
         dist = urlopen(distantfile)
         with open(localfile, 'wb') as f:
             f.write(dist.read())


### PR DESCRIPTION
CircleCI sometimes times out because no output is received for a long time while downloading files.
Here we try two approaches:
- increase no_output_timeout in config.yml
- use --debug flag to print output every time a file is downloaded