### PR TITLE
Enable AxonaIO to read spiketimes and waveforms

### DIFF
--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -113,7 +113,6 @@ class AxonaRawIO(BaseRawIO):
                   'set': {'filename': self.set_file,
                           'header_encoding': 'cp1252'},
                   'unit': {'data_type': unit_dtype,
-                           'wf_left_sweep_us': 200,
                            'tetrode_ids': [],
                            'header_encoding': 'cp1252'}}
         self.file_parameters = params
@@ -158,9 +157,6 @@ class AxonaRawIO(BaseRawIO):
                 tdict['num_spikes'] = int(tdict['num_spikes'])
                 tdict['header_size'] = len(
                     self.get_header_bstring(tetrode_file))
-                ls = self.file_parameters['unit']['wf_left_sweep_us'] * \
-                     self._to_hz(tdict['timebase']) * 10 ** -6
-                tdict['wf_left_sweep'] = ls
 
                 # memory mapping spiking data
                 spikes = np.memmap(
@@ -175,7 +171,9 @@ class AxonaRawIO(BaseRawIO):
                 wf_units = 'dimensionless'
                 wf_gain = 1
                 wf_offset = 0.
-                wf_left_sweep = tdict['wf_left_sweep']
+                # left sweep information is only stored in set file
+                wf_left_sweep = int(self.file_parameters['set']['file_header']
+                                    ['pretrigSamps'])
                 wf_sampling_rate = self._to_hz(tdict['sample_rate'],
                                                dtype=float)
                 spike_channels.append((unit_name, unit_id, wf_units, wf_gain,

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -380,13 +380,7 @@ class AxonaRawIO(BaseRawIO):
         assert seg_index == 0
 
         tetrode_id = unit_index
-
-        # spike times are repeated for each contact -> use only first contact
-        unit_spikes = self._get_spike_timestamps(block_index, seg_index,
-                                                 unit_index, t_start, t_stop)
         waveforms = self._raw_spikes[tetrode_id]['samples']
-        nb_spikes = len(unit_spikes)
-        nb_samples_per_waveform = waveforms.shape[-1]
 
         # slice timestamps / waveforms only when necessary
         if t_start is None and t_stop is None:

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -97,7 +97,7 @@ class AxonaRawIO(BaseRawIO):
         to raw data (.bin file) and prepare header dictionary in neo format.
         '''
 
-        unit_dtype = np.dtype([('spiketime', '>i4'),
+        unit_dtype = np.dtype([('spiketimes', '>i4'),
                                ('samples', 'int8', (50,))])
 
         # Utility collection of file parameters (general info and header data)
@@ -352,7 +352,7 @@ class AxonaRawIO(BaseRawIO):
         raw_spikes = self._raw_spikes[tetrode_id]
 
         # spike times are repeated for each contact -> use only first contact
-        unit_spikes = raw_spikes['spiketime'][::4]
+        unit_spikes = raw_spikes['spiketimes'][::4]
 
         # slice spike times only if needed
         if t_start is None or t_stop is None:
@@ -389,7 +389,7 @@ class AxonaRawIO(BaseRawIO):
         tetrode_id = unit_index
 
         # spike times are repeated for each contact -> use only first contact
-        unit_spikes = self._raw_spikes[tetrode_id]['spiketime'][::4]
+        unit_spikes = self._raw_spikes[tetrode_id]['spiketimes'][::4]
         waveforms = self._raw_spikes[tetrode_id]['samples']
         nb_spikes = len(unit_spikes)
         nb_samples_per_waveform = waveforms.shape[-1]

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -122,15 +122,16 @@ class AxonaRawIO(BaseRawIO):
         params['set']['file_header'] = set_dict
         params['set']['sampling_rate'] = int(set_dict['rawRate'])
 
+        signal_streams = self._get_signal_streams_header()
+        signal_channels = self._get_signal_chan_header()
+
         # SCAN BIN FILE
-        signal_streams = []
-        signal_channels = []
         if self.bin_file:
             bin_dict = self.file_parameters['bin']
             # add derived parameters from bin file
             bin_dict['num_channels'] = len(self.get_active_tetrode()) * 4
-            num_tot_packets = int(self.bin_file.stat().st_size
-                                  / bin_dict['bytes_packet'])
+            num_tot_packets = int(
+                self.bin_file.stat().st_size / bin_dict['bytes_packet'])
             bin_dict['num_total_packets'] = num_tot_packets
             bin_dict['num_total_samples'] = num_tot_packets * 3
 
@@ -139,9 +140,6 @@ class AxonaRawIO(BaseRawIO):
                 self.bin_file, dtype=self.file_parameters['bin']['data_type'],
                 mode='r', offset=self.file_parameters['bin']['header_size']
             )
-
-            signal_streams = self._get_signal_streams_header()
-            signal_channels = self._get_signal_chan_header()
 
         # SCAN TETRODE FILES
         # In this IO one tetrode corresponds to one unit

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -293,17 +293,6 @@ class AxonaRawIO(BaseRawIO):
         sample 3: 32b (head) + 128*2 (all channels 1st and 2nd entry) + ...
         """
 
-        if self.bin_file is None:
-
-            # NOTE: Passing None or an empty array is not permitted in neo. Here,
-            # we create a fake continuous recording from the tetrode files, filling
-            # data in-between spikes with Gaussian noise. Ultimately we may want to
-            # move the axonaunitextractor.get_traces() code in here instead, going
-            # back and forth is a bit funny.
-            from spikeextractors.extractors.axonaunitrecordingextractor import AxonaUnitRecordingExtractor
-            ue = AxonaUnitRecordingExtractor(filename=self.set_file)
-            return ue.get_traces(return_scaled=False).transpose()
-
         bin_dict = self.file_parameters['bin']
 
         # Set default values

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -269,7 +269,7 @@ class AxonaRawIO(BaseRawIO):
             return self.file_parameters['bin']['num_total_samples']
         else:
             sr = self.file_parameters['set']['sampling_rate']
-            return float(self.file_parameters['unit']['duration']) * sr
+            return int(self.file_parameters['unit']['duration'] * sr)
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
         return 0.

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -269,7 +269,7 @@ class AxonaRawIO(BaseRawIO):
             return self.file_parameters['bin']['num_total_samples']
         else:
             sr = self.file_parameters['set']['sampling_rate']
-            return int(self.file_parameters['unit']['duration'] * sr)
+            return int(float(self.file_parameters['unit']['duration']) * sr)
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
         return 0.

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -381,16 +381,14 @@ class AxonaRawIO(BaseRawIO):
             # Fill waveforms into traces timestamp by timestamp
             for t, wf in zip(spike_train, waveforms):
 
-                t = int(t // (timebase_sr / sampling_rate))  # timestamps are at higher frequency
+                t = int(t // (timebase_sr / sampling_rate))  # timestamps are sampled at higher frequency
                 t = t - start_frame
                 if (t - samples_pre < 0) and (t + samples_post > traces.shape[1]):
-                    traces[itrc:itrc + nch, :] = \
-                        wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
+                    traces[itrc:itrc + nch, :] = wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
                 elif t - samples_pre < 0:
                     traces[itrc:itrc + nch, :t + samples_post] = wf[:, samples_pre - t:]
                 elif t + samples_post > traces.shape[1]:
-                    traces[itrc:itrc + nch, t - samples_pre:] = \
-                        wf[:, :traces.shape[1] - (t - samples_pre)]
+                    traces[itrc:itrc + nch, t - samples_pre:] = wf[:, :traces.shape[1] - (t - samples_pre)]
                 else:
                     traces[itrc:itrc + nch, t - samples_pre:t + samples_post] = wf
 

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -504,7 +504,7 @@ class AxonaRawIO(BaseRawIO):
         This function will take the tetrode number and return the Axona
         channel numbers, i.e. Tetrode 1 = Ch1-Ch4, Tetrode 2 = Ch5-Ch8, etc.
         """
-        return np.arange(1, 5) + 4 * (int(tetrode) - 1)
+        return np.arange(0, 4) + 4 * (int(tetrode) - 1)
 
     def read_datetime(self):
         """

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -269,8 +269,7 @@ class AxonaRawIO(BaseRawIO):
         if 'num_total_packets' in self.file_parameters['bin']:
             return self.file_parameters['bin']['num_total_samples']
         else:
-            sr = self.file_parameters['set']['sampling_rate']
-            return int(float(self.file_parameters['unit']['duration']) * sr)
+            return 0
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
         return 0.

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -520,27 +520,30 @@ class AxonaRawIO(BaseRawIO):
         return datetime.datetime.strptime(date_str + ', ' + time_str,
                                           "%d %b %Y, %H:%M:%S")
 
-    def _get_channel_gain(self):
+    def _get_channel_gain(self, bytes_per_sample=2):
         """
-        Read gain for each channel from .set file and return list of integers
-
         This is actually not the gain_ch value from the .set file, but the
         conversion factor from raw data to uV.
 
-        Formula for .eeg and .X files, presumably also .bin files:
+        Formula for conversion to uV:
 
-        1000*adc_fullscale_mv / (gain_ch*128)
+        1000 * adc_fullscale_mv / (gain_ch * max-value), with
+        max_value = 2**(8 * bytes_per_sample - 1)
+
+        Adapted from
+        https://github.com/CINPLA/pyxona/blob/stable/pyxona/core.py
         """
         gain_list = []
 
         adc_fm = int(
             self.file_parameters['set']['file_header']['ADC_fullscale_mv'])
+
         for key, value in self.file_parameters['set']['file_header'].items():
             if key.startswith('gain_ch'):
                 gain_list.append(np.float32(value))
 
-        # rescaling gain factors
-        gain_list = [1000 * adc_fm / (gain * 128) for gain in gain_list]
+        max_value = 2**(8 * bytes_per_sample - 1)
+        gain_list = [1000 * adc_fm / (gain * max_value) for gain in gain_list]
 
         return gain_list
 

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -182,7 +182,7 @@ class AxonaRawIO(BaseRawIO):
                 wf_sampling_rate = spikemode_to_sr.get(int(sm), None)
                 if wf_sampling_rate is None:
                     wf_sampling_rate = self._to_hz(tdict['sample_rate'],
-                                               dtype=float)
+                                                   dtype=float)
 
                 spike_channels.append((unit_name, unit_id, wf_units, wf_gain,
                                        wf_offset, wf_left_sweep,

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -144,7 +144,8 @@ class AxonaRawIO(BaseRawIO):
             signal_channels = self._get_signal_chan_header()
 
         # SCAN TETRODE FILES
-        # In this IO one tetrode corresponds to one unit
+        # In this IO one tetrode corresponds to one unit as spikes are not
+        # sorted yet.
         self._raw_spikes = []
         spike_channels = []
         if self.tetrode_files:

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -502,7 +502,7 @@ class AxonaRawIO(BaseRawIO):
     def _get_channel_from_tetrode(self, tetrode):
         """
         This function will take the tetrode number and return the Axona
-        channel numbers, i.e. Tetrode 1 = Ch1-Ch4, Tetrode 2 = Ch5-Ch8, etc.
+        channel numbers, i.e. Tetrode 1 = Ch0-Ch3, Tetrode 2 = Ch4-Ch7, etc.
         """
         return np.arange(0, 4) + 4 * (int(tetrode) - 1)
 

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -401,7 +401,7 @@ class AxonaRawIO(BaseRawIO):
     def _get_tetrode_channel_table(self, channel_ids):
         '''Create auxiliary np.array with the following columns:
         Tetrode ID, Channel ID, Channel ID within tetrode
-        This is useful in `_get_mock_analogsignal_chunk()`
+        This is useful in `get_traces()`
 
         Parameters
         ----------

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -259,7 +259,7 @@ class AxonaRawIO(BaseRawIO):
                 raise ValueError('Can not determine common tetrode recording'
                                  'duration.')
 
-            tetrode_duration = int(self.file_parameters['unit']['duration'])
+            tetrode_duration = float(self.file_parameters['unit']['duration'])
             t_stop = max(t_stop, tetrode_duration)
 
         return t_stop
@@ -269,7 +269,7 @@ class AxonaRawIO(BaseRawIO):
             return self.file_parameters['bin']['num_total_samples']
         else:
             sr = self.file_parameters['set']['sampling_rate']
-            return int(self.file_parameters['unit']['duration']) * sr
+            return float(self.file_parameters['unit']['duration']) * sr
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
         return 0.

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -12,7 +12,7 @@ There are many other data formats from Axona, which we do not consider (yet).
 These are derivative from the raw continuous data (.bin) and could in principle
 be extracted from it (see file format overview for details).
 
-Author: Steffen Buergers
+Author: Steffen Buergers, Julia Sprenger
 
 """
 
@@ -97,40 +97,43 @@ class AxonaRawIO(BaseRawIO):
         to raw data (.bin file) and prepare header dictionary in neo format.
         '''
 
-        # Get useful parameters from .set file
-        params = ['rawRate']
-        global_params = self.get_header_parameters(self.set_file, params)
-
         unit_dtype = np.dtype([('spiketime', '>i4'),
                                ('samples', 'int8', (50,))])
 
         # Utility collection of file parameters (general info and header data)
-        params = {'bin': {'bytes_packet': 432,
+        params = {'bin': {'filename': self.bin_file,
+                          'bytes_packet': 432,
                           'bytes_data': 384,
                           'bytes_head': 32,
                           'bytes_tail': 16,
                           'data_type': np.int16,
                           'header_size': 0,
-                          'header_encoding': 'cp1252',
-                          'sampling_rate': int(global_params['rawRate']),
-                          'num_channels': len(self.get_active_tetrode()) * 4},
-                  'set': {'header_encoding': 'cp1252'},
+                          # bin files don't contain a file header
+                          'header_encoding': None},
+                  'set': {'filename': self.set_file,
+                          'header_encoding': 'cp1252'},
                   'unit': {'data_type': unit_dtype,
                            'wf_left_sweep_us': 200,
-                           'tetrode_ids': []}}
+                           'tetrode_ids': [],
+                           'header_encoding': 'cp1252'}}
         self.file_parameters = params
+
+        # SCAN SET FILE
+        set_dict = self.get_header_parameters(self.set_file, 'set')
+        params['set']['file_header'] = set_dict
+        params['set']['sampling_rate'] = int(set_dict['rawRate'])
 
         # SCAN BIN FILE
         signal_streams = []
         signal_channels = []
         if self.bin_file:
+            bin_dict = self.file_parameters['bin']
             # add derived parameters from bin file
-            num_tot_packets = int(
-                self.bin_file.stat().st_size / self.file_parameters['bin'][
-                    'bytes_packet'])
-            self.file_parameters['bin']['num_total_packets'] = num_tot_packets
-            self.file_parameters['bin'][
-                'num_total_samples'] = num_tot_packets * 3
+            bin_dict['num_channels'] = len(self.get_active_tetrode()) * 4
+            num_tot_packets = int(self.bin_file.stat().st_size
+                                  / bin_dict['bytes_packet'])
+            bin_dict['num_total_packets'] = num_tot_packets
+            bin_dict['num_total_samples'] = num_tot_packets * 3
 
             # Create np.memmap to .bin file
             self._raw_signals = np.memmap(
@@ -149,13 +152,15 @@ class AxonaRawIO(BaseRawIO):
 
             for i, tetrode_file in enumerate(self.tetrode_files):
                 # collecting tetrode specific parameters and dtype conversions
-                tdict = self.get_header_parameters(tetrode_file, None)
+                tdict = self.get_header_parameters(tetrode_file, 'unit')
+                tdict['filename'] = tetrode_file
                 tdict['timebase_hz'] = int(tdict['timebase'].replace(' hz', ''))
                 tdict['sample_rate_hz'] = int(
                     tdict['sample_rate'].replace(' hz', ''))
                 tdict['num_chans'] = int(tdict['num_chans'])
                 tdict['num_spikes'] = int(tdict['num_spikes'])
-                tdict['header_size'] = self.get_header_lenth(tetrode_file)
+                tdict['header_size'] = len(
+                    self.get_header_bstring(tetrode_file))
                 ls = self.file_parameters['unit']['wf_left_sweep_us'] * tdict[
                     'timebase_hz'] * 10 ** -6
                 tdict['wf_left_sweep'] = ls
@@ -216,6 +221,13 @@ class AxonaRawIO(BaseRawIO):
             seg_ann['signals'][0]['__array_annotations__']['tetrode_id'] = \
                 [tetr for tetr in self.get_active_tetrode() for _ in range(4)]
 
+        if seg_ann['spikes']:
+            # adding segment annotations
+            seg_keys = ['experimenter', 'comments', 'sw_version']
+            for seg_key in seg_keys:
+                if seg_key in self.file_parameters['unit']:
+                    seg_ann[seg_key] = self.file_parameters['unit'][seg_key]
+
     def _get_signal_streams_header(self):
         # create signals stream information (we always expect a single stream)
         return np.array([('stream 0', '0')], dtype=_signal_stream_dtype)
@@ -227,16 +239,17 @@ class AxonaRawIO(BaseRawIO):
         t_stop = 0.
 
         if 'num_total_packets' in self.file_parameters['bin']:
-            t_stop = self.file_parameters['bin']['num_total_samples'] / \
-                     self.file_parameters['bin']['sampling_rate']
+            sr = self.file_parameters['set']['sampling_rate']
+            t_stop = self.file_parameters['bin']['num_total_samples'] / sr
 
-        if 'unit' in self.file_parameters:
+        if self.file_parameters['unit']['tetrode_ids']:
             # get tetrode recording durations in seconds
-            tetrode_durations = [
-                int(self.file_parameters['unit'][i]['duration'])
-                for i in range(1, 33) if i in
-                self.file_parameters['unit']]
-            t_stop = max(t_stop, max(tetrode_durations))
+            if 'duration' not in self.file_parameters['unit']:
+                raise ValueError('Can not determine common tetrode recording'
+                                 'duration.')
+
+            tetrode_duration = int(self.file_parameters['unit']['duration'])
+            t_stop = max(t_stop, tetrode_duration)
 
         return t_stop
 
@@ -265,26 +278,26 @@ class AxonaRawIO(BaseRawIO):
         sample 3: 32b (head) + 128*2 (all channels 1st and 2nd entry) + ...
         """
 
+        bin_dict = self.file_parameters['bin']
+
         # Set default values
         if i_start is None:
             i_start = 0
         if i_stop is None:
-            i_stop = self.file_parameters['bin']['num_total_samples']
+            i_stop = bin_dict['num_total_samples']
         if channel_indexes is None:
-            channel_indexes = [i for i in range(
-                self.file_parameters['bin']['num_channels'])]
+            channel_indexes = [i for i in range(bin_dict['num_channels'])]
 
         num_samples = (i_stop - i_start)
 
         # Create base index vector for _raw_signals for time period of interest
         num_packets_oi = (num_samples + 2) // 3
-        offset = i_start // 3 * (
-                    self.file_parameters['bin']['bytes_packet'] // 2)
+        offset = i_start // 3 * (bin_dict['bytes_packet'] // 2)
         rem = (i_start % 3)
 
-        sample1 = np.arange(num_packets_oi + 1, dtype=np.uint32) * \
-                  (self.file_parameters['bin']['bytes_packet'] // 2) + \
-                  self.file_parameters['bin']['bytes_head'] // 2 + offset
+        raw_samples = np.arange(num_packets_oi + 1, dtype=np.uint32)
+        sample1 = raw_samples * (bin_dict['bytes_packet'] // 2) + \
+                  bin_dict['bytes_head'] // 2 + offset
         sample2 = sample1 + 64
         sample3 = sample2 + 64
 
@@ -298,7 +311,7 @@ class AxonaRawIO(BaseRawIO):
         # Read one channel at a time
         raw_signals = np.ndarray(shape=(num_samples,
                                         len(channel_indexes)),
-                                 dtype=self.file_parameters['bin']['data_type'])
+                                 dtype=bin_dict['data_type'])
 
         for i, ch_idx in enumerate(channel_indexes):
             chan_offset = self.channel_memory_offset[ch_idx]
@@ -356,7 +369,6 @@ class AxonaRawIO(BaseRawIO):
 
     def _get_spike_raw_waveforms(self, block_index, seg_index, unit_index,
                                  t_start, t_stop):
-
         assert block_index == 0
         assert seg_index == 0
 
@@ -399,17 +411,20 @@ class AxonaRawIO(BaseRawIO):
 
         return waveforms
 
-    def get_header_lenth(self, file):
+    def get_header_bstring(self, file):
         """
-        Scan file for the occurrence of 'data_start' and return the length
-        of the header in bytes
+        Scan file for the occurrence of 'data_start' and return the header
+        as byte string
 
-        INPUT
+        Parameters
+        ----------
         file (str or path): file to be loaded
 
-        OUTPUT
-        n_bytes (int): number of bytes occupied by the header
+        Returns
+        -------
+        str: header byte content
         """
+
         header = b''
         with open(file, 'rb') as f:
             for bin_line in f:
@@ -418,27 +433,22 @@ class AxonaRawIO(BaseRawIO):
                     break
                 else:
                     header += bin_line
-
-        # adding arbitrary 12 bytes here -> need to confirm
-        return len(header)
+        return header
 
     # ------------------ HELPER METHODS --------------------
-    # These are credited largely to Geoff Barrett from the Hussaini lab:
+    # This is largely based on code by Geoff Barrett from the Hussaini lab:
     # https://github.com/GeoffBarrett/BinConverter
-    # Adapted or modified by Steffen Buergers
+    # Adapted or modified by Steffen Buergers, Julia Sprenger
 
-    def get_header_parameters(self, file, params):
+    def get_header_parameters(self, file, file_type):
         """
-        Given a list of param., looks for each in first word of a phrase
-        in the .set file. Adds found paramters as dictionary keys and
-        following phrases as values (strings). If params is None all key
-        are returned.
+        Extract header parameters as dictionary keys and
+        following phrases as values (strings).
 
         Parameters
         ----------
         file (str or path): file to be loaded
-        params (list, set or None): parameter names to search for.
-            If None, all available parameters will be returned.
+        file_type (str): type of file to be loaded ('set' or 'unit')
 
         Returns
         -------
@@ -446,22 +456,18 @@ class AxonaRawIO(BaseRawIO):
                        were found & values being strings of the data.
 
         EXAMPLE
-        self.get_header_parameters('file.set', ['experimenter', 'trial_time'])
+        self.get_header_parameters('file.set', 'set')
         """
-        header = {}
-        if params is not None:
-            params = set(params)
-        with open(file, 'rb') as f:
-            for raw_line in f:
-                if b'data_start' in raw_line:
-                    break
-                line = raw_line.decode('cp1252').replace('\r\n', ''). \
-                    replace('\r', '').strip()
-                parts = line.split(' ')
-                key = parts[0]
-                if (params is None) or (key in params):
-                    header[key] = ' '.join(parts[1:])
-        return header
+
+        params = {}
+        encoding = self.file_parameters[file_type]['header_encoding']
+        header_string = self.get_header_bstring(file).decode(encoding)
+
+        # omit the last line as this contains only `data_start` key
+        for line in header_string.splitlines()[:-1]:
+            key, value = line.split(' ', 1)
+            params[key] = value
+        return params
 
     def get_active_tetrode(self):
         """
@@ -470,17 +476,13 @@ class AxonaRawIO(BaseRawIO):
         """
         active_tetrodes = []
 
-        with open(self.set_file, encoding='cp1252') as f:
-            for line in f:
-
-                # The pattern to look for is collectMask_X Y,
-                # where X is the tetrode number, and Y is 1 or 0
-                if 'collectMask_' in line:
-                    tetrode_str, tetrode_status = line.split(' ')
-                    if int(tetrode_status) == 1:
-                        tetrode_id = int(re.findall(r'\d+', tetrode_str)[0])
-                        active_tetrodes.append(tetrode_id)
-
+        for key, status in self.file_parameters['set']['file_header'].items():
+            # The pattern to look for is collectMask_X Y,
+            # where X is the tetrode number, and Y is 1 or 0
+            if key.startswith('collectMask_'):
+                if int(status):
+                    tetrode_id = int(key.strip('collectMask_'))
+                    active_tetrodes.append(tetrode_id)
         return active_tetrodes
 
     def _get_channel_from_tetrode(self, tetrode):
@@ -494,16 +496,14 @@ class AxonaRawIO(BaseRawIO):
         """
         Creates datetime object (y, m, d, h, m, s) from .set file header
         """
-        with open(self.set_file, 'r',
-                  encoding=self.file_parameters['set']['header_encoding']) as f:
-            for line in f:
-                if line.startswith('trial_date'):
-                    date_string = re.findall(r'\d+\s\w+\s\d{4}$', line)[0]
-                if line.startswith('trial_time'):
-                    time_string = line[len('trial_time') + 1::].replace('\n',
-                                                                        '')
 
-        return datetime.datetime.strptime(date_string + ', ' + time_string,
+        date_str = self.file_parameters['set']['file_header']['trial_date']
+        time_str = self.file_parameters['set']['file_header']['trial_time']
+
+        # extract core date string
+        date_str = re.findall(r'\d+\s\w+\s\d{4}$', date_str)[0]
+
+        return datetime.datetime.strptime(date_str + ', ' + time_str,
                                           "%d %b %Y, %H:%M:%S")
 
     def _get_channel_gain(self):
@@ -519,16 +519,16 @@ class AxonaRawIO(BaseRawIO):
         """
         gain_list = []
 
-        with open(self.set_file, encoding='cp1252') as f:
-            for line in f:
-                if line.startswith('ADC_fullscale_mv'):
-                    adc_fullscale_mv = int(line.split(" ")[1])
-                if line.startswith('gain_ch'):
-                    gain_list.append(
-                        np.float32(re.findall(r'\d*', line.split(' ')[1])[0])
-                    )
+        adc_fm = int(
+            self.file_parameters['set']['file_header']['ADC_fullscale_mv'])
+        for key, value in self.file_parameters['set']['file_header'].items():
+            if key.startswith('gain_ch'):
+                gain_list.append(np.float32(value))
 
-        return [1000 * adc_fullscale_mv / (gain * 128) for gain in gain_list]
+        # rescaling gain factors
+        gain_list = [1000 * adc_fm / (gain * 128) for gain in gain_list]
+
+        return gain_list
 
     def _get_signal_chan_header(self):
         """
@@ -563,7 +563,9 @@ class AxonaRawIO(BaseRawIO):
                 chan_id = str(cntr)
                 gain = gain_list[cntr]
                 stream_id = '0'
-                sr = self.file_parameters['bin']['sampling_rate']
+                # the sampling rate information is stored in the set header
+                # and not in the bin file
+                sr = self.file_parameters['set']['sampling_rate']
                 sig_channels.append((ch_name, chan_id, sr, dtype,
                                      units, gain, offset, stream_id))
 

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -371,7 +371,8 @@ class AxonaRawIO(BaseRawIO):
 
     def _rescale_spike_timestamp(self, spike_timestamps, dtype):
         spike_times = spike_timestamps.astype(dtype)
-        spike_times /= self._to_hz(self.file_parameters['unit']['timebase'])
+        spike_times /= self._to_hz(self.file_parameters['unit']['timebase'],
+                                   dtype=int)
         return spike_times
 
     def _get_spike_raw_waveforms(self, block_index, seg_index, unit_index,
@@ -437,8 +438,8 @@ class AxonaRawIO(BaseRawIO):
         # convert t_start and t_stop to sampling frequency
         # Note: this assumes no time offset!
         unit_params = self.file_parameters['unit']
-        lim0 = t_start * self._to_hz(unit_params['timebase'])
-        lim1 = t_stop * self._to_hz(unit_params['timebase'])
+        lim0 = t_start * self._to_hz(unit_params['timebase'], dtype=int)
+        lim1 = t_stop * self._to_hz(unit_params['timebase'], dtype=int)
 
         mask = (unit_spikes >= lim0) & (unit_spikes <= lim1)
 
@@ -578,5 +579,5 @@ class AxonaRawIO(BaseRawIO):
 
         return np.array(sig_channels, dtype=_signal_channel_dtype)
 
-    def _to_hz(self, param, dtype=int):
+    def _to_hz(self, param, dtype=float):
         return dtype(param.replace(' hz', ''))

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -591,4 +591,4 @@ class AxonaRawIO(BaseRawIO):
         return np.array(sig_channels, dtype=_signal_channel_dtype)
 
     def _to_hz(self, param, dtype=int):
-        return dtype(param.replace(' hz',''))
+        return dtype(param.replace(' hz', ''))

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -182,7 +182,7 @@ class AxonaRawIO(BaseRawIO):
                 wf_sampling_rate = spikemode_to_sr.get(int(sm), None)
                 if wf_sampling_rate is None:
                     wf_sampling_rate = self._to_hz(tdict['sample_rate'],
-                                                   dtype=float)
+                                               dtype=float)
 
                 spike_channels.append((unit_name, unit_id, wf_units, wf_gain,
                                        wf_offset, wf_left_sweep,

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -174,8 +174,18 @@ class AxonaRawIO(BaseRawIO):
                 # left sweep information is only stored in set file
                 wf_left_sweep = int(self.file_parameters['set']['file_header']
                                     ['pretrigSamps'])
-                wf_sampling_rate = self._to_hz(tdict['sample_rate'],
+
+                # Extract waveform sample rate
+                # 1st priority source: Spike2msMode (0 -> 48kHz; 1 -> 24kHz)
+                # 2nd priority source: tetrode sample rate
+                spikemode_to_sr = {0: 48000, 1: 24000}  # spikemode->rate in Hz
+                sm = self.file_parameters['set']['file_header'].get(
+                    'Spike2msMode', -1)
+                wf_sampling_rate = spikemode_to_sr.get(int(sm), None)
+                if wf_sampling_rate is None:
+                    wf_sampling_rate = self._to_hz(tdict['sample_rate'],
                                                dtype=float)
+
                 spike_channels.append((unit_name, unit_id, wf_units, wf_gain,
                                        wf_offset, wf_left_sweep,
                                        wf_sampling_rate))

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -129,7 +129,8 @@ class AxonaRawIO(BaseRawIO):
                 self.bin_file.stat().st_size / self.file_parameters['bin'][
                     'bytes_packet'])
             self.file_parameters['bin']['num_total_packets'] = num_tot_packets
-            self.file_parameters['bin']['num_total_samples'] = num_tot_packets * 3
+            self.file_parameters['bin'][
+                'num_total_samples'] = num_tot_packets * 3
 
             # Create np.memmap to .bin file
             self._raw_signals = np.memmap(
@@ -167,8 +168,8 @@ class AxonaRawIO(BaseRawIO):
                     shape=(tdict['num_spikes']))
                 self._raw_spikes.append(spikes)
 
-                unit_name = f'tetrode {i+1}'
-                unit_id = f'{i+1}'
+                unit_name = f'tetrode {i + 1}'
+                unit_id = f'{i + 1}'
                 wf_units = 'dimensionless'
                 wf_gain = 1
                 wf_offset = 0.
@@ -178,8 +179,8 @@ class AxonaRawIO(BaseRawIO):
                                        wf_offset, wf_left_sweep,
                                        wf_sampling_rate))
 
-                self.file_parameters['unit']['tetrode_ids'].append(i+1)
-                self.file_parameters['unit'][i+1] = tdict
+                self.file_parameters['unit']['tetrode_ids'].append(i + 1)
+                self.file_parameters['unit'][i + 1] = tdict
 
             # propagate common tetrode parameters to global unit level
             units_dict = self.file_parameters['unit']
@@ -188,9 +189,8 @@ class AxonaRawIO(BaseRawIO):
                 for key, value in units_dict[ids[0]].items():
                     # copy key-value pair if present across all tetrodes
                     if all([key in units_dict[t] for t in ids]) and \
-                       all([units_dict[t][key] == value for t in ids]):
+                            all([units_dict[t][key] == value for t in ids]):
                         self.file_parameters['unit'][key] = value
-
 
         # Create RawIO header dict
         self.header = {}
@@ -216,8 +216,6 @@ class AxonaRawIO(BaseRawIO):
             seg_ann['signals'][0]['__array_annotations__']['tetrode_id'] = \
                 [tetr for tetr in self.get_active_tetrode() for _ in range(4)]
 
-
-
     def _get_signal_streams_header(self):
         # create signals stream information (we always expect a single stream)
         return np.array([('stream 0', '0')], dtype=_signal_stream_dtype)
@@ -234,9 +232,10 @@ class AxonaRawIO(BaseRawIO):
 
         if 'unit' in self.file_parameters:
             # get tetrode recording durations in seconds
-            tetrode_durations = [int(self.file_parameters['unit'][i]['duration'])
-                                 for i in range(1, 33) if i in
-                                 self.file_parameters['unit']]
+            tetrode_durations = [
+                int(self.file_parameters['unit'][i]['duration'])
+                for i in range(1, 33) if i in
+                self.file_parameters['unit']]
             t_stop = max(t_stop, max(tetrode_durations))
 
         return t_stop
@@ -272,17 +271,20 @@ class AxonaRawIO(BaseRawIO):
         if i_stop is None:
             i_stop = self.file_parameters['bin']['num_total_samples']
         if channel_indexes is None:
-            channel_indexes = [i for i in range(self.file_parameters['bin']['num_channels'])]
+            channel_indexes = [i for i in range(
+                self.file_parameters['bin']['num_channels'])]
 
         num_samples = (i_stop - i_start)
 
         # Create base index vector for _raw_signals for time period of interest
         num_packets_oi = (num_samples + 2) // 3
-        offset = i_start // 3 * (self.file_parameters['bin']['bytes_packet'] // 2)
+        offset = i_start // 3 * (
+                    self.file_parameters['bin']['bytes_packet'] // 2)
         rem = (i_start % 3)
 
         sample1 = np.arange(num_packets_oi + 1, dtype=np.uint32) * \
-            (self.file_parameters['bin']['bytes_packet'] // 2) + self.file_parameters['bin']['bytes_head'] // 2 + offset
+                  (self.file_parameters['bin']['bytes_packet'] // 2) + \
+                  self.file_parameters['bin']['bytes_head'] // 2 + offset
         sample2 = sample1 + 64
         sample3 = sample2 + 64
 
@@ -295,16 +297,14 @@ class AxonaRawIO(BaseRawIO):
 
         # Read one channel at a time
         raw_signals = np.ndarray(shape=(num_samples,
-                                 len(channel_indexes)),
+                                        len(channel_indexes)),
                                  dtype=self.file_parameters['bin']['data_type'])
 
         for i, ch_idx in enumerate(channel_indexes):
-
             chan_offset = self.channel_memory_offset[ch_idx]
             raw_signals[:, i] = self._raw_signals[sig_ids + chan_offset]
 
         return raw_signals
-
 
     def _spike_count(self, block_index, seg_index, unit_index):
         tetrode_id = unit_index
@@ -315,8 +315,8 @@ class AxonaRawIO(BaseRawIO):
         nb_unit_spikes = int(np.ceil(nb_tetrode_spikes / 4))
         return nb_unit_spikes
 
-
-    def _get_spike_timestamps(self, block_index, seg_index, unit_index, t_start, t_stop):
+    def _get_spike_timestamps(self, block_index, seg_index, unit_index,
+                              t_start, t_stop):
         assert block_index == 0
         assert seg_index == 0
 
@@ -360,7 +360,7 @@ class AxonaRawIO(BaseRawIO):
         assert block_index == 0
         assert seg_index == 0
 
-        tetrode_id =unit_index
+        tetrode_id = unit_index
 
         # spike times are repeated for each contact -> use only first contact
         unit_spikes = self._raw_spikes[tetrode_id]['spiketime'][::4]
@@ -455,7 +455,7 @@ class AxonaRawIO(BaseRawIO):
             for raw_line in f:
                 if b'data_start' in raw_line:
                     break
-                line = raw_line.decode('cp1252').replace('\r\n', '').\
+                line = raw_line.decode('cp1252').replace('\r\n', ''). \
                     replace('\r', '').strip()
                 parts = line.split(' ')
                 key = parts[0]
@@ -494,12 +494,14 @@ class AxonaRawIO(BaseRawIO):
         """
         Creates datetime object (y, m, d, h, m, s) from .set file header
         """
-        with open(self.set_file, 'r', encoding=self.file_parameters['set']['header_encoding']) as f:
+        with open(self.set_file, 'r',
+                  encoding=self.file_parameters['set']['header_encoding']) as f:
             for line in f:
                 if line.startswith('trial_date'):
                     date_string = re.findall(r'\d+\s\w+\s\d{4}$', line)[0]
                 if line.startswith('trial_time'):
-                    time_string = line[len('trial_time') + 1::].replace('\n', '')
+                    time_string = line[len('trial_time') + 1::].replace('\n',
+                                                                        '')
 
         return datetime.datetime.strptime(date_string + ', ' + time_string,
                                           "%d %b %Y, %H:%M:%S")
@@ -556,7 +558,6 @@ class AxonaRawIO(BaseRawIO):
         for itetr in range(num_active_tetrode):
 
             for ielec in range(elec_per_tetrode):
-
                 cntr = (itetr * elec_per_tetrode) + ielec
                 ch_name = '{}{}'.format(itetr + 1, letters[ielec])
                 chan_id = str(cntr)

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -188,12 +188,19 @@ class AxonaRawIO(BaseRawIO):
             # propagate common tetrode parameters to global unit level
             units_dict = self.file_parameters['unit']
             ids = units_dict['tetrode_ids']
+            copied_keys = []
             if ids:
                 for key, value in units_dict[ids[0]].items():
                     # copy key-value pair if present across all tetrodes
                     if all([key in units_dict[t] for t in ids]) and \
                             all([units_dict[t][key] == value for t in ids]):
                         self.file_parameters['unit'][key] = value
+                        copied_keys.append(key)
+
+                # remove key from individual tetrode parameters
+                for key in copied_keys:
+                    for t in ids:
+                        self.file_parameters['unit'][t].pop(key)
 
         # Create RawIO header dict
         self.header = {}

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -231,11 +231,11 @@ class AxonaRawIO(BaseRawIO):
         bl_ann = self.raw_annotations['blocks'][0]
         seg_ann = bl_ann['segments'][0]
         seg_ann['rec_datetime'] = self.read_datetime()
-        if seg_ann['signals']:
+        if len(seg_ann['signals']):
             seg_ann['signals'][0]['__array_annotations__']['tetrode_id'] = \
                 [tetr for tetr in self.get_active_tetrode() for _ in range(4)]
 
-        if seg_ann['spikes']:
+        if len(seg_ann['spikes']):
             # adding segment annotations
             seg_keys = ['experimenter', 'comments', 'sw_version']
             for seg_key in seg_keys:

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -346,8 +346,6 @@ class AxonaRawIO(BaseRawIO):
         assert block_index == 0
         assert seg_index == 0
 
-        unit_params = self.file_parameters['unit']
-
         tetrode_id = unit_index
         raw_spikes = self._raw_spikes[tetrode_id]
 
@@ -355,26 +353,17 @@ class AxonaRawIO(BaseRawIO):
         unit_spikes = raw_spikes['spiketimes'][::4]
 
         # slice spike times only if needed
-        if t_start is None or t_stop is None:
+        if t_start is None and t_stop is None:
+            return unit_spikes
 
-            if t_start is None:
-                t_start = self._segment_t_start(block_index, seg_index)
-            if t_stop is None:
-                t_stop = self._segment_t_stop(block_index, seg_index)
+        if t_start is None:
+            t_start = self._segment_t_start(block_index, seg_index)
+        if t_stop is None:
+            t_stop = self._segment_t_stop(block_index, seg_index)
 
-            # convert to t_start and t_stop to sampling frequency
-            # Note: this assumes no time offset!
-            lim0 = t_start * self._to_hz(unit_params['timebase'])
-            lim1 = t_stop * self._to_hz(unit_params['timebase'])
+        mask = self._get_temporal_mask(t_start, t_stop, tetrode_id)
 
-            # slice spike times
-            mask = (unit_spikes >= lim0) & (unit_spikes <= lim1)
-            spike_timestamps = unit_spikes[mask]
-
-        else:
-            spike_timestamps = unit_spikes
-
-        return spike_timestamps
+        return unit_spikes[mask]
 
     def _rescale_spike_timestamp(self, spike_timestamps, dtype):
         spike_times = spike_timestamps.astype(dtype)
@@ -389,29 +378,28 @@ class AxonaRawIO(BaseRawIO):
         tetrode_id = unit_index
 
         # spike times are repeated for each contact -> use only first contact
-        unit_spikes = self._raw_spikes[tetrode_id]['spiketimes'][::4]
+        unit_spikes = self._get_spike_timestamps(block_index, seg_index,
+                                                 unit_index, t_start, t_stop)
         waveforms = self._raw_spikes[tetrode_id]['samples']
         nb_spikes = len(unit_spikes)
         nb_samples_per_waveform = waveforms.shape[-1]
 
         # slice timestamps / waveforms only when necessary
-        if t_start is None or t_stop is None:
-            if t_start is None:
-                t_start = self._segment_t_start(block_index, seg_index)
-            if t_stop is None:
-                t_stop = self._segment_t_stop(block_index, seg_index)
+        if t_start is None and t_stop is None:
+            waveforms = waveforms.reshape(nb_spikes, 4, nb_samples_per_waveform)
+            return waveforms
+        
+        if t_start is None:
+            t_start = self._segment_t_start(block_index, seg_index)
+        if t_stop is None:
+            t_stop = self._segment_t_stop(block_index, seg_index)
 
-            # convert to t_start and t_stop to sampling frequency
-            # Note: this assumes no time offset!
-            lim0 = t_start * self._to_hz(self.file_parameters['unit']['timebase'])
-            lim1 = t_stop * self._to_hz(self.file_parameters['unit']['timebase'])
-
-            # slice spike times
-            mask = (unit_spikes >= lim0) & (unit_spikes <= lim1)
-            # unwrap mask to match waveform dimension
-            mask = np.repeat(mask, 4)
-            mask = mask[:len(waveforms)]
-            waveforms = waveforms[mask]
+        mask = self._get_temporal_mask(t_start, t_stop, tetrode_id)
+        
+        # unwrap mask to match waveform dimension
+        mask = np.repeat(mask, 4)
+        mask = mask[:len(waveforms)]
+        waveforms = waveforms[mask]
 
         # waveforms must be a 3D numpy array (nb_spike, nb_channel, nb_sample)
         waveforms = waveforms.reshape(nb_spikes, 4, nb_samples_per_waveform)
@@ -446,6 +434,25 @@ class AxonaRawIO(BaseRawIO):
     # This is largely based on code by Geoff Barrett from the Hussaini lab:
     # https://github.com/GeoffBarrett/BinConverter
     # Adapted or modified by Steffen Buergers, Julia Sprenger
+    
+    def _get_temporal_mask(self, t_start, t_stop, tetrode_id):
+        # Conenience function for creating a temporal mask given
+        # start time (t_start) and stop time (t_stop)
+        # Used by _get_spike_raw_waveforms and _get_spike_timestamps
+
+        # spike times are repeated for each contact -> use only first contact
+        raw_spikes = self._raw_spikes[tetrode_id]
+        unit_spikes = raw_spikes['spiketimes'][::4]
+        
+        # convert t_start and t_stop to sampling frequency
+        # Note: this assumes no time offset!
+        unit_params = self.file_parameters['unit']
+        lim0 = t_start * self._to_hz(unit_params['timebase'])
+        lim1 = t_stop * self._to_hz(unit_params['timebase'])
+
+        mask = (unit_spikes >= lim0) & (unit_spikes <= lim1)
+        
+        return mask
 
     def get_header_parameters(self, file, file_type):
         """

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -293,6 +293,17 @@ class AxonaRawIO(BaseRawIO):
         sample 3: 32b (head) + 128*2 (all channels 1st and 2nd entry) + ...
         """
 
+        if self.bin_file is None:
+
+            # NOTE: Passing None or an empty array is not permitted in neo. Here,
+            # we create a fake continuous recording from the tetrode files, filling
+            # data in-between spikes with Gaussian noise. Ultimately we may want to
+            # move the axonaunitextractor.get_traces() code in here instead, going
+            # back and forth is a bit funny.
+            from spikeextractors.extractors.axonaunitrecordingextractor import AxonaUnitRecordingExtractor
+            ue = AxonaUnitRecordingExtractor(filename=self.set_file)
+            return ue.get_traces(return_scaled=False).transpose()
+
         bin_dict = self.file_parameters['bin']
 
         # Set default values

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -163,7 +163,7 @@ class AxonaRawIO(BaseRawIO):
                     tetrode_file,
                     dtype=self.file_parameters['unit']['data_type'],
                     mode='r', offset=tdict['header_size'],
-                    shape=(tdict['num_spikes']))
+                    shape=(tdict['num_spikes'] * 4))
                 self._raw_spikes.append(spikes)
 
                 unit_name = f'tetrode {i + 1}'
@@ -412,13 +412,6 @@ class AxonaRawIO(BaseRawIO):
             mask = np.repeat(mask, 4)
             mask = mask[:len(waveforms)]
             waveforms = waveforms[mask]
-
-        # pad waveforms with zeros if not all traces are present
-        # Note: This will cause loading of the waveforms into working memory
-        if waveforms.shape[0] % 4 != 0:
-            n_pad = 4 - waveforms.shape[0] % 4
-            pad = np.zeros((n_pad, waveforms.shape[1]))
-            waveforms = np.vstack((waveforms, pad))
 
         # waveforms must be a 3D numpy array (nb_spike, nb_channel, nb_sample)
         waveforms = waveforms.reshape(nb_spikes, 4, nb_samples_per_waveform)

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -436,7 +436,7 @@ class AxonaRawIO(BaseRawIO):
     # Adapted or modified by Steffen Buergers, Julia Sprenger
     
     def _get_temporal_mask(self, t_start, t_stop, tetrode_id):
-        # Conenience function for creating a temporal mask given
+        # Convenience function for creating a temporal mask given
         # start time (t_start) and stop time (t_stop)
         # Used by _get_spike_raw_waveforms and _get_spike_timestamps
 

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -106,7 +106,7 @@ class AxonaRawIO(BaseRawIO):
                           'bytes_data': 384,
                           'bytes_head': 32,
                           'bytes_tail': 16,
-                          'data_type': np.int16,
+                          'data_type': 'int16',
                           'header_size': 0,
                           # bin files don't contain a file header
                           'header_encoding': None},

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -122,16 +122,14 @@ class AxonaRawIO(BaseRawIO):
         params['set']['file_header'] = set_dict
         params['set']['sampling_rate'] = int(set_dict['rawRate'])
 
-        signal_streams = self._get_signal_streams_header()
-        signal_channels = self._get_signal_chan_header()
-
-        # SCAN BIN FILE
+        signal_streams = []
+        signal_channels = []
         if self.bin_file:
             bin_dict = self.file_parameters['bin']
             # add derived parameters from bin file
             bin_dict['num_channels'] = len(self.get_active_tetrode()) * 4
-            num_tot_packets = int(
-                self.bin_file.stat().st_size / bin_dict['bytes_packet'])
+            num_tot_packets = int(self.bin_file.stat().st_size
+                                  / bin_dict['bytes_packet'])
             bin_dict['num_total_packets'] = num_tot_packets
             bin_dict['num_total_samples'] = num_tot_packets * 3
 
@@ -140,6 +138,9 @@ class AxonaRawIO(BaseRawIO):
                 self.bin_file, dtype=self.file_parameters['bin']['data_type'],
                 mode='r', offset=self.file_parameters['bin']['header_size']
             )
+
+            signal_streams = self._get_signal_streams_header()
+            signal_channels = self._get_signal_chan_header()
 
         # SCAN TETRODE FILES
         # In this IO one tetrode corresponds to one unit

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -381,14 +381,16 @@ class AxonaRawIO(BaseRawIO):
             # Fill waveforms into traces timestamp by timestamp
             for t, wf in zip(spike_train, waveforms):
 
-                t = int(t // (timebase_sr / sampling_rate))  # timestamps are sampled at higher frequency
+                t = int(t // (timebase_sr / sampling_rate))  # timestamps are at higher frequency
                 t = t - start_frame
                 if (t - samples_pre < 0) and (t + samples_post > traces.shape[1]):
-                    traces[itrc:itrc + nch, :] = wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
+                    traces[itrc:itrc + nch, :] = \
+                        wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
                 elif t - samples_pre < 0:
                     traces[itrc:itrc + nch, :t + samples_post] = wf[:, samples_pre - t:]
                 elif t + samples_post > traces.shape[1]:
-                    traces[itrc:itrc + nch, t - samples_pre:] = wf[:, :traces.shape[1] - (t - samples_pre)]
+                    traces[itrc:itrc + nch, t - samples_pre:] = \
+                        wf[:, :traces.shape[1] - (t - samples_pre)]
                 else:
                     traces[itrc:itrc + nch, t - samples_pre:t + samples_post] = wf
 

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -122,6 +122,7 @@ class AxonaRawIO(BaseRawIO):
         params['set']['file_header'] = set_dict
         params['set']['sampling_rate'] = int(set_dict['rawRate'])
 
+        # SCAN BIN FILE
         signal_streams = []
         signal_channels = []
         if self.bin_file:

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -401,7 +401,7 @@ class AxonaRawIO(BaseRawIO):
     def _get_tetrode_channel_table(self, channel_ids):
         '''Create auxiliary np.array with the following columns:
         Tetrode ID, Channel ID, Channel ID within tetrode
-        This is useful in `get_traces()`
+        This is useful in `_get_mock_analogsignal_chunk()`
 
         Parameters
         ----------

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -293,26 +293,19 @@ class AxonaRawIO(BaseRawIO):
         sample 3: 32b (head) + 128*2 (all channels 1st and 2nd entry) + ...
         """
 
-        if self.bin_file is None:
-
-            # NOTE: Passing None or an empty array is not permitted in neo. Here,
-            # we create a fake continuous recording from the tetrode files, filling
-            # data in-between spikes with Gaussian noise. Ultimately we may want to
-            # move the axonaunitextractor.get_traces() code in here instead, going
-            # back and forth is a bit funny.
-            from spikeextractors.extractors.axonaunitrecordingextractor import AxonaUnitRecordingExtractor
-            ue = AxonaUnitRecordingExtractor(filename=self.set_file)
-            return ue.get_traces(return_scaled=False).transpose()
-
         bin_dict = self.file_parameters['bin']
 
         # Set default values
         if i_start is None:
             i_start = 0
         if i_stop is None:
-            i_stop = bin_dict['num_total_samples']
+            i_stop = self.get_signal_size(block_index=block_index, seg_index=seg_index)
         if channel_indexes is None:
-            channel_indexes = [i for i in range(bin_dict['num_channels'])]
+            channel_indexes = [i for i in range(self.header['signal_channels'].shape[0])]
+
+        if self.bin_file is None:
+            return self._get_mock_analogsignal_chunk(channel_ids=channel_indexes,
+                                                     start_frame=i_start, end_frame=i_stop)
 
         num_samples = (i_stop - i_start)
 
@@ -323,7 +316,7 @@ class AxonaRawIO(BaseRawIO):
 
         raw_samples = np.arange(num_packets_oi + 1, dtype=np.uint32)
         sample1 = raw_samples * (bin_dict['bytes_packet'] // 2) + \
-                  bin_dict['bytes_head'] // 2 + offset
+            bin_dict['bytes_head'] // 2 + offset
         sample2 = sample1 + 64
         sample3 = sample2 + 64
 
@@ -344,6 +337,98 @@ class AxonaRawIO(BaseRawIO):
             raw_signals[:, i] = self._raw_signals[sig_ids + chan_offset]
 
         return raw_signals
+
+    def _get_mock_analogsignal_chunk(self, channel_ids, start_frame, end_frame,
+                                     noise_std=0, return_scaled=False):
+        # Create mock continuous recording from tetrode file (.X) data
+        # by filling Gaussian noise into gaps between waveforms.
+
+        timebase_sr = int(self.file_parameters['unit']['timebase'].split(' ')[0])
+        samples_pre = int(self.file_parameters['set']['file_header']['pretrigSamps'])
+        samples_post = int(self.file_parameters['set']['file_header']['spikeLockout'])
+        sampling_rate = int(self.file_parameters['set']['sampling_rate'])
+
+        tcmap = self._get_tetrode_channel_table(channel_ids)
+
+        traces = noise_std * np.random.randn(len(channel_ids), end_frame - start_frame)
+        if return_scaled:
+            traces = traces.astype(np.float32)
+        else:
+            traces = traces.astype(np.int8)
+
+        # Loop through tetrodes and include requested channels in traces
+        itrc = 0
+        for tetrode_id in np.unique(tcmap[:, 0]):
+
+            channels_oi = tcmap[tcmap[:, 0] == tetrode_id, 2]
+
+            waveforms = self._get_spike_raw_waveforms(
+                block_index=0, seg_index=0,
+                unit_index=tetrode_id - 1,  # Tetrodes IDs are 1-indexed
+                t_start=start_frame / sampling_rate,
+                t_stop=end_frame / sampling_rate
+            )
+            waveforms = waveforms[:, channels_oi, :]
+            nch = len(channels_oi)
+
+            spike_train = self._get_spike_timestamps(
+                block_index=0, seg_index=0,
+                unit_index=tetrode_id - 1,
+                t_start=start_frame / sampling_rate,
+                t_stop=end_frame / sampling_rate
+            )
+
+            # Fill waveforms into traces timestamp by timestamp
+            for t, wf in zip(spike_train, waveforms):
+
+                t = int(t // (timebase_sr / sampling_rate))  # timestamps are sampled at higher frequency
+                t = t - start_frame
+                if (t - samples_pre < 0) and (t + samples_post > traces.shape[1]):
+                    traces[itrc:itrc + nch, :] = wf[:, samples_pre - t:traces.shape[1] - (t - samples_pre)]
+                elif t - samples_pre < 0:
+                    traces[itrc:itrc + nch, :t + samples_post] = wf[:, samples_pre - t:]
+                elif t + samples_post > traces.shape[1]:
+                    traces[itrc:itrc + nch, t - samples_pre:] = wf[:, :traces.shape[1] - (t - samples_pre)]
+                else:
+                    traces[itrc:itrc + nch, t - samples_pre:t + samples_post] = wf
+
+            itrc += nch
+
+        return traces.transpose()
+
+    def _get_tetrode_channel_table(self, channel_ids):
+        '''Create auxiliary np.array with the following columns:
+        Tetrode ID, Channel ID, Channel ID within tetrode
+        This is useful in `get_traces()`
+
+        Parameters
+        ----------
+        channel_ids : list
+            List of channel ids to include in table
+
+        Returns
+        -------
+        np.array
+            Rows = channels,
+            columns = TetrodeID, ChannelID, ChannelID within Tetrode
+        '''
+        active_tetrodes = self.get_active_tetrode()
+
+        tcmap = np.zeros((len(active_tetrodes) * 4, 3), dtype=int)
+        row_id = 0
+        for tetrode_id in [int(s[0].split(' ')[1]) for s in self.header['spike_channels']]:
+
+            all_channel_ids = self._get_channel_from_tetrode(tetrode_id)
+
+            for i in range(4):
+                tcmap[row_id, 0] = int(tetrode_id)
+                tcmap[row_id, 1] = int(all_channel_ids[i])
+                tcmap[row_id, 2] = int(i)
+                row_id += 1
+
+        del_idx = [False if i in channel_ids else True for i in tcmap[:, 1]]
+
+        return np.delete(tcmap, del_idx, axis=0)
 
     def _spike_count(self, block_index, seg_index, unit_index):
         tetrode_id = unit_index

--- a/neo/test/iotest/test_axonaio.py
+++ b/neo/test/iotest/test_axonaio.py
@@ -20,7 +20,8 @@ class TestAxonaIO(BaseTestIO, unittest.TestCase, ):
         'axona'
     ]
     entities_to_test = [
-        'axona/axona_raw.set'
+        'axona/axona_raw.set',
+        'axona/dataset_unit_spikes/20140815-180secs.set'
     ]
 
 

--- a/neo/test/iotest/test_axonaio.py
+++ b/neo/test/iotest/test_axonaio.py
@@ -21,7 +21,8 @@ class TestAxonaIO(BaseTestIO, unittest.TestCase, ):
     ]
     entities_to_test = [
         'axona/axona_raw.set',
-        'axona/dataset_unit_spikes/20140815-180secs.set'
+        'axona/dataset_unit_spikes/20140815-180secs.set',
+        'axona/dataset_multi_modal/axona_sample.set'
     ]
 
 

--- a/neo/test/iotest/test_axonaio.py
+++ b/neo/test/iotest/test_axonaio.py
@@ -6,12 +6,7 @@ import unittest
 
 from neo.io.axonaio import AxonaIO
 from neo.test.iotest.common_io_test import BaseTestIO
-from neo.io.proxyobjects import (AnalogSignalProxy,
-                SpikeTrainProxy, EventProxy, EpochProxy)
-from neo import (AnalogSignal, SpikeTrain)
-
-import quantities as pq
-import numpy as np
+from neo.test.rawiotest.test_axonarawio import TestAxonaRawIO
 
 
 class TestAxonaIO(BaseTestIO, unittest.TestCase, ):
@@ -19,11 +14,8 @@ class TestAxonaIO(BaseTestIO, unittest.TestCase, ):
     entities_to_download = [
         'axona'
     ]
-    entities_to_test = [
-        'axona/axona_raw.set',
-        'axona/dataset_unit_spikes/20140815-180secs.set',
-        'axona/dataset_multi_modal/axona_sample.set'
-    ]
+
+    entities_to_test = TestAxonaRawIO.entities_to_test
 
 
 if __name__ == "__main__":

--- a/neo/test/rawiotest/test_axonarawio.py
+++ b/neo/test/rawiotest/test_axonarawio.py
@@ -14,12 +14,13 @@ from neo.test.rawiotest.common_rawio_test import BaseTestRawIO
 
 class TestAxonaRawIO(BaseTestRawIO, unittest.TestCase):
     rawioclass = AxonaRawIO
-    entities_to_test = [
-        'axona/axona_raw.bin',
-        'axona/axona_raw.set',
-    ]
     entities_to_download = [
         'axona'
+    ]
+    entities_to_test = [
+        'axona/axona_raw.set',
+        'axona/dataset_unit_spikes/20140815-180secs.set',
+        'axona/dataset_multi_modal/axona_sample.set'
     ]
 
 


### PR DESCRIPTION
This PR implements the required rawio methods for reading spiketimes and waveforms. It also restructures the IO to be able to support multi-file datasets (.bin & unit files).

This PR depends on the Axona unit test data that will be added to the ephy_testing_data: https://gin.g-node.org/NeuralEnsemble/ephy_testing_data/pulls/49/files