### PR TITLE
[spikeglxrawio] .meta file parsing fix

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -293,8 +293,13 @@ def read_meta_file(meta_file):
         lines = f.read().splitlines()
 
     info = {}
+    # Fix taken from: https://github.com/SpikeInterface/probeinterface/blob/
+    # 19d6518fbc67daca71aba5e99d8aa0d445b75eb7/probeinterface/io.py#L649-L662
     for line in lines:
-        k, v = line.split('=')
+        split_lines = line.split('=')
+        if len(split_lines) != 2:
+            continue
+        k, v = split_lines
         if k.startswith('~'):
             # replace by the list
             k = k[1:]

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -200,7 +200,10 @@ def scan_files(dirname):
                 continue
             meta_filename = Path(root) / file
             bin_filename = Path(root) / file.replace('.meta', '.bin')
-            meta = read_meta_file(meta_filename)
+            if meta_filename.exists() and bin_filename.exists():
+                meta = read_meta_file(meta_filename)
+            else:
+                continue
 
             num_chan = int(meta['nSavedChans'])
 


### PR DESCRIPTION
This PR fixes .meta line parsing using the solution from the [Probe Interface project](
https://github.com/SpikeInterface/probeinterface/blob/19d6518fbc67daca71aba5e99d8aa0d445b75eb7/probeinterface/io.py#L649-L662). I also make parsing of .meta conditional, since it should only be done when .bin with a matching name is present.