### PR TITLE
Allow passing full path to ENT and POS files to ElanIO + fix event detection

### DIFF
--- a/neo/io/elanio.py
+++ b/neo/io/elanio.py
@@ -11,11 +11,23 @@ class ElanIO(ElanRawIO, BaseFromRaw):
     Elan is developed in Lyon, France, at INSERM U821
 
     https://elan.lyon.inserm.fr
+
+    Args:
+        filename (string) :
+            Full path to the .eeg file
+        entfile (string) :
+            Full path to the .ent file (optional). If None, the path to the ent
+            file is inferred from the filename by adding the ".ent" extension
+            to it
+        posfile (string) :
+            Full path to the .pos file (optional). If None, the path to the pos
+            file is inferred from the filename by adding the ".pos" extension
+            to it
     """
     _prefered_signal_group_mode = 'group-by-same-units'
     _default_group_mode_have_change_in_0_9 = True
 
-    def __init__(self, filename, entfile='', posfile=''):
+    def __init__(self, filename, entfile=None, posfile=None):
         ElanRawIO.__init__(self, filename=filename, entfile=entfile,
                            posfile=posfile)
         BaseFromRaw.__init__(self, filename)

--- a/neo/io/elanio.py
+++ b/neo/io/elanio.py
@@ -15,6 +15,7 @@ class ElanIO(ElanRawIO, BaseFromRaw):
     _prefered_signal_group_mode = 'group-by-same-units'
     _default_group_mode_have_change_in_0_9 = True
 
-    def __init__(self, filename):
-        ElanRawIO.__init__(self, filename=filename)
+    def __init__(self, filename, entfile='', posfile=''):
+        ElanRawIO.__init__(self, filename=filename, entfile=entfile,
+                           posfile=posfile)
         BaseFromRaw.__init__(self, filename)

--- a/neo/rawio/elanrawio.py
+++ b/neo/rawio/elanrawio.py
@@ -31,13 +31,21 @@ class ElanRawIO(BaseRawIO):
     extensions = ['eeg']
     rawmode = 'one-file'
 
-    def __init__(self, filename=''):
+    def __init__(self, filename='', entfile='', posfile=''):
         BaseRawIO.__init__(self)
         self.filename = filename
 
+        # check whether ent and pos files are defined
+        if not entfile:
+            entfile = self.filename + '.ent'
+        if not posfile:
+            posfile = self.filename + '.pos'
+        self.entfile = entfile
+        self.posfile = posfile
+
     def _parse_header(self):
 
-        with open(self.filename + '.ent', mode='rt', encoding='ascii', newline=None) as f:
+        with open(self.entfile, mode='rt', encoding='ascii', newline=None) as f:
 
             # version
             version = f.readline()[:-1]
@@ -139,12 +147,12 @@ class ElanRawIO(BaseRawIO):
         self._raw_signals = self._raw_signals[:, :-2]
 
         # triggers
-        with open(self.filename + '.pos', mode='rt', encoding='ascii', newline=None) as f:
+        with open(self.posfile, mode='rt', encoding='ascii', newline=None) as f:
             self._raw_event_timestamps = []
             self._event_labels = []
             self._reject_codes = []
             for l in f.readlines():
-                r = re.findall(r' *(\d+) *(\d+) *(\d+) *', l)
+                r = re.findall(r' *(\d+)\s* *(\d+)\s* *(\d+) *', l)
                 self._raw_event_timestamps.append(int(r[0][0]))
                 self._event_labels.append(str(r[0][1]))
                 self._reject_codes.append(str(r[0][2]))

--- a/neo/rawio/elanrawio.py
+++ b/neo/rawio/elanrawio.py
@@ -36,9 +36,9 @@ class ElanRawIO(BaseRawIO):
         self.filename = filename
 
         # check whether ent and pos files are defined
-        if not entfile:
+        if entfile is None:
             entfile = self.filename + '.ent'
-        if not posfile:
+        if posfile is None:
             posfile = self.filename + '.pos'
         self.entfile = entfile
         self.posfile = posfile

--- a/neo/rawio/elanrawio.py
+++ b/neo/rawio/elanrawio.py
@@ -31,7 +31,7 @@ class ElanRawIO(BaseRawIO):
     extensions = ['eeg']
     rawmode = 'one-file'
 
-    def __init__(self, filename='', entfile='', posfile=''):
+    def __init__(self, filename=None, entfile=None, posfile=None):
         BaseRawIO.__init__(self)
         self.filename = filename
 


### PR DESCRIPTION
Hi,

I'm using Neo for reading Elan files (.eeg, .ent, .pos). However, by default the class only support the same base name for all three  files. In my case, they have different names and unfortunately I'm not allowed to change it.

In addition to that, maybe the default event encoding changed, but the events are not correctly detected. 