### PR TITLE
Axonarawio add pos stream

### DIFF
--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -291,7 +291,7 @@ class AxonaRawIO(BaseRawIO):
         ADU2_idx = np.where(flags == b'ADU2')
 
         timestamp = np.ndarray(
-            (self.num_total_packets,), np.int32, self.mmpos, 12, 
+            (self.num_total_packets,), np.int32, self.mmpos, 12,
             self.bytes_packet
         )[ADU2_idx].reshape((-1, 1))
 

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -56,7 +56,7 @@ class AxonaRawIO(BaseRawIO):
 
         float_chunk = r.rescale_signal_raw_to_float(
             raw_chunk, dtype=np.float64,
-            channel_indexes=[0, 3, 6], 
+            channel_indexes=[0, 3, 6],
             stream_index=0
         )
         print('\nRaw acquisition traces in uV:\n', float_chunk)
@@ -161,7 +161,7 @@ class AxonaRawIO(BaseRawIO):
 
     def _get_signal_streams_header(self):
         if self.contains_pos_tracking:
-            return np.array([('stream 0', '0'), ('stream 1', '1')], 
+            return np.array([('stream 0', '0'), ('stream 1', '1')],
                             dtype=_signal_stream_dtype)
         return np.array([('stream 0', '0')], dtype=_signal_stream_dtype)
 
@@ -482,7 +482,7 @@ class AxonaRawIO(BaseRawIO):
                 stream_id = '0'
                 sig_channels.append((ch_name, chan_id, self.sr_ecephys, dtype,
                                      units, gain, offset, stream_id))
-        
+
         # Append video tracking data
         if self.contains_pos_tracking:
 
@@ -491,14 +491,14 @@ class AxonaRawIO(BaseRawIO):
             # the code from https://github.com/HussainiLab/BinConverter/blob/master/BinConverter/core/readBin.py
             # which suggests two-spot mode data.
             # TODO: Add check for type of data and whether this schema fits
-            pos_channel_names = 't,x1,y1,x2,y2,numpix1,numpix2,unused'.split(',')
+            pos_chan_names = 't,x1,y1,x2,y2,numpix1,numpix2,unused'.split(',')
             pos_units = ['', '', '', '', '', 'pix', 'pix', '']
-            for i, (name, unit) in enumerate(zip(pos_channel_names, pos_units)):
+            for i, (name, unit) in enumerate(zip(pos_chan_names, pos_units)):
                 sig_channels.append(
-                    (name, str(int(chan_id) + 1 + i), r.sr_pos, np.float64,
+                    (name, str(int(chan_id) + 1 + i), self.sr_pos, np.float64,
                      unit, 1, 0, '1')
                 )
-        
+
         # TODO: _signal_channel_dtype does not match the pos data currently
         # numbers there are all np.float64, they shoul dbe U16
         return np.array(sig_channels, dtype=_signal_channel_dtype)

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -207,7 +207,8 @@ class AxonaRawIO(BaseRawIO):
     # https://github.com/GeoffBarrett/BinConverter
     # Adapted or modified by Steffen Buergers
 
-    def _get_ecephys_analogsignal_chunk(self, i_start, i_stop, channel_indexes):
+    def _get_ecephys_analogsignal_chunk(self, i_start, i_stop,
+                                        channel_indexes):
         """
         Return raw (continuous) signals as 2d numpy array (time x chan).
 
@@ -341,8 +342,6 @@ class AxonaRawIO(BaseRawIO):
         with open(self.set_file, encoding=self.set_file_encoding) as f:
             for line in f:
 
-                # The pattern to look for is collectMask_X Y,
-                # where X is the tetrode number, and Y is 1 or 0
                 if 'collectMask_' in line:
                     tetrode_str, tetrode_status = line.split(' ')
                     if int(tetrode_status) == 1:

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -28,6 +28,7 @@ import os
 import re
 import datetime
 import contextlib
+import mmap
 
 
 class AxonaRawIO(BaseRawIO):

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -189,7 +189,9 @@ class AxonaRawIO(BaseRawIO):
         """
         if stream_index == 1:
             if self.contains_pos_tracking:
-                raw_signals = self._get_pos_analogsignal_chunk(i_start, i_stop)
+                raw_signals = self._get_pos_analogsignal_chunk(
+                    i_start, i_stop, channel_indexes
+                )
 
         elif stream_index == 0:
             raw_signals = self._get_ecephys_analogsignal_chunk(
@@ -258,7 +260,8 @@ class AxonaRawIO(BaseRawIO):
 
         return raw_signals
 
-    def _get_pos_analogsignal_chunk(self, i_start=None, i_stop=None):
+    def _get_pos_analogsignal_chunk(self, i_start=None, i_stop=None,
+                                    channel_indexes=None):
         """
         Return np.array of video position tracking (Nsamp x 9 columns),
         with columns being the following:
@@ -344,7 +347,7 @@ class AxonaRawIO(BaseRawIO):
 
         # TODO: If the timestamp is meaningless for analyses as the fileFormat
         # manual claims, why return it in the output?
-        return pos[i_start:i_stop, :]
+        return pos[i_start:i_stop, channel_indexes]
 
     def get_set_file_parameters(self, params):
         """


### PR DESCRIPTION
In addition to ecephys data the Axona system saves video tracking data in the `.bin` files containing the raw data. 
Each data packet contains a header, footer and 3 samples of ecephys data for each channel. The header includes a
flag, either ADU1 or ADU2, where ADU2 denotes that video tracking data is available in this packet, which is then located
in the header. 

To quote from the [file format manual](http://space-memory-navigation.org/DacqUSBFileFormats.pdf):
```
Each position sample is 20 
bytes long, and consists of a 4-byte frame counter (incremented at around 50 Hz, 
according to the camera sync signal), and then 8 2-byte words. In four-spot mode, the 8 
words are redx, redy, greenx, greeny, bluex, bluey, whitex, whitey. In two-spot mode, they 
are big_spotx, big_spoty, little_spotx, little_spoty, number_of_pixels_in_big_spot, 
number_of_pixels_in_little_spot, total_tracked_pixels, and the 8th word is unused. Each 
word is MSB-first. If a position wasn't tracked (e.g., the light was obscured), then the 
values for x and y will both be 0x3ff (= 1023).
```

In this PR this video tracking position (pos) data is added to `axonarawio.py` as a separate stream. 