### PR TITLE
Fix broken example in Group docs

### DIFF
--- a/doc/source/grouping.rst
+++ b/doc/source/grouping.rst
@@ -111,7 +111,7 @@ Each :class:`ChannelIndex` also contains the list of channels on which that neur
     block.channel_indexes.extend((chx0, chx1))
 
 
-Using :class:`ChannelView` and :class`Group`::
+Using :class:`ChannelView` and :class:`Group`::
 
     import numpy as np
     from quantities import ms, mV, kHz
@@ -136,7 +136,7 @@ Using :class:`ChannelView` and :class`Group`::
     # assign each spiketrain to a neuron (now using Group)
     units = []
     for i, spiketrain in enumerate(spiketrains):
-        unit = Group(spiketrain, name=f"Neuron #{i + 1}")
+        unit = Group([spiketrain], name=f"Neuron #{i + 1}")
         units.append(unit)
 
     # create a ChannelView of the signal for each unit, to show which channels the spikes come from


### PR DESCRIPTION
Brackets are needed around `spiketrain` in `Group(spiketrain, ...)` to prevent this:

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-1-d6cd90dbfc95> in <module>
     22 units = []
     23 for i, spiketrain in enumerate(spiketrains):
---> 24     unit = Group(spiketrain, name=f"Neuron #{i + 1}")
     25     units.append(unit)
     26

c:\users\jeffrey\documents\python-dev\neo\git-repo\python-neo\neo\core\group.py in __init__(self, objects, name, description, file_origin, allowed_types, **annotations)
     53         else:
     54             self.allowed_types = tuple(allowed_types)
---> 55         if objects:
     56             self.add(*objects)
     57

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```