### PR TITLE
Spikeglx filesize check

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -248,6 +248,9 @@ def scan_files(dirname):
                 info['bin_file'] = str(bin_filename)
                 info_list.append(info)
 
+            if bin_filename.stat().st_size != meta['fileSizeBytes']:
+                raise Exception('.meta file has faulty value for .bin filesize')
+
     return info_list
 
 

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -250,7 +250,7 @@ def scan_files(dirname):
                 info_list.append(info)
 
             if bin_filename.stat().st_size != meta['fileSizeBytes']:
-                raise warnings.warn('.meta file has faulty value for .bin file size on disc')
+                warnings.warn('.meta file has faulty value for .bin file size on disc')
 
     return info_list
 

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -44,6 +44,7 @@ imDatPrb_type=24 (NP 2.0, 4-shank)
 Author : Samuel Garcia
 """
 
+import warnings
 from .baserawio import (BaseRawIO, _signal_channel_dtype, _signal_stream_dtype,
                 _spike_channel_dtype, _event_channel_dtype)
 
@@ -249,7 +250,7 @@ def scan_files(dirname):
                 info_list.append(info)
 
             if bin_filename.stat().st_size != meta['fileSizeBytes']:
-                raise Exception('.meta file has faulty value for .bin file size on disc')
+                raise warnings.warn('.meta file has faulty value for .bin file size on disc')
 
     return info_list
 

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -249,7 +249,7 @@ def scan_files(dirname):
                 info_list.append(info)
 
             if bin_filename.stat().st_size != meta['fileSizeBytes']:
-                raise Exception('.meta file has faulty value for .bin filesize')
+                raise Exception('.meta file has faulty value for .bin file size on disc')
 
     return info_list
 


### PR DESCRIPTION
I came across some pair of spikeglx imec output files that have different value of filesize (of the `.bin`) file than that retrieved from the `.meta` file.
While this may be a faulty .meta file, but I think an exception should be thrown while parsing such a file. 