### PR TITLE
Update CI badge

### DIFF
--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -2,7 +2,7 @@ name: neo.io and neo.rawio tests
 
 on:
   pull_request:
-    branches: [master, gh_actions_and_datalad]
+    branches: [master]
     types: [synchronize, opened, reopened, ready_for_review]
 
   # run checks on any change of master, including merge of PRs

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -5,6 +5,10 @@ on:
     branches: [master, gh_actions_and_datalad]
     types: [synchronize, opened, reopened, ready_for_review]
 
+  # run checks on any change of master, including merge of PRs
+  push:
+    branches: [master]
+
 jobs:
   build-and-test:
     name: Test on (${{ matrix.os }})

--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,8 @@ Code status
    :target: https://travis-ci.org/NeuralEnsemble/python-neo
    :alt: Core Unit Test Status (TravisCI)
 .. image:: https://github.com/NeuralEnsemble/python-neo/actions/workflows/full-test.yml/badge.svg?event=push&branch=master
-    :target: https://github.com/NeuralEnsemble/python-neo/actions?query=event%3Apush+branch%3Amaster
-    :alt: IO Unit Test Status (Github Actions)
+   :target: https://github.com/NeuralEnsemble/python-neo/actions?query=event%3Apush+branch%3Amaster
+   :alt: IO Unit Test Status (Github Actions)
 .. image:: https://coveralls.io/repos/NeuralEnsemble/python-neo/badge.png
    :target: https://coveralls.io/r/NeuralEnsemble/python-neo
    :alt: Unit Test Coverage

--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,8 @@ Code status
 .. image:: https://travis-ci.org/NeuralEnsemble/python-neo.png?branch=master
    :target: https://travis-ci.org/NeuralEnsemble/python-neo
    :alt: Unit Test Status (TravisCI)
-.. image:: https://github.com/NeuralEnsemble/python-neo/actions/workflows/full-test.yml/badge.svg
-    :target: https://github.com/NeuralEnsemble/python-neo/actions/workflows/
+.. image:: https://github.com/NeuralEnsemble/python-neo/actions/workflows/full-test.yml/badge.svg?event=push&branch=master
+    :target: https://github.com/NeuralEnsemble/python-neo/actions?query=event%3Apush+branch%3Amaster
     :alt: IO Unit Test Status (Github Actions)
 .. image:: https://coveralls.io/repos/NeuralEnsemble/python-neo/badge.png
    :target: https://coveralls.io/r/NeuralEnsemble/python-neo

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Code status
 
 .. image:: https://travis-ci.org/NeuralEnsemble/python-neo.png?branch=master
    :target: https://travis-ci.org/NeuralEnsemble/python-neo
-   :alt: Unit Test Status (TravisCI)
+   :alt: Core Unit Test Status (TravisCI)
 .. image:: https://github.com/NeuralEnsemble/python-neo/actions/workflows/full-test.yml/badge.svg?event=push&branch=master
     :target: https://github.com/NeuralEnsemble/python-neo/actions?query=event%3Apush+branch%3Amaster
     :alt: IO Unit Test Status (Github Actions)

--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,6 @@ Code status
 .. image:: https://coveralls.io/repos/NeuralEnsemble/python-neo/badge.png
    :target: https://coveralls.io/r/NeuralEnsemble/python-neo
    :alt: Unit Test Coverage
-.. image:: https://requires.io/github/NeuralEnsemble/python-neo/requirements.png?branch=master
-   :target: https://requires.io/github/NeuralEnsemble/python-neo/requirements/?branch=master
-   :alt: Requirements Status
 
 More information
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -34,9 +34,9 @@ Code status
 .. image:: https://travis-ci.org/NeuralEnsemble/python-neo.png?branch=master
    :target: https://travis-ci.org/NeuralEnsemble/python-neo
    :alt: Unit Test Status (TravisCI)
-.. image:: https://circleci.com/gh/NeuralEnsemble/python-neo.svg?style=svg
-    :target: https://circleci.com/gh/NeuralEnsemble/python-neo
-    :alt: Unit Test Status (CircleCI)
+.. image:: https://github.com/NeuralEnsemble/python-neo/actions/workflows/full-test.yml/badge.svg
+    :target: https://github.com/NeuralEnsemble/python-neo/actions/workflows/
+    :alt: IO Unit Test Status (Github Actions)
 .. image:: https://coveralls.io/repos/NeuralEnsemble/python-neo/badge.png
    :target: https://coveralls.io/r/NeuralEnsemble/python-neo
    :alt: Unit Test Coverage


### PR DESCRIPTION
This PR updates the badges as they are included in the readme.rst.
It removes the broken requirements badge and replaces the CI badge with a new badge generated upon any merge into the master branch.

As the new CI configuration is not run yet in this PR, the new badge is not yet created, but will (hopefully) once merged.
@samuelgarcia What do you think?