### PR TITLE
Fix Maxwell gain when 'lsb' is not in settings

### DIFF
--- a/neo/rawio/maxwellrawio.py
+++ b/neo/rawio/maxwellrawio.py
@@ -93,14 +93,14 @@ class MaxwellRawIO(BaseRawIO):
                 sr = 20000.
                 settings = h5["settings"]
                 if 'lsb' in settings:
-                    gain_uV = settings['lsb'][:][0] * 1e6
+                    gain_uV = settings['lsb'][0] * 1e6
                 else:
                     if "gain" not in settings:
                         print("'gain' amd 'lsb' not found in settings. "
                               "Setting gain to 512 (default)")
                         gain = 512
                     else:
-                        gain = settings['gain'][:][0]
+                        gain = settings['gain'][0]
                     gain_uV = 3.3 / (1024 * gain) * 1e6
                 sigs = h5['sig']
                 mapping = h5["mapping"]
@@ -109,16 +109,16 @@ class MaxwellRawIO(BaseRawIO):
                 self._channel_slice = ids
             elif int(version) > 20160704:
                 settings = h5['wells'][stream_id][self.rec_name]['settings']
-                sr = settings['sampling'][:][0]
+                sr = settings['sampling'][0]
                 if 'lsb' in settings:
-                    gain_uV = settings['lsb'][:][0] * 1e6
+                    gain_uV = settings['lsb'][0] * 1e6
                 else:
                     if "gain" not in settings:
                         print("'gain' amd 'lsb' not found in settings. "
                               "Setting gain to 512 (default)")
                         gain = 512
                     else:
-                        gain = settings['gain'][:][0]
+                        gain = settings['gain'][0]
                     gain_uV = 3.3 / (1024 * gain) * 1e6
                 mapping = settings['mapping']
                 sigs = h5['wells'][stream_id][self.rec_name]['groups']['routed']['raw']

--- a/neo/rawio/maxwellrawio.py
+++ b/neo/rawio/maxwellrawio.py
@@ -91,7 +91,16 @@ class MaxwellRawIO(BaseRawIO):
         for stream_id in signal_streams['id']:
             if int(version) == 20160704:
                 sr = 20000.
-                gain_uV = h5['settings']['lsb'][0] * 1e6
+                settings = h5["settings"]
+                if 'lsb' in settings:
+                    gain_uV = settings['lsb'][:][0] * 1e6
+                else:
+                    if "gain" not in settings:
+                        print("'gain' amd 'lsb' not found in settings. Setting gain to 512 (default)")
+                        gain = 512
+                    else:
+                        gain = settings['gain'][:][0]
+                    gain_uV = 3.3 / (1024 * gain) * 1e6
                 sigs = h5['sig']
                 mapping = h5["mapping"]
                 ids = np.array(mapping['channel'])

--- a/neo/rawio/maxwellrawio.py
+++ b/neo/rawio/maxwellrawio.py
@@ -100,7 +100,15 @@ class MaxwellRawIO(BaseRawIO):
             elif int(version) > 20160704:
                 settings = h5['wells'][stream_id][self.rec_name]['settings']
                 sr = settings['sampling'][:][0]
-                gain_uV = settings['lsb'][:][0] * 1e6
+                if 'lsb' in settings:
+                    gain_uV = settings['lsb'][:][0] * 1e6
+                else:
+                    if "gain" not in settings:
+                        print("'gain' amd 'lsb' not found in settings. Setting gain to 512 (default)")
+                        gain = 512
+                    else:
+                        gain = settings['gain'][:][0]
+                    gain_uV = 3.3 / (1024 * gain) * 1e6
                 mapping = settings['mapping']
                 sigs = h5['wells'][stream_id][self.rec_name]['groups']['routed']['raw']
 

--- a/neo/rawio/maxwellrawio.py
+++ b/neo/rawio/maxwellrawio.py
@@ -96,7 +96,8 @@ class MaxwellRawIO(BaseRawIO):
                     gain_uV = settings['lsb'][:][0] * 1e6
                 else:
                     if "gain" not in settings:
-                        print("'gain' amd 'lsb' not found in settings. Setting gain to 512 (default)")
+                        print("'gain' amd 'lsb' not found in settings. "
+                              "Setting gain to 512 (default)")
                         gain = 512
                     else:
                         gain = settings['gain'][:][0]
@@ -113,7 +114,8 @@ class MaxwellRawIO(BaseRawIO):
                     gain_uV = settings['lsb'][:][0] * 1e6
                 else:
                     if "gain" not in settings:
-                        print("'gain' amd 'lsb' not found in settings. Setting gain to 512 (default)")
+                        print("'gain' amd 'lsb' not found in settings. "
+                              "Setting gain to 512 (default)")
                         gain = 512
                     else:
                         gain = settings['gain'][:][0]


### PR DESCRIPTION
In some older files, the `lsb` field might not be present in settings. In that case, the `gain_uV` can be computed as:

`gain_uV = 3.3 / (1024 * gain) * 1e6`

where `gain` is the amplifier gain, 3.3 is the ADC voltage range, and 1024 (10^10), is the number of bits of the ADC.