### PR TITLE
Good channel order for old openephys format.

### DIFF
--- a/neo/test/rawiotest/test_openephysrawio.py
+++ b/neo/test/rawiotest/test_openephysrawio.py
@@ -72,6 +72,12 @@ class TestOpenEphysRawIO(BaseTestRawIO, unittest.TestCase, ):
         with self.assertRaises(Exception):
             reader.parse_header()
 
+    def test_channel_order(self):
+        reader = OpenEphysRawIO(dirname=self.get_filename_path(
+            'OpenEphys_SampleData_1'))
+        reader.parse_header()
+        reader.header['signal_channels']['name'][0].startswith('CH')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In old implementation channel order was not the natural one.
"CH" channels where put after the "ADC" channels. This was the total inverse of the sofwtare.
This put the good order.