### PR TITLE
Rawio improvement

### DIFF
--- a/doc/source/rawio.rst
+++ b/doc/source/rawio.rst
@@ -77,11 +77,11 @@ Then browse the internal header and display information::
     nb_block: 1
     nb_segment:  [1]
     signal_channels: [V1]
-    unit_channels: [Wspk1u, Wspk2u, Wspk4u, Wspk5u ... Wspk29u Wspk30u Wspk31u Wspk32u]
+    spike_channels: [Wspk1u, Wspk2u, Wspk4u, Wspk5u ... Wspk29u Wspk30u Wspk31u Wspk32u]
     event_channels: []
 
 You get the number of blocks and segments per block. You have information
-about channels: **signal_channels**, **unit_channels**, **event_channels**.
+about channels: **signal_channels**, **spike_channels**, **event_channels**.
 
 All this information is internally available in the *header* dict::
 
@@ -91,7 +91,7 @@ All this information is internally available in the *header* dict::
     event_channels []
     nb_segment [1]
     nb_block 1
-    unit_channels [('Wspk1u', 'ch1#0', '',  0.00146484,  0., 0,  30000.)
+    spike_channels [('Wspk1u', 'ch1#0', '',  0.00146484,  0., 0,  30000.)
     ('Wspk2u', 'ch2#0', '',  0.00146484,  0., 0,  30000.)
     ...
 
@@ -141,7 +141,7 @@ Inspect units channel. Each channel gives a SpikeTrain for each Segment.
 Note that for many formats a physical channel can have several units after spike
 sorting. So the nb_unit could be more than physical channel or signal channels.
 
-    >>> nb_unit = reader.unit_channels_count()
+    >>> nb_unit = reader.spike_channels_count()
     >>> print('nb_unit', nb_unit)
     nb_unit 30
     >>> for unit_index in range(nb_unit):

--- a/examples/read_files_neo_rawio.py
+++ b/examples/read_files_neo_rawio.py
@@ -32,7 +32,7 @@ print(float_sigs.shape, float_sigs.dtype)
 print(sampling_rate, t_start, units)
 
 # Count unit and spike per units
-nb_unit = reader.unit_channels_count()
+nb_unit = reader.spike_channels_count()
 print('nb_unit', nb_unit)
 for unit_index in range(nb_unit):
     nb_spike = reader.spike_count(block_index=0, seg_index=0, unit_index=unit_index)

--- a/neo/io/basefromrawio.py
+++ b/neo/io/basefromrawio.py
@@ -150,13 +150,13 @@ class BaseFromRaw(BaseIO):
                         sig_groups.append(group)
 
         if create_group_across_segment['SpikeTrain']:
-            unit_channels = self.header['unit_channels']
+            spike_channels = self.header['spike_channels']
             st_groups = []
-            for c in range(unit_channels.size):
+            for c in range(spike_channels.size):
                 group = Group(name='SpikeTrain group {}'.format(c))
-                group.annotate(unit_name=unit_channels[c]['name'])
-                group.annotate(unit_id=unit_channels[c]['id'])
-                unit_annotations = self.raw_annotations['unit_channels'][c]
+                group.annotate(unit_name=spike_channels[c]['name'])
+                group.annotate(unit_id=spike_channels[c]['id'])
+                unit_annotations = self.raw_annotations['spike_channels'][c]
                 unit_annotations = check_annotations(unit_annotations)
                 group.annotate(**unit_annotations)
                 bl.groups.append(group)
@@ -259,8 +259,8 @@ class BaseFromRaw(BaseIO):
                     seg.analogsignals.append(anasig)
 
         # SpikeTrain and waveforms (optional)
-        unit_channels = self.header['unit_channels']
-        for unit_index in range(len(unit_channels)):
+        spike_channels = self.header['spike_channels']
+        for unit_index in range(len(spike_channels)):
             # make a proxy...
             sptr = SpikeTrainProxy(rawio=self, unit_index=unit_index,
                                                 block_index=block_index, seg_index=seg_index)

--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -311,11 +311,11 @@ class SpikeTrainProxy(BaseProxy):
         # both necessary attr and annotations
         annotations = {}
         for k in ('name', 'id'):
-            annotations[k] = self._rawio.header['unit_channels'][unit_index][k]
+            annotations[k] = self._rawio.header['spike_channels'][unit_index][k]
         ann = self._rawio.raw_annotations['blocks'][block_index]['segments'][seg_index]['units'][unit_index]
         annotations.update(ann)
 
-        h = self._rawio.header['unit_channels'][unit_index]
+        h = self._rawio.header['spike_channels'][unit_index]
         wf_sampling_rate = h['wf_sampling_rate']
         if not np.isnan(wf_sampling_rate) and wf_sampling_rate > 0:
             self.sampling_rate = wf_sampling_rate * pq.Hz

--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -86,17 +86,24 @@ class AnalogSignalProxy(BaseProxy):
     _recommended_attrs = BaseNeo._recommended_attrs
     proxy_for = AnalogSignal
 
-    def __init__(self, rawio=None, global_channel_indexes=None, block_index=0, seg_index=0):
+    def __init__(self, rawio=None, stream_index=None, block_index=0, seg_index=0):
         self._rawio = rawio
         self._block_index = block_index
         self._seg_index = seg_index
-        if global_channel_indexes is None:
-            global_channel_indexes = slice(None)
-        total_nb_chan = self._rawio.header['signal_channels'].size
-        self._global_channel_indexes = np.arange(total_nb_chan)[global_channel_indexes]
+        self._stream_index = stream_index
+        #~ if global_channel_indexes is None:
+            #~ global_channel_indexes = slice(None)
+        #~ total_nb_chan = self._rawio.header['signal_channels'].size
+        #~ self._global_channel_indexes = np.arange(total_nb_chan)[global_channel_indexes]
+        #~ self._nb_chan = self._global_channel_indexes.size
+        
+        signal_streams = self._rawio.header['signal_streams']
+        stream_id = signal_streams[stream_index]['id']
+        signal_channels = self._rawio.header['signal_channels']
+        self._global_channel_indexes, = np.nonzero(signal_channels['stream_id'] == stream_id)
         self._nb_chan = self._global_channel_indexes.size
 
-        sig_chans = self._rawio.header['signal_channels'][self._global_channel_indexes]
+        sig_chans = signal_channels[self._global_channel_indexes]
 
         assert np.unique(sig_chans['units']).size == 1, 'Channel do not have same units'
         assert np.unique(sig_chans['dtype']).size == 1, 'Channel do not have same dtype'
@@ -108,10 +115,9 @@ class AnalogSignalProxy(BaseProxy):
         self.sampling_rate = sig_chans['sampling_rate'][0] * pq.Hz
         self.sampling_period = 1. / self.sampling_rate
         sigs_size = self._rawio.get_signal_size(block_index=block_index, seg_index=seg_index,
-                                        channel_indexes=self._global_channel_indexes)
+                                        stream_index=stream_index)
         self.shape = (sigs_size, self._nb_chan)
-        self.t_start = self._rawio.get_signal_t_start(block_index, seg_index,
-                                    self._global_channel_indexes) * pq.s
+        self.t_start = self._rawio.get_signal_t_start(block_index, seg_index,stream_index) * pq.s
 
         # magnitude_mode='raw' is supported only if all offset=0
         # and all gain are the same
@@ -120,44 +126,48 @@ class AnalogSignalProxy(BaseProxy):
 
         if support_raw_magnitude:
             str_units = ensure_signal_units(sig_chans['units'][0]).units.dimensionality.string
-            self._raw_units = pq.CompoundUnit('{}*{}'.format(sig_chans['gain'][0], str_units))
+            gain0 = sig_chans['gain'][0]
+            self._raw_units = pq.CompoundUnit(f'{gain0}*{str_units}')
         else:
             self._raw_units = None
 
-        # both necessary attr and annotations
-        annotations = {}
-        annotations['name'] = self._make_name(None)
-        if len(sig_chans) == 1:
-            # when only one channel raw_annotations are set to standart annotations
-            d = self._rawio.raw_annotations['blocks'][block_index]['segments'][seg_index][
-                'signals'][self._global_channel_indexes[0]]
-            annotations.update(d)
+        # retrieve annotations and array annotations
+        ann = self._rawio.raw_annotations['blocks'][block_index]['segments'][seg_index]['signals'][stream_index]
+        annotations = ann.copy()
+        array_annotations = annotations.pop('__array_annotations__')
+        
+        #~ annotations['name'] = self._make_name(None)
+        #~ if len(sig_chans) == 1:
+            #~ # when only one channel raw_annotations are set to standart annotations
+            #~ d = self._rawio.raw_annotations['blocks'][block_index]['segments'][seg_index][
+                #~ 'signals'][self._global_channel_indexes[0]]
+            #~ annotations.update(d)
 
-        array_annotations = {
-            'channel_names': np.array(sig_chans['name'], copy=True),
-            'channel_ids': np.array(sig_chans['id'], copy=True),
-        }
-        # array annotations for signal can be at 2 places
-        # global at signal channel level
-        d = self._rawio.raw_annotations['signal_channels']
-        array_annotations.update(create_analogsignal_array_annotations(
-                                                d, self._global_channel_indexes))
-        # or specific to block/segment/signals
-        d = self._rawio.raw_annotations['blocks'][block_index]['segments'][seg_index]['signals']
-        array_annotations.update(create_analogsignal_array_annotations(
-                                                d, self._global_channel_indexes))
+        #~ array_annotations = {
+            #~ 'channel_names': np.array(sig_chans['name'], copy=True),
+            #~ 'channel_ids': np.array(sig_chans['id'], copy=True),
+        #~ }
+        #~ # array annotations for signal can be at 2 places
+        #~ # global at signal channel level
+        #~ d = self._rawio.raw_annotations['signal_channels']
+        #~ array_annotations.update(create_analogsignal_array_annotations(
+                                                #~ d, self._global_channel_indexes))
+        #~ # or specific to block/segment/signals
+        #~ d = self._rawio.raw_annotations['blocks'][block_index]['segments'][seg_index]['signals']
+        #~ array_annotations.update(create_analogsignal_array_annotations(
+                                                #~ d, self._global_channel_indexes))
 
         BaseProxy.__init__(self, array_annotations=array_annotations, **annotations)
 
-    def _make_name(self, channel_indexes):
-        sig_chans = self._rawio.header['signal_channels'][self._global_channel_indexes]
-        if channel_indexes is not None:
-            sig_chans = sig_chans[channel_indexes]
-        if len(sig_chans) == 1:
-            name = sig_chans['name'][0]
-        else:
-            name = 'Channel bundle ({}) '.format(','.join(sig_chans['name']))
-        return name
+    #~ def _make_name(self, channel_indexes):
+        #~ sig_chans = self._rawio.header['signal_channels'][self._global_channel_indexes]
+        #~ if channel_indexes is not None:
+            #~ sig_chans = sig_chans[channel_indexes]
+        #~ if len(sig_chans) == 1:
+            #~ name = sig_chans['name'][0]
+        #~ else:
+            #~ name = 'Channel bundle ({}) '.format(','.join(sig_chans['name']))
+        #~ return name
 
     @property
     def duration(self):
@@ -226,12 +236,14 @@ class AnalogSignalProxy(BaseProxy):
                 i_stop = int((t_stop - self.t_start).magnitude * sr.magnitude)
 
         raw_signal = self._rawio.get_analogsignal_chunk(block_index=self._block_index,
-                    seg_index=self._seg_index, i_start=i_start, i_stop=i_stop,
-                    channel_indexes=self._global_channel_indexes[channel_indexes])
+                    seg_index=self._seg_index, i_start=i_start, i_stop=i_stop, 
+                    stream_index=self._stream_index, channel_indexes=channel_indexes)
+                    #~ channel_indexes=self._global_channel_indexes[channel_indexes])
 
         # if slice in channel : change name and array_annotations
         if raw_signal.shape[1] != self._nb_chan:
-            name = self._make_name(channel_indexes)
+            #~ name = self._make_name(channel_indexes)
+            name = 'slice of  ' + self.name
             array_annotations = {k: v[channel_indexes] for k, v in self.array_annotations.items()}
         else:
             name = self.name
@@ -248,8 +260,9 @@ class AnalogSignalProxy(BaseProxy):
                 dtype = 'float64'
             else:
                 dtype = 'float32'
-            sig = self._rawio.rescale_signal_raw_to_float(raw_signal, dtype=dtype,
-                                    channel_indexes=self._global_channel_indexes[channel_indexes])
+            sig = self._rawio.rescale_signal_raw_to_float(raw_signal, dtype=dtype, 
+                                    stream_index=self._stream_index, channel_indexes=channel_indexes)
+                                    #~ channel_indexes=self._global_channel_indexes[channel_indexes])
             units = self.units
 
         anasig = AnalogSignal(sig, units=units, copy=False, t_start=sig_t_start,
@@ -294,28 +307,25 @@ class SpikeTrainProxy(BaseProxy):
     _recommended_attrs = ()
     proxy_for = SpikeTrain
 
-    def __init__(self, rawio=None, unit_index=None, block_index=0, seg_index=0):
+    def __init__(self, rawio=None, spike_channel_index=None, block_index=0, seg_index=0):
 
         self._rawio = rawio
         self._block_index = block_index
         self._seg_index = seg_index
-        self._unit_index = unit_index
+        self._spike_channel_index = spike_channel_index
 
         nb_spike = self._rawio.spike_count(block_index=block_index, seg_index=seg_index,
-                                        unit_index=unit_index)
+                                        spike_channel_index=spike_channel_index)
         self.shape = (nb_spike, )
 
         self.t_start = self._rawio.segment_t_start(block_index, seg_index) * pq.s
         self.t_stop = self._rawio.segment_t_stop(block_index, seg_index) * pq.s
 
-        # both necessary attr and annotations
-        annotations = {}
-        for k in ('name', 'id'):
-            annotations[k] = self._rawio.header['spike_channels'][unit_index][k]
-        ann = self._rawio.raw_annotations['blocks'][block_index]['segments'][seg_index]['units'][unit_index]
-        annotations.update(ann)
+        ann = self._rawio.raw_annotations['blocks'][block_index]['segments'][seg_index]['spikes'][spike_channel_index]
+        annotations = ann.copy()
+        array_annotations = annotations.pop('__array_annotations__')
 
-        h = self._rawio.header['spike_channels'][unit_index]
+        h = self._rawio.header['spike_channels'][spike_channel_index]
         wf_sampling_rate = h['wf_sampling_rate']
         if not np.isnan(wf_sampling_rate) and wf_sampling_rate > 0:
             self.sampling_rate = wf_sampling_rate * pq.Hz
@@ -324,8 +334,8 @@ class SpikeTrainProxy(BaseProxy):
         else:
             self.sampling_rate = None
             self.left_sweep = None
-
-        BaseProxy.__init__(self, **annotations)
+        
+        BaseProxy.__init__(self, array_annotations=array_annotations, **annotations)
 
     def load(self, time_slice=None, strict_slicing=True,
                     magnitude_mode='rescaled', load_waveforms=False):
@@ -345,7 +355,7 @@ class SpikeTrainProxy(BaseProxy):
         _t_start, _t_stop = prepare_time_slice(time_slice)
 
         spike_timestamps = self._rawio.get_spike_timestamps(block_index=self._block_index,
-                        seg_index=self._seg_index, unit_index=self._unit_index, t_start=_t_start,
+                        seg_index=self._seg_index, spike_channel_index=self._spike_channel_index, t_start=_t_start,
                         t_stop=_t_stop)
 
         if magnitude_mode == 'raw':
@@ -361,11 +371,11 @@ class SpikeTrainProxy(BaseProxy):
             assert self.sampling_rate is not None, 'Do not have waveforms'
 
             raw_wfs = self._rawio.get_spike_raw_waveforms(block_index=self._block_index,
-                seg_index=self._seg_index, unit_index=self._unit_index,
+                seg_index=self._seg_index, spike_channel_index=self._spike_channel_index,
                             t_start=_t_start, t_stop=_t_stop)
             if magnitude_mode == 'rescaled':
                 float_wfs = self._rawio.rescale_waveforms_to_float(raw_wfs,
-                                dtype='float32', unit_index=self._unit_index)
+                                dtype='float32', spike_channel_index=self._spike_channel_index)
                 waveforms = pq.Quantity(float_wfs, units=self._wf_units,
                             dtype='float32', copy=False)
             elif magnitude_mode == 'raw':
@@ -380,7 +390,14 @@ class SpikeTrainProxy(BaseProxy):
                 t_start=t_start, copy=False, sampling_rate=self.sampling_rate,
                 waveforms=waveforms, left_sweep=self.left_sweep, name=self.name,
                 file_origin=self.file_origin, description=self.description, **self.annotations)
+        
+        if time_slice is None:
+            sptr.array_annotate(**self.array_annotations)
+        else:
+            # TODO handle array_annotations with time_slice
+            pass
 
+        
         return sptr
 
 
@@ -409,7 +426,12 @@ class _EventOrEpoch(BaseProxy):
         ann = self._rawio.raw_annotations['blocks'][block_index]['segments'][seg_index]['events'][event_channel_index]
         annotations.update(ann)
 
-        BaseProxy.__init__(self, **annotations)
+
+        ann = self._rawio.raw_annotations['blocks'][block_index]['segments'][seg_index]['events'][event_channel_index]
+        annotations = ann.copy()
+        array_annotations = annotations.pop('__array_annotations__')
+        
+        BaseProxy.__init__(self, array_annotations=array_annotations, **annotations)
 
     def load(self, time_slice=None, strict_slicing=True):
         '''
@@ -424,7 +446,8 @@ class _EventOrEpoch(BaseProxy):
         t_start, t_stop = consolidate_time_slice(time_slice, self.t_start,
                                                                     self.t_stop, strict_slicing)
         _t_start, _t_stop = prepare_time_slice(time_slice)
-
+    
+        
         timestamp, durations, labels = self._rawio.get_event_timestamps(block_index=self._block_index,
                         seg_index=self._seg_index, event_channel_index=self._event_channel_index,
                         t_start=_t_start, t_stop=_t_stop)
@@ -435,7 +458,9 @@ class _EventOrEpoch(BaseProxy):
 
         if durations is not None:
             durations = self._rawio.rescale_epoch_duration(durations, dtype=dtype) * pq.s
-
+        
+        
+        
         h = self._rawio.header['event_channels'][self._event_channel_index]
         if h['type'] == b'event':
             ret = Event(times=times, labels=labels, units='s',
@@ -447,6 +472,12 @@ class _EventOrEpoch(BaseProxy):
                 name=self.name, file_origin=self.file_origin,
                 description=self.description, **self.annotations)
 
+        if time_slice is None:
+            ret.array_annotate(**self.array_annotations)
+        else:
+            # TODO handle array_annotations with time_slice
+            pass
+        
         return ret
 
 
@@ -607,31 +638,31 @@ def consolidate_time_slice(time_slice, seg_t_start, seg_t_stop, strict_slicing):
     return (t_start, t_stop)
 
 
-def create_analogsignal_array_annotations(sig_annotations, global_channel_indexes):
-    """
-    Create array_annotations from raw_annoations.
-    Since raw_annotation are not np.array but nested dict, this func
-    try to find keys in raw_annotation that are shared by all channel
-    and make array_annotation with it.
-    """
-    # intersection of keys across channels
-    common_keys = None
-    for ind in global_channel_indexes:
-        keys = [k for k, v in sig_annotations[ind].items() if not \
-                    isinstance(v, (list, tuple, np.ndarray))]
-        if common_keys is None:
-            common_keys = keys
-        else:
-            common_keys = [k for k in common_keys if k in keys]
+#~ def create_analogsignal_array_annotations(sig_annotations, global_channel_indexes):
+    #~ """
+    #~ Create array_annotations from raw_annoations.
+    #~ Since raw_annotation are not np.array but nested dict, this func
+    #~ try to find keys in raw_annotation that are shared by all channel
+    #~ and make array_annotation with it.
+    #~ """
+    #~ # intersection of keys across channels
+    #~ common_keys = None
+    #~ for ind in global_channel_indexes:
+        #~ keys = [k for k, v in sig_annotations[ind].items() if not \
+                    #~ isinstance(v, (list, tuple, np.ndarray))]
+        #~ if common_keys is None:
+            #~ common_keys = keys
+        #~ else:
+            #~ common_keys = [k for k in common_keys if k in keys]
 
-    # this is redundant and done with other name
-    for k in ['name', 'channel_id']:
-        if k in common_keys:
-            common_keys.remove(k)
+    #~ # this is redundant and done with other name
+    #~ for k in ['name', 'channel_id']:
+        #~ if k in common_keys:
+            #~ common_keys.remove(k)
 
-    array_annotations = {}
-    for k in common_keys:
-        values = [sig_annotations[ind][k] for ind in global_channel_indexes]
-        array_annotations[k] = np.array(values)
+    #~ array_annotations = {}
+    #~ for k in common_keys:
+        #~ values = [sig_annotations[ind][k] for ind in global_channel_indexes]
+        #~ array_annotations[k] = np.array(values)
 
-    return array_annotations
+    #~ return array_annotations

--- a/neo/rawio/axographrawio.py
+++ b/neo/rawio/axographrawio.py
@@ -154,7 +154,7 @@ Acquisition modes:
     Intervals".
 """
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import os
@@ -1316,8 +1316,8 @@ class AxographRawIO(BaseRawIO):
             np.array(sig_channels, dtype=_signal_channel_dtype)
         self.header['event_channels'] = \
             np.array(event_channels, dtype=_event_channel_dtype)
-        self.header['unit_channels'] = \
-            np.array([], dtype=_unit_channel_dtype)
+        self.header['spike_channels'] = \
+            np.array([], dtype=_spike_channel_dtype)
 
         ##############################################
         # DATA OBJECTS

--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -33,7 +33,7 @@ Note: j.s.nowacki@gmail.com has a C++ library with SWIG bindings which also
 reads abf files - would be good to cross-check
 
 """
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -215,15 +215,15 @@ class AxonRawIO(BaseRawIO):
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # No spikes
-        unit_channels = []
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # fille into header dict
         self.header = {}
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [nb_segment]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # insert some annotation at some place

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -72,7 +72,7 @@ _signal_channel_dtype = [
     ('gain', 'float64'),
     ('offset', 'float64'),
     ('group_id', 'int64'),
-    ('local_index', 'int64'),
+    # ('local_index', 'int64'),
 ]
 
 _common_sig_characteristics = ['sampling_rate', 'dtype', 'stream_id']

--- a/neo/rawio/bci2000rawio.py
+++ b/neo/rawio/bci2000rawio.py
@@ -3,7 +3,7 @@ BCI2000RawIO is a class to read BCI2000 .dat files.
 https://www.bci2000.org/mediawiki/index.php/Technical_Reference:BCI2000_File_Format
 """
 
-from .baserawio import BaseRawIO, _signal_channel_dtype, _unit_channel_dtype, _event_channel_dtype
+from .baserawio import BaseRawIO, _signal_channel_dtype, _spike_channel_dtype, _event_channel_dtype
 
 import numpy as np
 import re
@@ -62,7 +62,7 @@ class BCI2000RawIO(BaseRawIO):
             sig_channels.append((ch_name, chan_id, sr, dtype, units, gain, offset, group_id))
         self.header['signal_channels'] = np.array(sig_channels, dtype=_signal_channel_dtype)
 
-        self.header['unit_channels'] = np.array([], dtype=_unit_channel_dtype)
+        self.header['spike_channels'] = np.array([], dtype=_spike_channel_dtype)
 
         # creating event channel for each state variable
         event_channels = []

--- a/neo/rawio/brainvisionrawio.py
+++ b/neo/rawio/brainvisionrawio.py
@@ -7,7 +7,7 @@ S. More.
 Author: Samuel Garcia
 """
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -78,8 +78,8 @@ class BrainVisionRawIO(BaseRawIO):
         sig_channels = np.array(sig_channels, dtype=_signal_channel_dtype)
 
         # No spikes
-        unit_channels = []
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # read all markers in memory
 
@@ -113,7 +113,7 @@ class BrainVisionRawIO(BaseRawIO):
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [1]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         self._generate_minimal_annotations()

--- a/neo/rawio/elanrawio.py
+++ b/neo/rawio/elanrawio.py
@@ -16,7 +16,7 @@ Author: Samuel Garcia
 
 """
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -166,15 +166,15 @@ class ElanRawIO(BaseRawIO):
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # No spikes
-        unit_channels = []
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # fille into header dict
         self.header = {}
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [1]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # insert some annotation at some place

--- a/neo/rawio/examplerawio.py
+++ b/neo/rawio/examplerawio.py
@@ -17,7 +17,7 @@ Rules for creating a new class:
             self.header['nb_block'] = 2
             self.header['nb_segment'] = [2, 3]
             self.header['signal_channels'] = sig_channels
-            self.header['unit_channels'] = unit_channels
+            self.header['spike_channels'] = spike_channels
             self.header['event_channels'] = event_channels
 
   2. Step 2: RawIO test:
@@ -37,7 +37,7 @@ Rules for creating a new class:
 
 """
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -61,7 +61,7 @@ class ExampleRawIO(BaseRawIO):
         * has 2 blocks
         * blocks have 2 and 3 segments
         * has 16 signal_channels sample_rate = 10000
-        * has 3 unit_channels
+        * has 3 spike_channels
         * has 2 event channels: one has *type=event*, the other has
           *type=epoch*
 
@@ -96,7 +96,7 @@ class ExampleRawIO(BaseRawIO):
         return self.filename
 
     def _parse_header(self):
-        # This is the central of a RawIO
+        # This is the central part of a RawIO
         # we need to collect in the original format all
         # informations needed for further fast access
         # at any place in the file
@@ -134,7 +134,7 @@ class ExampleRawIO(BaseRawIO):
         # then wf_units/wf_gain/wf_offset/wf_left_sweep/wf_sampling_rate
         # can be set to any value because _spike_raw_waveforms
         # will return None
-        unit_channels = []
+        spike_channels = []
         for c in range(3):
             unit_name = 'unit{}'.format(c)
             unit_id = '#{}'.format(c)
@@ -143,9 +143,9 @@ class ExampleRawIO(BaseRawIO):
             wf_offset = 0.
             wf_left_sweep = 20
             wf_sampling_rate = 10000.
-            unit_channels.append((unit_name, unit_id, wf_units, wf_gain,
+            spike_channels.append((unit_name, unit_id, wf_units, wf_gain,
                                   wf_offset, wf_left_sweep, wf_sampling_rate))
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # creating event/epoch channel
         # This is mandatory!!!!
@@ -161,7 +161,7 @@ class ExampleRawIO(BaseRawIO):
         self.header['nb_block'] = 2
         self.header['nb_segment'] = [2, 3]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # insert some annotation at some place
@@ -302,7 +302,7 @@ class ExampleRawIO(BaseRawIO):
 
         # In our IO waveforms come from all channels
         # they are int16
-        # convertion to real units is done with self.header['unit_channels']
+        # convertion to real units is done with self.header['spike_channels']
         # Here, we have a realistic case: all waveforms are only noise.
         # it is not always the case
         # we 20 spikes with a sweep of 50 (5ms)

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -18,7 +18,7 @@ Author: Samuel Garcia
 """
 # from __future__ import unicode_literals is not compatible with numpy.dtype both py2 py3
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -81,15 +81,15 @@ class IntanRawIO(BaseRawIO):
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # No spikes
-        unit_channels = []
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # fille into header dict
         self.header = {}
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [1]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         self._generate_minimal_annotations()

--- a/neo/rawio/mearecrawio.py
+++ b/neo/rawio/mearecrawio.py
@@ -9,7 +9,7 @@ https://link.springer.com/article/10.1007/s12021-020-09467-7
 Author : Alessio Buccino
 """
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -71,7 +71,7 @@ class MEArecRawIO(BaseRawIO):
         sig_channels = np.array(sig_channels, dtype=_signal_channel_dtype)
 
         # creating units channels
-        unit_channels = []
+        spike_channels = []
         self._spiketrains = self._recgen.spiketrains
         for c in range(len(self._spiketrains)):
             unit_name = 'unit{}'.format(c)
@@ -82,9 +82,9 @@ class MEArecRawIO(BaseRawIO):
             wf_offset = 0.
             wf_left_sweep = 0
             wf_sampling_rate = self._sampling_rate
-            unit_channels.append((unit_name, unit_id, wf_units, wf_gain,
+            spike_channels.append((unit_name, unit_id, wf_units, wf_gain,
                                   wf_offset, wf_left_sweep, wf_sampling_rate))
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         event_channels = []
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
@@ -93,7 +93,7 @@ class MEArecRawIO(BaseRawIO):
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [1]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         self._generate_minimal_annotations()

--- a/neo/rawio/micromedrawio.py
+++ b/neo/rawio/micromedrawio.py
@@ -9,7 +9,7 @@ Author: Samuel Garcia
 # from __future__ import unicode_literals is not compatible with numpy.dtype both py2 py3
 
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -142,15 +142,15 @@ class MicromedRawIO(BaseRawIO):
                 self._raw_events.append(rawevent)
 
             # No spikes
-            unit_channels = []
-            unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+            spike_channels = []
+            spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
             # fille into header dict
             self.header = {}
             self.header['nb_block'] = 1
             self.header['nb_segment'] = [1]
             self.header['signal_channels'] = sig_channels
-            self.header['unit_channels'] = unit_channels
+            self.header['spike_channels'] = spike_channels
             self.header['event_channels'] = event_channels
 
             # insert some annotation at some place

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -17,7 +17,7 @@ Author: Julia Sprenger, Carlos Canova, Samuel Garcia, Peter N. Steinmetz.
 # from __future__ import unicode_literals is not compatible with numpy.dtype both py2 py3
 
 
-from neo.rawio.baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from neo.rawio.baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                                  _event_channel_dtype)
 
 import numpy as np
@@ -70,7 +70,7 @@ class NeuralynxRawIO(BaseRawIO):
     def _parse_header(self):
 
         sig_channels = []
-        unit_channels = []
+        spike_channels = []
         event_channels = []
 
         self.ncs_filenames = OrderedDict()  # (chan_name, chan_id): filename
@@ -183,7 +183,7 @@ class NeuralynxRawIO(BaseRawIO):
                         wf_offset = 0.
                         wf_left_sweep = -1  # NOT KNOWN
                         wf_sampling_rate = info['sampling_rate']
-                        unit_channels.append(
+                        spike_channels.append(
                             (unit_name, '{}'.format(unit_id), wf_units, wf_gain,
                              wf_offset, wf_left_sweep, wf_sampling_rate))
                         unit_annotations.append(dict(file_origin=filename))
@@ -212,7 +212,7 @@ class NeuralynxRawIO(BaseRawIO):
                     self._nev_memmap[chan_id] = data
 
         sig_channels = np.array(sig_channels, dtype=_signal_channel_dtype)
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # require all sampled signals, ncs files, to have same sampling rate
@@ -281,7 +281,7 @@ class NeuralynxRawIO(BaseRawIO):
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [self._nb_segment]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # Annotations
@@ -295,7 +295,7 @@ class NeuralynxRawIO(BaseRawIO):
                 sig_ann = seg_annotations['signals'][c]
                 sig_ann.update(signal_annotations[c])
 
-            for c in range(unit_channels.size):
+            for c in range(spike_channels.size):
                 unit_ann = seg_annotations['units'][c]
                 unit_ann.update(unit_annotations[c])
 

--- a/neo/rawio/neuroscoperawio.py
+++ b/neo/rawio/neuroscoperawio.py
@@ -16,7 +16,7 @@ Author: Samuel Garcia
 
 """
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -84,15 +84,15 @@ class NeuroScopeRawIO(BaseRawIO):
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # No spikes
-        unit_channels = []
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # fille into header dict
         self.header = {}
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [1]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         self._generate_minimal_annotations()

--- a/neo/rawio/nixrawio.py
+++ b/neo/rawio/nixrawio.py
@@ -8,7 +8,7 @@ Author: Chek Yin Choi
 """
 
 from .baserawio import (BaseRawIO, _signal_channel_dtype,
-                        _unit_channel_dtype, _event_channel_dtype)
+                        _spike_channel_dtype, _event_channel_dtype)
 from ..io.nixio import NixIO
 from ..io.nixio import check_nix_version
 import numpy as np
@@ -77,7 +77,7 @@ class NIXRawIO(BaseRawIO):
             break
         sig_channels = np.array(sig_channels, dtype=_signal_channel_dtype)
 
-        unit_channels = []
+        spike_channels = []
         unit_name = ""
         unit_id = ""
         for bl in self.file.blocks:
@@ -99,13 +99,13 @@ class NIXRawIO(BaseRawIO):
                                 wf_left_sweep = wf.metadata["left_sweep"]
                         wf_gain = 1
                         wf_offset = 0.
-                        unit_channels.append(
+                        spike_channels.append(
                             (unit_name, unit_id, wf_units, wf_gain,
                              wf_offset, wf_left_sweep, wf_sampling_rate)
                         )
                 break
             break
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         event_channels = []
         event_count = 0
@@ -184,7 +184,7 @@ class NIXRawIO(BaseRawIO):
         self.header['nb_block'] = len(self.file.blocks)
         self.header['nb_segment'] = [len(bl.groups) for bl in self.file.blocks]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         self._generate_minimal_annotations()
@@ -289,7 +289,7 @@ class NIXRawIO(BaseRawIO):
 
     def _spike_count(self, block_index, seg_index, unit_index):
         count = 0
-        head_id = self.header['unit_channels'][unit_index][1]
+        head_id = self.header['spike_channels'][unit_index][1]
         for mt in self.file.blocks[block_index].groups[seg_index].multi_tags:
             for src in mt.sources:
                 if mt.type == 'neo.spiketrain' and [src.type == "neo.unit"]:

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -9,7 +9,7 @@ import re
 
 import numpy as np
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 
@@ -163,7 +163,7 @@ class OpenEphysRawIO(BaseRawIO):
         self._sig_sampling_rate = sig_channels['sampling_rate'][0]  # unique for channel
 
         # scan for spikes files
-        unit_channels = []
+        spike_channels = []
 
         if len(info['spikes']) > 0:
 
@@ -216,10 +216,10 @@ class OpenEphysRawIO(BaseRawIO):
                 for sorted_id in all_sorted_ids:
                     unit_name = "{}#{}".format(name, sorted_id)
                     unit_id = "{}#{}".format(name, sorted_id)
-                    unit_channels.append((unit_name, unit_id, wf_units,
+                    spike_channels.append((unit_name, unit_id, wf_units,
                                 wf_gain, wf_offset, wf_left_sweep, wf_sampling_rate))
 
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # event file are:
         #    * all_channel.events (header + binray)  -->  event 0
@@ -248,7 +248,7 @@ class OpenEphysRawIO(BaseRawIO):
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [nb_segment]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # Annotate some objects from coninuous files
@@ -302,7 +302,7 @@ class OpenEphysRawIO(BaseRawIO):
         return sigs_chunk
 
     def _get_spike_slice(self, seg_index, unit_index, t_start, t_stop):
-        name, sorted_id = self.header['unit_channels'][unit_index]['name'].split('#')
+        name, sorted_id = self.header['spike_channels'][unit_index]['name'].split('#')
         sorted_id = int(sorted_id)
         data_spike = self._spikes_memmap[seg_index][name]
 

--- a/neo/rawio/plexonrawio.py
+++ b/neo/rawio/plexonrawio.py
@@ -23,7 +23,7 @@ Author: Samuel Garcia
 """
 # from __future__ import unicode_literals is not compatible with numpy.dtype both py2 py3
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -186,7 +186,7 @@ class PlexonRawIO(BaseRawIO):
                 self.internal_unit_ids.append((chan_id, unit_id))
 
         # Spikes channels
-        unit_channels = []
+        spike_channels = []
         for unit_index, (chan_id, unit_id) in enumerate(self.internal_unit_ids):
             c = np.nonzero(dspChannelHeaders['Channel'] == chan_id)[0][0]
             h = dspChannelHeaders[c]
@@ -207,9 +207,9 @@ class PlexonRawIO(BaseRawIO):
             wf_offset = 0.
             wf_left_sweep = -1  # DONT KNOWN
             wf_sampling_rate = global_header['WaveformFreq']
-            unit_channels.append((name, _id, wf_units, wf_gain, wf_offset,
+            spike_channels.append((name, _id, wf_units, wf_gain, wf_offset,
                                   wf_left_sweep, wf_sampling_rate))
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # Event channels
         event_channels = []
@@ -226,7 +226,7 @@ class PlexonRawIO(BaseRawIO):
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [1]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # Annotations

--- a/neo/rawio/rawbinarysignalrawio.py
+++ b/neo/rawio/rawbinarysignalrawio.py
@@ -17,7 +17,7 @@ Important release note:
 Author: Samuel Garcia
 """
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -70,15 +70,15 @@ class RawBinarySignalRawIO(BaseRawIO):
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # No spikes
-        unit_channels = []
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # fille into header dict
         self.header = {}
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [1]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # insert some annotation at some place

--- a/neo/rawio/rawmcsrawio.py
+++ b/neo/rawio/rawmcsrawio.py
@@ -14,7 +14,7 @@ could be written instead of this ersatz.
 Author: Samuel Garcia
 """
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -58,15 +58,15 @@ class RawMCSRawIO(BaseRawIO):
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # No spikes
-        unit_channels = []
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # fille into header dict
         self.header = {}
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [1]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # insert some annotation at some place

--- a/neo/rawio/spike2rawio.py
+++ b/neo/rawio/spike2rawio.py
@@ -19,7 +19,7 @@ Author: Samuel Garcia
 """
 # from __future__ import unicode_literals is not compatible with numpy.dtype both py2 py3
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -192,7 +192,7 @@ class Spike2RawIO(BaseRawIO):
 
         # create typed channels
         sig_channels = []
-        unit_channels = []
+        spike_channels = []
         event_channels = []
 
         self.internal_unit_ids = {}
@@ -255,14 +255,14 @@ class Spike2RawIO(BaseRawIO):
                     # All spike from one channel are group in one SpikeTrain
                     unit_ids = ['all']
                 for unit_id in unit_ids:
-                    unit_index = len(unit_channels)
+                    unit_index = len(spike_channels)
                     self.internal_unit_ids[unit_index] = (chan_id, unit_id)
                     _id = "ch{}#{}".format(chan_id, unit_id)
-                    unit_channels.append((name, _id, wf_units, wf_gain, wf_offset,
+                    spike_channels.append((name, _id, wf_units, wf_gain, wf_offset,
                                           wf_left_sweep, wf_sampling_rate))
 
         sig_channels = np.array(sig_channels, dtype=_signal_channel_dtype)
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         if len(sig_channels) > 0:
@@ -300,7 +300,7 @@ class Spike2RawIO(BaseRawIO):
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [nb_segment]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # Annotations
@@ -316,7 +316,7 @@ class Spike2RawIO(BaseRawIO):
             anasig_an['physical_channel_index'] = self._channel_infos[chan_id]['phy_chan']
             anasig_an['comment'] = self._channel_infos[chan_id]['comment']
 
-        for c, unit_channel in enumerate(unit_channels):
+        for c, unit_channel in enumerate(spike_channels):
             chan_id, unit_id = self.internal_unit_ids[c]
             unit_an = seg_ann['units'][c]
             unit_an['physical_channel_index'] = self._channel_infos[chan_id]['phy_chan']
@@ -481,7 +481,7 @@ class Spike2RawIO(BaseRawIO):
                                          lim0, lim1, marker_filter=marker_filter)
 
     def _get_spike_timestamps(self, block_index, seg_index, unit_index, t_start, t_stop):
-        unit_header = self.header['unit_channels'][unit_index]
+        unit_header = self.header['spike_channels'][unit_index]
         chan_id, unit_id = self.internal_unit_ids[unit_index]
 
         if self.ced_units:
@@ -501,7 +501,7 @@ class Spike2RawIO(BaseRawIO):
         return spike_times
 
     def _get_spike_raw_waveforms(self, block_index, seg_index, unit_index, t_start, t_stop):
-        unit_header = self.header['unit_channels'][unit_index]
+        unit_header = self.header['spike_channels'][unit_index]
         chan_id, unit_id = self.internal_unit_ids[unit_index]
 
         if self.ced_units:

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -39,7 +39,7 @@ https://github.com/SpikeInterface/spikeextractors/blob/master/spikeextractors/ex
 Author : Samuel Garcia
 """
 
-from .baserawio import BaseRawIO, _signal_channel_dtype, _unit_channel_dtype, _event_channel_dtype
+from .baserawio import BaseRawIO, _signal_channel_dtype, _spike_channel_dtype, _event_channel_dtype
 
 from pathlib import Path
 import os
@@ -128,8 +128,8 @@ class SpikeGLXRawIO(BaseRawIO):
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # No spikes
-        unit_channels = []
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # deal with nb_segment and t_start/t_stop per segment
         self._t_starts = {seg_index: 0. for seg_index in range(nb_segment)}
@@ -145,7 +145,7 @@ class SpikeGLXRawIO(BaseRawIO):
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [nb_segment]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # insert some annotation at some place

--- a/neo/rawio/tdtrawio.py
+++ b/neo/rawio/tdtrawio.py
@@ -22,7 +22,7 @@ Units in this IO are not guaranteed.
 Author: Samuel Garcia, SummitKwan, Chadwick Boulay
 
 """
-from .baserawio import BaseRawIO, _signal_channel_dtype, _unit_channel_dtype, _event_channel_dtype
+from .baserawio import BaseRawIO, _signal_channel_dtype, _spike_channel_dtype, _event_channel_dtype
 
 import numpy as np
 import os
@@ -218,7 +218,7 @@ class TdtRawIO(BaseRawIO):
         self.internal_unit_ids = {}
         self._waveforms_size = []
         self._waveforms_dtype = []
-        unit_channels = []
+        spike_channels = []
         keep = info_channel_groups['TankEvType'] == EVTYPE_SNIP
         tsq = np.hstack(self._tsq)
         # If there is no chance the differet TSQ files will have different units,
@@ -231,7 +231,7 @@ class TdtRawIO(BaseRawIO):
                        (tsq['channel'] == chan_id)
                 unit_ids = np.unique(tsq[mask]['sortcode'])
                 for unit_id in unit_ids:
-                    unit_index = len(unit_channels)
+                    unit_index = len(spike_channels)
                     self.internal_unit_ids[unit_index] = (info['StoreName'], chan_id, unit_id)
 
                     unit_name = "ch{}#{}".format(chan_id, unit_id)
@@ -240,14 +240,14 @@ class TdtRawIO(BaseRawIO):
                     wf_offset = 0.
                     wf_left_sweep = info['NumPoints'] // 2
                     wf_sampling_rate = info['SampleFreq']
-                    unit_channels.append((unit_name, '{}'.format(unit_id),
+                    spike_channels.append((unit_name, '{}'.format(unit_id),
                                           wf_units, wf_gain, wf_offset,
                                           wf_left_sweep, wf_sampling_rate))
 
                     self._waveforms_size.append(info['NumPoints'])
                     self._waveforms_dtype.append(np.dtype(data_formats[info['DataFormat']]))
 
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # signal channels EVTYPE_STRON
         event_channels = []
@@ -264,7 +264,7 @@ class TdtRawIO(BaseRawIO):
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [nb_segment]
         self.header['signal_channels'] = signal_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # Annotations only standard ones:

--- a/neo/rawio/winedrrawio.py
+++ b/neo/rawio/winedrrawio.py
@@ -9,7 +9,7 @@ Author: Samuel Garcia
 
 """
 
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -80,15 +80,15 @@ class WinEdrRawIO(BaseRawIO):
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # No spikes
-        unit_channels = []
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # fille into header dict
         self.header = {}
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [1]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # insert some annotation at some place

--- a/neo/rawio/winwcprawio.py
+++ b/neo/rawio/winwcprawio.py
@@ -8,7 +8,7 @@ http://spider.science.strath.ac.uk/sipbs/software.htm
 Author : sgarcia
 Author: Samuel Garcia
 """
-from .baserawio import (BaseRawIO, _signal_channel_dtype, _unit_channel_dtype,
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _spike_channel_dtype,
                         _event_channel_dtype)
 
 import numpy as np
@@ -99,15 +99,15 @@ class WinWcpRawIO(BaseRawIO):
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # No spikes
-        unit_channels = []
-        unit_channels = np.array(unit_channels, dtype=_unit_channel_dtype)
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
 
         # fille into header dict
         self.header = {}
         self.header['nb_block'] = 1
         self.header['nb_segment'] = [nb_segment]
         self.header['signal_channels'] = sig_channels
-        self.header['unit_channels'] = unit_channels
+        self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         # insert some annotation at some place

--- a/neo/test/rawiotest/common_rawio_test.py
+++ b/neo/test/rawiotest/common_rawio_test.py
@@ -132,7 +132,7 @@ class BaseTestRawIO:
             # ~ ax.plot(sigs[:, 0])
             # ~ plt.show()
 
-            # ~ nb_unit = reader.unit_channels_count()
+            # ~ nb_unit = reader.spike_channels_count()
             # ~ for unit_index in range(nb_unit):
             # ~ wfs = reader.spike_raw_waveforms(block_index=0, seg_index=0,
             # ~ unit_index=unit_index)

--- a/neo/test/rawiotest/rawio_compliance.py
+++ b/neo/test/rawiotest/rawio_compliance.py
@@ -16,7 +16,7 @@ import logging
 
 import numpy as np
 
-from neo.rawio.baserawio import (_signal_channel_dtype, _unit_channel_dtype,
+from neo.rawio.baserawio import (_signal_channel_dtype, _spike_channel_dtype,
                                  _event_channel_dtype, _common_sig_characteristics)
 
 
@@ -28,7 +28,7 @@ def header_is_total(reader):
     """
     Test if hedaer contains:
       * 'signal_channels'
-      * 'unit_channels'
+      * 'spike_channels'
       * 'event_channels'
 
     """
@@ -40,11 +40,11 @@ def header_is_total(reader):
         for k, _ in _signal_channel_dtype:
             assert k in dt.fields, '%s not in signal_channels.dtype' % k
 
-    assert 'unit_channels' in h, 'unit_channels missing in header'
-    if h['unit_channels'] is not None:
-        dt = h['unit_channels'].dtype
-        for k, _ in _unit_channel_dtype:
-            assert k in dt.fields, '%s not in unit_channels.dtype' % k
+    assert 'spike_channels' in h, 'spike_channels missing in header'
+    if h['spike_channels'] is not None:
+        dt = h['spike_channels'].dtype
+        for k, _ in _spike_channel_dtype:
+            assert k in dt.fields, '%s not in spike_channels.dtype' % k
 
     assert 'event_channels' in h, 'event_channels missing in header'
     if h['event_channels'] is not None:
@@ -60,7 +60,7 @@ def count_element(reader):
     """
 
     nb_sig = reader.signal_channels_count()
-    nb_unit = reader.unit_channels_count()
+    nb_unit = reader.spike_channels_count()
     nb_event_channel = reader.event_channels_count()
 
     nb_block = reader.block_count()
@@ -272,7 +272,7 @@ def read_spike_times(reader):
     """
 
     nb_block = reader.block_count()
-    nb_unit = reader.unit_channels_count()
+    nb_unit = reader.spike_channels_count()
 
     for block_index in range(nb_block):
         nb_seg = reader.segment_count(block_index)
@@ -313,7 +313,7 @@ def read_spike_waveforms(reader):
     Read and convert some all waveforms.
     """
     nb_block = reader.block_count()
-    nb_unit = reader.unit_channels_count()
+    nb_unit = reader.spike_channels_count()
 
     for block_index in range(nb_block):
         nb_seg = reader.segment_count(block_index)

--- a/neo/test/rawiotest/test_blackrockrawio.py
+++ b/neo/test/rawiotest/test_blackrockrawio.py
@@ -73,9 +73,9 @@ class TestBlackrockRawIO(BaseTestRawIO, unittest.TestCase, ):
             assert_equal(raw_sigs[:-1], lfp_ml[c, :])
 
         # Check if spikes in channels are equal
-        nb_unit = reader.unit_channels_count()
+        nb_unit = reader.spike_channels_count()
         for unit_index in range(nb_unit):
-            unit_name = reader.header['unit_channels'][unit_index]['name']
+            unit_name = reader.header['spike_channels'][unit_index]['name']
             # name is chXX#YY where XX is channel_id and YY is unit_id
             channel_id, unit_id = unit_name.split('#')
             channel_id = int(channel_id.replace('ch', ''))
@@ -150,9 +150,9 @@ class TestBlackrockRawIO(BaseTestRawIO, unittest.TestCase, ):
                 assert_equal(raw_sigs[:], lfp_ml[c, :])
 
             # Check if spikes in channels are equal
-            nb_unit = reader.unit_channels_count()
+            nb_unit = reader.spike_channels_count()
             for unit_index in range(nb_unit):
-                unit_name = reader.header['unit_channels'][unit_index]['name']
+                unit_name = reader.header['spike_channels'][unit_index]['name']
                 # name is chXX#YY where XX is channel_id and YY is unit_id
                 channel_id, unit_id = unit_name.split('#')
                 channel_id = int(channel_id.replace('ch', ''))


### PR DESCRIPTION
See #895 

Some important change in rawio API.
  * use now the concept of signals_stream + signal_channels to avoid ambiguity
  * _get_analogsignal_chunk work with local to stream index
  * better raw_annotations 
  *  raw_annotations also handle array_annotations
  * signal 'id' is now a str (like all other 'id')

TODO:
  * create generic lay object
  * implemnent prefer_slice=True/False

For nowonly ExampleIO/Examplerawio is done.
