### PR TITLE
Include NeuralynxRawIO directory in non-develop installs, wheels, and source distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,9 @@ setup(
     name="neo",
     version=neo_version,
     packages=[
-        'neo', 'neo.core', 'neo.io', 'neo.rawio', 'neo.test',
-        'neo.test.coretest', 'neo.test.iotest', 'neo.test.rawiotest'],
+        'neo', 'neo.core', 'neo.io', 'neo.rawio', 'neo.rawio.neuralynxrawio',
+        'neo.test', 'neo.test.coretest', 'neo.test.iotest',
+        'neo.test.rawiotest'],
     install_requires=install_requires,
     extras_require=extras_require,
     author="Neo authors and contributors",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup
+from setuptools import setup, find_packages
 import os
 
 long_description = open("README.rst").read()
@@ -24,10 +24,7 @@ with open("neo/version.py") as fp:
 setup(
     name="neo",
     version=neo_version,
-    packages=[
-        'neo', 'neo.core', 'neo.io', 'neo.rawio', 'neo.rawio.neuralynxrawio',
-        'neo.test', 'neo.test.coretest', 'neo.test.iotest',
-        'neo.test.rawiotest'],
+    packages=find_packages(),
     install_requires=install_requires,
     extras_require=extras_require,
     author="Neo authors and contributors",


### PR DESCRIPTION
This change is needed for `setup.py` to discover the `neo/rawio/neuralynxrawio` directory. Otherwise, it is excluded from non-development installs (`python setup.py install` and `pip install .`), wheels (`python setup.py bdist_wheel`), and source distributions (`python setup.py sdist`).

Note that this was not a problem for development-mode installations (`python setup.py develop` and `pip install -e .`) because when installing from the repo the NeuralynxRawIO directory is, of course, already there. It's only when the other methods are used that the directory fails to be copied to the correct final location (e.g., into `site-packages` or the source tarball).

The automated CircleCI and Travis CI tests use `pip install .`, so one would expect them to catch this problem. However, this slipped past them. I think that's because tests are executed from the repo's top-level directory, so `neo/rawio/neuralynxrawio` can be located in the working directory, even if it isn't in `site-packages`.

The only reason I noticed this is because of #930. ReadTheDocs does not change its working directory to the package's top-level before installing (instead, it installs with a lengthy path: `/home/docs/checkouts/readthedocs.org/user_builds/neo/envs/latest/bin/python /home/docs/checkouts/readthedocs.org/user_builds/neo/checkouts/latest/setup.py install --force`). Consequently, it cannot locate the NeuralynxRawIO directory when it tries to import neo after installation, and autodoc fails to compile the module and class documentation.