### PR TITLE
Update ElphyIO

### DIFF
--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -281,7 +281,7 @@ from neo.io.brainwaref32io import BrainwareF32IO
 from neo.io.brainwaresrcio import BrainwareSrcIO
 from neo.io.cedio import CedIO
 from neo.io.elanio import ElanIO
-# from neo.io.elphyio import ElphyIO
+from neo.io.elphyio import ElphyIO
 from neo.io.exampleio import ExampleIO
 from neo.io.igorproio import IgorIO
 from neo.io.intanio import IntanIO

--- a/neo/io/elphyio.py
+++ b/neo/io/elphyio.py
@@ -4223,13 +4223,14 @@ class ElphyIO(BaseIO):
         # each channel in the episode
         for channel in range(1, self.elphy_file.n_channels(episode) + 1):
             signal = self.elphy_file.get_signal(episode, channel)
+            x_unit = signal.x_unit.strip().decode()
             analog_signal = AnalogSignal(
                 signal.data['y'],
                 units=signal.y_unit,
                 t_start=signal.t_start * getattr(pq, signal.x_unit.strip().decode()),
                 t_stop=signal.t_stop * getattr(pq, signal.x_unit.strip().decode()),
                 # sampling_rate = signal.sampling_frequency * pq.kHz,
-                sampling_period=signal.sampling_period * getattr(pq, signal.x_unit.strip().decode()),
+                sampling_period=signal.sampling_period * getattr(pq, x_unit),
                 channel_name="episode {}, channel {}".format(int(episode + 1), int(channel + 1))
             )
             analog_signal.segment = segment

--- a/neo/io/elphyio.py
+++ b/neo/io/elphyio.py
@@ -87,8 +87,7 @@ import quantities as pq
 from neo.io.baseio import BaseIO
 
 # to import from core
-from neo.core import (Block, Segment,
-                      AnalogSignal, Event, SpikeTrain)
+from neo.core import (Block, Segment, AnalogSignal, Event, SpikeTrain)
 
 
 # --------------------------------------------------------
@@ -562,7 +561,7 @@ class ClassicFileInfo(FileInfoBlock):
 
     def get_title(self):
         title_length, title = struct.unpack('<B20s', self.file.read(21))
-        return unicode(title[0:title_length])
+        return str(title[0:title_length])
 
     def get_user_file_info(self):
         header = dict()
@@ -674,7 +673,7 @@ class MultistimFileInfo(FileInfoBlock):
         title_length = read_from_char(self.file, 'B')
         title, = struct.unpack('<%ss' % title_length, self.file.read(title_length))
         self.file.seek(self.file.tell() + 255 - title_length)
-        return unicode(title)
+        return str(title)
 
     def get_user_file_info(self):
         header = dict()
@@ -1858,7 +1857,7 @@ class ElphyLayout:
         for _ch in ch_mask:
             size = self.sample_size(ep, _ch)
             val = 1 if _ch == ch else 0
-            for _ in xrange(0, size):
+            for _ in np.arange(0, size):
                 _mask.append(val)
         return np.array(_mask)
 
@@ -1899,7 +1898,7 @@ class ElphyLayout:
         # create the mask for each shape
         shape_mask = list()
         for shape in reshape:
-            for _ in xrange(1, shape + 1):
+            for _ in np.arange(1, shape + 1):
                 shape_mask.append(shape)
 
         # create a set of masks to extract data

--- a/neo/test/iotest/test_elphyio.py
+++ b/neo/test/iotest/test_elphyio.py
@@ -8,23 +8,25 @@ from neo.io import ElphyIO
 from neo.test.iotest.common_io_test import BaseTestIO
 
 
-
-class TestElanIO(BaseTestIO, unittest.TestCase):
+class TestElphyIO(BaseTestIO, unittest.TestCase):
     ioclass = ElphyIO
-    files_to_test = ['DATA1.DAT', 'ElphyExample.DAT',
-                         'ElphyExample_Mode1.dat', 'ElphyExample_Mode2.dat',
-                         'ElphyExample_Mode3.dat']
-    files_to_download = ['DATA1.DAT', 'ElphyExample.DAT',
-                         'ElphyExample_Mode1.dat', 'ElphyExample_Mode2.dat',
-                         'ElphyExample_Mode3.dat']
+    entities_to_download = [
+        'elphy'
+    ]
+    entities_to_test = ['elphy/DATA1.DAT',
+                        'elphy/ElphyExample.DAT',
+                        'elphy/ElphyExample_Mode1.dat',
+                        'elphy/ElphyExample_Mode2.dat',
+                        'elphy/ElphyExample_Mode3.dat']
 
     def test_read_data(self):
-        io = ElphyIO(self.get_filename_path('DATA1.DAT'))
-        bl = io.read_block()
+        for filename in self.entities_to_test:
+            io = ElphyIO(self.get_local_path(filename))
+            bl = io.read_block()
 
-        print(bl)
-
-
+            self.assertTrue(len(bl.segments) > 0)
+            # ensure that at least one data object is generated for each file
+            self.assertTrue(any(list(bl.segments[0].size.values())))
 
 if __name__ == "__main__":
     unittest.main()

--- a/neo/test/iotest/test_elphyio.py
+++ b/neo/test/iotest/test_elphyio.py
@@ -1,0 +1,30 @@
+"""
+Tests of neo.io.elphyo
+"""
+
+import unittest
+
+from neo.io import ElphyIO
+from neo.test.iotest.common_io_test import BaseTestIO
+
+
+
+class TestElanIO(BaseTestIO, unittest.TestCase):
+    ioclass = ElphyIO
+    files_to_test = ['DATA1.DAT', 'ElphyExample.DAT',
+                         'ElphyExample_Mode1.dat', 'ElphyExample_Mode2.dat',
+                         'ElphyExample_Mode3.dat']
+    files_to_download = ['DATA1.DAT', 'ElphyExample.DAT',
+                         'ElphyExample_Mode1.dat', 'ElphyExample_Mode2.dat',
+                         'ElphyExample_Mode3.dat']
+
+    def test_read_data(self):
+        io = ElphyIO(self.get_filename_path('DATA1.DAT'))
+        bl = io.read_block()
+
+        print(bl)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/neo/test/iotest/test_elphyio.py
+++ b/neo/test/iotest/test_elphyio.py
@@ -28,5 +28,6 @@ class TestElphyIO(BaseTestIO, unittest.TestCase):
             # ensure that at least one data object is generated for each file
             self.assertTrue(any(list(bl.segments[0].size.values())))
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR readds ElphyIO to the standard list of IOs, updates it to be compatible with the current python versions and adds very basic tests. For now the tests are only checking if data objects were create, but do not check the data values loaded. Here I am missing the time for implementation as well as an alternative system to read elphy files for comparison.

@samuelgarcia @apdavison Do you think this is still enough to keep Elphy in the list of supported IOs despite #950 ?
I did not look into #332 yet, as there's no link to the mentioned alternative implementation. 