### PR TITLE
Rev raw io docs

### DIFF
--- a/doc/source/rawio.rst
+++ b/doc/source/rawio.rst
@@ -118,6 +118,10 @@ By index is unambiguous 0 to n-1 (included), whereas for some IOs channel_names
 (and sometimes channel_ids) have no guarantees to
 be unique. In such cases, using names or ids may raise an error.
 
+A selected subset of channels which is passed to get_analog_signal_chunk, get_analog_signal_size,
+or get_analog_signal_t_start has the additional restriction that all such channels must have
+the same t_start and signal_size.
+
 Example with BlackrockRawIO for the file FileSpec2.3001::
 
     >>> raw_sigs = reader.get_analogsignal_chunk(channel_indexes=None) #Take all channels

--- a/doc/source/rawio.rst
+++ b/doc/source/rawio.rst
@@ -114,8 +114,9 @@ Read signal chunks of data and scale them::
 
 
 There are 3 ways to select a subset of channels: by index (0 based), by id or by name.
-By index is not ambiguous 0 to n-1 (included), for some IOs channel_names (and sometimes channel_ids) have no guarantees to
-be unique, in such cases it would raise an error.
+By index is unambiguous 0 to n-1 (included), whereas for some IOs channel_names
+(and sometimes channel_ids) have no guarantees to
+be unique. In such cases, using names or ids may raise an error.
 
 Example with BlackrockRawIO for the file FileSpec2.3001::
 

--- a/doc/source/rawio.rst
+++ b/doc/source/rawio.rst
@@ -122,6 +122,10 @@ A selected subset of channels which is passed to get_analog_signal_chunk, get_an
 or get_analog_signal_t_start has the additional restriction that all such channels must have
 the same t_start and signal_size.
 
+Such subsets of channels may be available in specific RawIOs by using the
+get_group_signal_channel_indexes method, if the RawIO has defined separate
+group_ids for each group with those common characteristics.
+
 Example with BlackrockRawIO for the file FileSpec2.3001::
 
     >>> raw_sigs = reader.get_analogsignal_chunk(channel_indexes=None) #Take all channels

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -654,12 +654,32 @@ class BaseRawIO:
     ###
     # signal and channel zone
     def _get_signal_size(self, block_index, seg_index, channel_indexes):
+        """
+        Return the size of a set of AnalogSignals indexed by channel_indexes.
+
+        All channels indexed must have the same size and t_start.
+        """
         raise (NotImplementedError)
 
     def _get_signal_t_start(self, block_index, seg_index, channel_indexes):
+        """
+        Return the t_start of a set of AnalogSignals indexed by channel_indexes.
+
+        All channels indexed must have the same size and t_start.
+        """
         raise (NotImplementedError)
 
     def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop, channel_indexes):
+        """
+        Return the samples from a set of AnalogSignals indexed by channel_indexes.
+
+        All channels indexed must have the same size and t_start.
+
+        RETURNS
+        -------
+            array of samples, with each requested channel in a column
+        """
+
         raise (NotImplementedError)
 
     ###


### PR DESCRIPTION
This new branch has only the changes in documentation and comments addressing the need to have groups of channels with the same t_start and signal_length as well as the use of the method to obtain these. 

Replaces PR #915 to have a cleaner history.