### PR TITLE
Add EDF IO

### DIFF
--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -291,6 +291,7 @@ from neo.io.brainwaredamio import BrainwareDamIO
 from neo.io.brainwaref32io import BrainwareF32IO
 from neo.io.brainwaresrcio import BrainwareSrcIO
 from neo.io.cedio import CedIO
+from neo.io.edfio import EdfIO
 from neo.io.elanio import ElanIO
 from neo.io.elphyio import ElphyIO
 from neo.io.exampleio import ExampleIO
@@ -341,6 +342,7 @@ iolist = [
     BrainwareF32IO,
     BrainwareSrcIO,
     CedIO,
+    EdfIO,
     ElanIO,
     # ElphyIO,
     ExampleIO,

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -291,7 +291,7 @@ from neo.io.brainwaredamio import BrainwareDamIO
 from neo.io.brainwaref32io import BrainwareF32IO
 from neo.io.brainwaresrcio import BrainwareSrcIO
 from neo.io.cedio import CedIO
-from neo.io.edfio import EdfIO
+from neo.io.edfio import EDFIO
 from neo.io.elanio import ElanIO
 from neo.io.elphyio import ElphyIO
 from neo.io.exampleio import ExampleIO
@@ -342,7 +342,7 @@ iolist = [
     BrainwareF32IO,
     BrainwareSrcIO,
     CedIO,
-    EdfIO,
+    EDFIO,
     ElanIO,
     # ElphyIO,
     ExampleIO,

--- a/neo/io/edfio.py
+++ b/neo/io/edfio.py
@@ -1,25 +1,25 @@
 """
 IO for reading edf and edfplus files using pyedflib
-https://pyedflib.readthedocs.io/en/latest/
+
+PyEDFLib
+https://pyedflib.readthedocs.io
 https://github.com/holgern/pyedflib
 
-Author: Julia Sprenger
+EDF Format Specifications: https://www.edfplus.info/
 
+Author: Julia Sprenger
 """
 
 from neo.io.basefromrawio import BaseFromRaw
-from neo.rawio.edfrawio import EdfRawIO
+from neo.rawio.edfrawio import EDFRawIO
 
 
-class EdfIO(EdfRawIO, BaseFromRaw):
-    name = 'edf IO'
-    description = "IO for reading edf and edf+ files"
+class EDFIO(EDFRawIO, BaseFromRaw):
+    name = 'EDF IO'
+    description = "IO for reading EDF and EDF+ files"
 
-    # This is an inportant choice when there are several channels.
-    #   'split-all' :  1 AnalogSignal each 1 channel
-    #   'group-by-same-units' : one 2D AnalogSignal for each group of channel with same units
     _prefered_signal_group_mode = 'group-by-same-units'
 
     def __init__(self, filename=''):
-        EdfRawIO.__init__(self, filename=filename)
+        EDFRawIO.__init__(self, filename=filename)
         BaseFromRaw.__init__(self, filename)

--- a/neo/io/edfio.py
+++ b/neo/io/edfio.py
@@ -17,7 +17,6 @@ from neo.rawio.edfrawio import EDFRawIO
 class EDFIO(EDFRawIO, BaseFromRaw):
     """
     IO for reading edf and edf+ files.
-    Note that this IO does not yet implement true lazy loading.
     """
     name = 'EDF IO'
     description = "IO for reading EDF and EDF+ files"

--- a/neo/io/edfio.py
+++ b/neo/io/edfio.py
@@ -1,0 +1,25 @@
+"""
+IO for reading edf and edfplus files using pyedflib
+https://pyedflib.readthedocs.io/en/latest/
+https://github.com/holgern/pyedflib
+
+Author: Julia Sprenger
+
+"""
+
+from neo.io.basefromrawio import BaseFromRaw
+from neo.rawio.edfrawio import EdfRawIO
+
+
+class EdfIO(EdfRawIO, BaseFromRaw):
+    name = 'edf IO'
+    description = "IO for reading edf and edf+ files"
+
+    # This is an inportant choice when there are several channels.
+    #   'split-all' :  1 AnalogSignal each 1 channel
+    #   'group-by-same-units' : one 2D AnalogSignal for each group of channel with same units
+    _prefered_signal_group_mode = 'group-by-same-units'
+
+    def __init__(self, filename=''):
+        EdfRawIO.__init__(self, filename=filename)
+        BaseFromRaw.__init__(self, filename)

--- a/neo/io/edfio.py
+++ b/neo/io/edfio.py
@@ -1,5 +1,5 @@
 """
-IO for reading edf and edfplus files using pyedflib
+IO for reading edf and edf+ files using pyedflib
 
 PyEDFLib
 https://pyedflib.readthedocs.io
@@ -15,6 +15,10 @@ from neo.rawio.edfrawio import EDFRawIO
 
 
 class EDFIO(EDFRawIO, BaseFromRaw):
+    """
+    IO for reading edf and edf+ files.
+    Note that this IO does not yet implement true lazy loading.
+    """
     name = 'EDF IO'
     description = "IO for reading EDF and EDF+ files"
 

--- a/neo/rawio/__init__.py
+++ b/neo/rawio/__init__.py
@@ -169,7 +169,7 @@ from neo.rawio.biocamrawio import BiocamRawIO
 from neo.rawio.blackrockrawio import BlackrockRawIO
 from neo.rawio.brainvisionrawio import BrainVisionRawIO
 from neo.rawio.cedrawio import CedRawIO
-from neo.rawio.edfrawio import EdfRawIO
+from neo.rawio.edfrawio import EDFRawIO
 from neo.rawio.elanrawio import ElanRawIO
 from neo.rawio.examplerawio import ExampleRawIO
 from neo.rawio.intanrawio import IntanRawIO
@@ -201,7 +201,7 @@ rawiolist = [
     BlackrockRawIO,
     BrainVisionRawIO,
     CedRawIO,
-    EdfRawIO,
+    EDFRawIO,
     ElanRawIO,
     IntanRawIO,
     MicromedRawIO,

--- a/neo/rawio/__init__.py
+++ b/neo/rawio/__init__.py
@@ -19,6 +19,7 @@ Classes:
 * :attr:`BlackrockRawIO`
 * :attr:`BrainVisionRawIO`
 * :attr:`CedRawIO`
+* :attr: `EdfRawIO`
 * :attr:`ElanRawIO`
 * :attr:`IntanRawIO`
 * :attr:`MaxwellRawIO`
@@ -67,6 +68,10 @@ Classes:
     .. autoattribute:: extensions
 
 .. autoclass:: neo.rawio.CedRawIO
+
+    .. autoattribute:: extensions
+
+.. autoclass:: neo.rawio.EdfRawIO
 
     .. autoattribute:: extensions
 
@@ -164,6 +169,7 @@ from neo.rawio.biocamrawio import BiocamRawIO
 from neo.rawio.blackrockrawio import BlackrockRawIO
 from neo.rawio.brainvisionrawio import BrainVisionRawIO
 from neo.rawio.cedrawio import CedRawIO
+from neo.rawio.edfrawio import EdfRawIO
 from neo.rawio.elanrawio import ElanRawIO
 from neo.rawio.examplerawio import ExampleRawIO
 from neo.rawio.intanrawio import IntanRawIO
@@ -195,6 +201,7 @@ rawiolist = [
     BlackrockRawIO,
     BrainVisionRawIO,
     CedRawIO,
+    EdfRawIO,
     ElanRawIO,
     IntanRawIO,
     MicromedRawIO,

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -18,7 +18,7 @@ import numpy as np
 try:
     from pyedflib import highlevel
     HAS_PYEDF = True
-except:
+except ImportError:
     HAS_PYEDF = False
 
 
@@ -82,7 +82,7 @@ class EDFRawIO(BaseRawIO):
             dtype = self.signals.dtype.str
             units = sig_dict['dimension']
             physical_range = sig_dict['physical_max'] - sig_dict['physical_min']
-            digital_range = sig_dict['digital_max']-sig_dict['digital_min']
+            digital_range = sig_dict['digital_max'] - sig_dict['digital_min']
             gain = physical_range / digital_range
             offset = -1 * sig_dict['digital_min'] * gain + sig_dict['physical_min']
             stream_id = 0  # file contains only a single stream
@@ -117,8 +117,10 @@ class EDFRawIO(BaseRawIO):
         # extract keys for array_annotations common to all signals and not already used
         ignore_annotations = ['label', 'dimension', 'sample_rate', 'physical_min', 'physical_max',
                               'digital_min', 'digital_max']
-        array_keys = [k for k in self.signal_headers[0]
-                      if k not in ignore_annotations and all([k in h for h in self.signal_headers])]
+        array_keys = []
+        for k in self.signal_headers[0]:
+            if k not in ignore_annotations and all([k in h for h in self.signal_headers]):
+                array_keys.append(k)
 
         for array_key in array_keys:
             array_anno = {array_key: [h[array_key] for h in self.signal_headers]}

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -197,11 +197,12 @@ class EDFRawIO(BaseRawIO):
             self.edf_reader.read_digital_signal(channel_idx, i_start, n, buffer)
             data.append(buffer)
 
+        # downgrade to int16 as this is what is used in the edf file format
+        # use fortran (column major) order to be more efficient after transposal
+        data = np.asarray(data, dtype=np.int16, order='F')
+
         # use dimensions (time, channel)
         data = data.T
-
-        # downgrade to int16 as this is what is used in the edf file format
-        data = np.asarray(data, dtype=np.int16)
 
         return data
 

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -153,7 +153,7 @@ class EDFRawIO(BaseRawIO):
 
     def _segment_t_start(self, block_index, seg_index):
         # no time offset provided by EDF format
-        return 0  # in seconds
+        return 0.  # in seconds
 
     def _segment_t_stop(self, block_index, seg_index):
         t_stop = self.edf_reader.datarecord_duration * self.edf_reader.datarecords_in_file
@@ -166,7 +166,7 @@ class EDFRawIO(BaseRawIO):
         return self.edf_reader.getNSamples()[chidx]
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
-        return 0  # EDF does not provide temporal offset information
+        return 0.  # EDF does not provide temporal offset information
 
     def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop,
                                 stream_index, channel_indexes):
@@ -197,10 +197,13 @@ class EDFRawIO(BaseRawIO):
             self.edf_reader.read_digital_signal(channel_idx, i_start, n, buffer)
             data.append(buffer)
 
+        # use dimensions (time, channel)
+        data = data.T
+
         # downgrade to int16 as this is what is used in the edf file format
         data = np.asarray(data, dtype=np.int16)
 
-        return data.T  # use dimensions (time, channel)
+        return data
 
     def _spike_count(self, block_index, seg_index, spike_channel_index):
         return None

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -51,7 +51,7 @@ class EDFRawIO(BaseRawIO):
 
         self.signals = None
         self.signal_headers = []
-        self.header = {}
+        self.edf_header = {}
 
     def _source_name(self):
         return self.filename

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -1,0 +1,354 @@
+"""
+ExampleRawIO is a class of a  fake example.
+This is to be used when coding a new RawIO.
+
+
+Rules for creating a new class:
+  1. Step 1: Create the main class
+    * Create a file in **neo/rawio/** that endith with "rawio.py"
+    * Create the class that inherits from BaseRawIO
+    * copy/paste all methods that need to be implemented.
+    * code hard! The main difficulty is `_parse_header()`.
+      In short you have a create a mandatory dict than
+      contains channel informations::
+
+            self.header = {}
+            self.header['nb_block'] = 2
+            self.header['nb_segment'] = [2, 3]
+            self.header['signal_streams'] = signal_streams
+            self.header['signal_channels'] = signal_channels
+            self.header['spike_channels'] = spike_channels
+            self.header['event_channels'] = event_channels
+
+  2. Step 2: RawIO test:
+    * create a file in neo/rawio/tests with the same name with "test_" prefix
+    * copy paste neo/rawio/tests/test_examplerawio.py and do the same
+
+  3. Step 3 : Create the neo.io class with the wrapper
+    * Create a file in neo/io/ that ends with "io.py"
+    * Create a class that inherits both your RawIO class and BaseFromRaw class
+    * copy/paste from neo/io/exampleio.py
+
+  4.Step 4 : IO test
+    * create a file in neo/test/iotest with the same previous name with "test_" prefix
+    * copy/paste from neo/test/iotest/test_exampleio.py
+
+
+
+"""
+
+from .baserawio import (BaseRawIO, _signal_channel_dtype, _signal_stream_dtype,
+                _spike_channel_dtype, _event_channel_dtype)
+
+import numpy as np
+
+try:
+    from pyedflib import highlevel
+    HAS_PYEDF = True
+except:
+    HAS_PYEDF = False
+
+
+class EdfRawIO(BaseRawIO):
+    """
+    Class for "reading" fake data from an imaginary file.
+
+    For the user, it gives access to raw data (signals, event, spikes) as they
+    are in the (fake) file int16 and int64.
+
+    For a developer, it is just an example showing guidelines for someone who wants
+    to develop a new IO module.
+
+    Two rules for developers:
+      * Respect the :ref:`neo_rawio_API`
+      * Follow the :ref:`io_guiline`
+
+    This fake IO:
+        * has 2 blocks
+        * blocks have 2 and 3 segments
+        * has  2 signals streams  of 8 channel each (sample_rate = 10000) so 16 channels in total
+        * has 3 spike_channels
+        * has 2 event channels: one has *type=event*, the other has
+          *type=epoch*
+
+
+    Usage:
+        >>> import neo.rawio
+        >>> r = neo.rawio.ExampleRawIO(filename='itisafake.nof')
+        >>> r.parse_header()
+        >>> print(r)
+        >>> raw_chunk = r.get_analogsignal_chunk(block_index=0, seg_index=0,
+                            i_start=0, i_stop=1024,  channel_names=channel_names)
+        >>> float_chunk = reader.rescale_signal_raw_to_float(raw_chunk, dtype='float64',
+                            channel_indexes=[0, 3, 6])
+        >>> spike_timestamp = reader.spike_timestamps(spike_channel_index=0,
+                            t_start=None, t_stop=None)
+        >>> spike_times = reader.rescale_spike_timestamp(spike_timestamp, 'float64')
+        >>> ev_timestamps, _, ev_labels = reader.event_timestamps(event_channel_index=0)
+
+    """
+    extensions = ['fake']
+    rawmode = 'one-file'
+
+    def __init__(self, filename=''):
+        if not HAS_PYEDF:
+            raise ValueError('Requires pyedflib')
+        BaseRawIO.__init__(self)
+        # note that this filename is ued in self._source_name
+        self.filename = filename
+
+    def _source_name(self):
+        return self.filename
+
+    def _parse_header(self):
+
+        signal_streams = []
+
+        signal_channels = []
+        signal_streams = np.array(signal_streams, dtype=_signal_stream_dtype)
+
+        # read an edf file
+        signals, signal_headers, header = highlevel.read_edf(self.filename)
+
+        signal_channels = []
+        for ch_idx, sig_dict in enumerate(signal_headers):
+            ch_name = sig_dict['label']
+            chan_id = ch_idx
+            sr = sig_dict['sample_rate']  # Hz
+            dtype = signals.dtype.str
+            units = sig_dict['dimension']
+            physical_range = sig_dict['physical_max'] - sig_dict['physical_min']
+            digital_range = sig_dict['digital_max']-sig_dict['digital_min']
+            gain = physical_range / digital_range
+            offset = -1 * sig_dict['digital_min'] * gain + sig_dict['physical_min']
+            stream_id = 0  # file contains only a single stream
+            signal_channels.append((ch_name, chan_id, sr, dtype, units, gain, offset, stream_id))
+
+        # no unit/epoch information contained in edf
+        spike_channels = []
+        spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
+
+        event_channels = []
+        event_channels = np.array(event_channels, dtype=_event_channel_dtype)
+
+        self.header = {}
+        self.header['nb_block'] = 2
+        self.header['nb_segment'] = [2, 3]
+        self.header['signal_streams'] = signal_streams
+        self.header['signal_channels'] = signal_channels
+        self.header['spike_channels'] = spike_channels
+        self.header['event_channels'] = event_channels
+
+        self._generate_minimal_annotations()
+        # this pprint lines really help for understand the nested (and complicated sometimes) dict
+        from pprint import pprint
+        pprint(self.raw_annotations)
+
+        # Until here all mandatory operations for setting up a rawio are implemented.
+        # The following lines provide additional, recommended annotations for the
+        # final neo objects.
+        bl_ann = self.raw_annotations['blocks'][0]
+        bl_ann['name'] = 'EDF Data Block'
+        bl_ann.update(header)
+        seg_ann = bl_ann['segments'][0]
+        seg_ann['name'] = 'Seg #0 Block #0'
+        ignore_annotations = ['label', 'dimension', 'sample_rate', 'physical_min', 'physical_max',
+                              'digital_min', 'digital_max']
+        array_keys = [k for k in signal_headers[0]
+                      if all([k in h for h in signal_headers.values()])]
+        for array_key in array_keys:
+            array_values = [v[array_key] for v in signal_headers.values]
+            seg_ann['signals'][ch_idx]['__array_annotations__'][array_key] = array_values
+
+    def _segment_t_start(self, block_index, seg_index):
+        # this must return an float scale in second
+        # this t_start will be shared by all object in the segment
+        # except AnalogSignal
+        all_starts = [[0., 15.], [0., 20., 60.]]
+        return all_starts[block_index][seg_index]
+
+    def _segment_t_stop(self, block_index, seg_index):
+        # this must return an float scale in second
+        all_stops = [[10., 25.], [10., 30., 70.]]
+        return all_stops[block_index][seg_index]
+
+    def _get_signal_size(self, block_index, seg_index, stream_index):
+        # We generate fake data in which the two stream signals have the same shape
+        # across all segments (10.0 seconds)
+        # This is not the case for real data, instead you should return the signal
+        # size depending on the block_index and segment_index
+        # this must return an int = the number of sample
+
+        # Note that channel_indexes can be ignored for most cases
+        # except for several sampling rate.
+        return 100000
+
+    def _get_signal_t_start(self, block_index, seg_index, stream_index):
+        # This give the t_start of signals.
+        # Very often this equal to _segment_t_start but not
+        # always.
+        # this must return an float scale in second
+
+        # Note that channel_indexes can be ignored for most cases
+        # except for several sampling rate.
+
+        # Here this is the same.
+        # this is not always the case
+        return self._segment_t_start(block_index, seg_index)
+
+    def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop,
+                                stream_index, channel_indexes):
+        # this must return a signal chunk in a signal stream
+        # limited with i_start/i_stop (can be None)
+        # channel_indexes can be None (=all channel in the stream) or a list or numpy.array
+        # This must return a numpy array 2D (even with one channel).
+        # This must return the orignal dtype. No conversion here.
+        # This must as fast as possible.
+        # To speed up this call all preparatory calculations should be implemented
+        # in _parse_header().
+
+        # Here we are lucky:  our signals is always zeros!!
+        # it is not always the case :)
+        # internally signals are int16
+        # convertion to real units is done with self.header['signal_channels']
+
+        if i_start is None:
+            i_start = 0
+        if i_stop is None:
+            i_stop = 100000
+
+        if i_start < 0 or i_stop > 100000:
+            # some check
+            raise IndexError("I don't like your jokes")
+
+        if channel_indexes is None:
+            nb_chan = 8
+        elif isinstance(channel_indexes, slice):
+            channel_indexes = np.arange(8, dtype='int')[channel_indexes]
+            nb_chan = len(channel_indexes)
+        else:
+            channel_indexes = np.asarray(channel_indexes)
+            if any(channel_indexes < 0):
+                raise IndexError('bad boy')
+            if any(channel_indexes >= 8):
+                raise IndexError('big bad wolf')
+            nb_chan = len(channel_indexes)
+
+        raw_signals = np.zeros((i_stop - i_start, nb_chan), dtype='int16')
+        return raw_signals
+
+    def _spike_count(self, block_index, seg_index, spike_channel_index):
+        # Must return the nb of spikes for given (block_index, seg_index, spike_channel_index)
+        # we are lucky:  our units have all the same nb of spikes!!
+        # it is not always the case
+        nb_spikes = 20
+        return nb_spikes
+
+    def _get_spike_timestamps(self, block_index, seg_index, spike_channel_index, t_start, t_stop):
+        # In our IO, timestamp are internally coded 'int64' and they
+        # represent the index of the signals 10kHz
+        # we are lucky: spikes have the same discharge in all segments!!
+        # incredible neuron!! This is not always the case
+
+        # the same clip t_start/t_start must be used in _spike_raw_waveforms()
+
+        ts_start = (self._segment_t_start(block_index, seg_index) * 10000)
+
+        spike_timestamps = np.arange(0, 10000, 500) + ts_start
+
+        if t_start is not None or t_stop is not None:
+            # restricte spikes to given limits (in seconds)
+            lim0 = int(t_start * 10000)
+            lim1 = int(t_stop * 10000)
+            mask = (spike_timestamps >= lim0) & (spike_timestamps <= lim1)
+            spike_timestamps = spike_timestamps[mask]
+
+        return spike_timestamps
+
+    def _rescale_spike_timestamp(self, spike_timestamps, dtype):
+        # must rescale to second a particular spike_timestamps
+        # with a fixed dtype so the user can choose the precisino he want.
+        spike_times = spike_timestamps.astype(dtype)
+        spike_times /= 10000.  # because 10kHz
+        return spike_times
+
+    def _get_spike_raw_waveforms(self, block_index, seg_index, spike_channel_index,
+                                 t_start, t_stop):
+        # this must return a 3D numpy array (nb_spike, nb_channel, nb_sample)
+        # in the original dtype
+        # this must be as fast as possible.
+        # the same clip t_start/t_start must be used in _spike_timestamps()
+
+        # If there there is no waveform supported in the
+        # IO them _spike_raw_waveforms must return None
+
+        # In our IO waveforms come from all channels
+        # they are int16
+        # convertion to real units is done with self.header['spike_channels']
+        # Here, we have a realistic case: all waveforms are only noise.
+        # it is not always the case
+        # we 20 spikes with a sweep of 50 (5ms)
+
+        # trick to get how many spike in the slice
+        ts = self._get_spike_timestamps(block_index, seg_index,
+                                        spike_channel_index, t_start, t_stop)
+        nb_spike = ts.size
+
+        np.random.seed(2205)  # a magic number (my birthday)
+        waveforms = np.random.randint(low=-2**4, high=2**4, size=nb_spike * 50, dtype='int16')
+        waveforms = waveforms.reshape(nb_spike, 1, 50)
+        return waveforms
+
+    def _event_count(self, block_index, seg_index, event_channel_index):
+        # event and spike are very similar
+        # we have 2 event channels
+        if event_channel_index == 0:
+            # event channel
+            return 6
+        elif event_channel_index == 1:
+            # epoch channel
+            return 10
+
+    def _get_event_timestamps(self, block_index, seg_index, event_channel_index, t_start, t_stop):
+        # the main difference between spike channel and event channel
+        # is that for here we have 3 numpy array timestamp, durations, labels
+        # durations must be None for 'event'
+        # label must a dtype ='U'
+
+        # in our IO event are directly coded in seconds
+        seg_t_start = self._segment_t_start(block_index, seg_index)
+        if event_channel_index == 0:
+            timestamp = np.arange(0, 6, dtype='float64') + seg_t_start
+            durations = None
+            labels = np.array(['trigger_a', 'trigger_b'] * 3, dtype='U12')
+        elif event_channel_index == 1:
+            timestamp = np.arange(0, 10, dtype='float64') + .5 + seg_t_start
+            durations = np.ones((10), dtype='float64') * .25
+            labels = np.array(['zoneX'] * 5 + ['zoneZ'] * 5, dtype='U12')
+
+        if t_start is not None:
+            keep = timestamp >= t_start
+            timestamp, labels = timestamp[keep], labels[keep]
+            if durations is not None:
+                durations = durations[keep]
+
+        if t_stop is not None:
+            keep = timestamp <= t_stop
+            timestamp, labels = timestamp[keep], labels[keep]
+            if durations is not None:
+                durations = durations[keep]
+
+        return timestamp, durations, labels
+
+    def _rescale_event_timestamp(self, event_timestamps, dtype, event_channel_index):
+        # must rescale to second a particular event_timestamps
+        # with a fixed dtype so the user can choose the precisino he want.
+
+        # really easy here because in our case it is already seconds
+        event_times = event_timestamps.astype(dtype)
+        return event_times
+
+    def _rescale_epoch_duration(self, raw_duration, dtype, event_channel_index):
+        # really easy here because in our case it is already seconds
+        durations = raw_duration.astype(dtype)
+        return durations

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -17,6 +17,7 @@ import numpy as np
 
 try:
     from pyedflib import EdfReader
+
     HAS_PYEDF = True
 except ImportError:
     HAS_PYEDF = False
@@ -227,7 +228,7 @@ class EDFRawIO(BaseRawIO):
 
         # only consider events and epochs that overlap with t_start t_stop range
         time_mask = ((t_start < timestamps) & (timestamps < t_stop)) | \
-                    ((t_start < (timestamps+durations)) & ((timestamps+durations) < t_stop))
+                    ((t_start < (timestamps + durations)) & ((timestamps + durations) < t_stop))
 
         # separate event from epoch times
         event_mask = durations[time_mask] == 0

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -84,10 +84,11 @@ class EDFRawIO(BaseRawIO):
             ch_name = sig_dict['label']
             chan_id = ch_idx
             sr = sig_dict['sample_rate']  # Hz
-            dtype = np.int16  # assume general int16 based on edf documentation
+            dtype = 'int16'  # assume general int16 based on edf documentation
             units = sig_dict['dimension']
             physical_range = sig_dict['physical_max'] - sig_dict['physical_min']
-            digital_range = sig_dict['digital_max'] - sig_dict['digital_min']
+            # number of digital steps resolved (+1 to account for '0')
+            digital_range = sig_dict['digital_max'] - sig_dict['digital_min'] + 1
             gain = physical_range / digital_range
             offset = -1 * sig_dict['digital_min'] * gain + sig_dict['physical_min']
 

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -222,3 +222,6 @@ class EDFRawIO(BaseRawIO):
 
     def _rescale_epoch_duration(self, raw_duration, dtype, event_channel_index):
         return None
+
+    def close(self):
+        self.edf_reader.close()

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -239,7 +239,7 @@ class EDFRawIO(BaseRawIO):
             durations = None
 
         times = timestamps[time_mask][event_mask]
-        labels = labels[time_mask][event_mask]
+        labels = np.asarray(labels[time_mask][event_mask], dtype='U')
 
         return times, durations, labels
 

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -1,40 +1,13 @@
 """
-ExampleRawIO is a class of a  fake example.
-This is to be used when coding a new RawIO.
+RawIO for reading EDF and EDF+ files using pyedflib
 
+PyEDFLib
+https://pyedflib.readthedocs.io
+https://github.com/holgern/pyedflib
 
-Rules for creating a new class:
-  1. Step 1: Create the main class
-    * Create a file in **neo/rawio/** that endith with "rawio.py"
-    * Create the class that inherits from BaseRawIO
-    * copy/paste all methods that need to be implemented.
-    * code hard! The main difficulty is `_parse_header()`.
-      In short you have a create a mandatory dict than
-      contains channel informations::
+EDF Format Specifications: https://www.edfplus.info/
 
-            self.header = {}
-            self.header['nb_block'] = 2
-            self.header['nb_segment'] = [2, 3]
-            self.header['signal_streams'] = signal_streams
-            self.header['signal_channels'] = signal_channels
-            self.header['spike_channels'] = spike_channels
-            self.header['event_channels'] = event_channels
-
-  2. Step 2: RawIO test:
-    * create a file in neo/rawio/tests with the same name with "test_" prefix
-    * copy paste neo/rawio/tests/test_examplerawio.py and do the same
-
-  3. Step 3 : Create the neo.io class with the wrapper
-    * Create a file in neo/io/ that ends with "io.py"
-    * Create a class that inherits both your RawIO class and BaseFromRaw class
-    * copy/paste from neo/io/exampleio.py
-
-  4.Step 4 : IO test
-    * create a file in neo/test/iotest with the same previous name with "test_" prefix
-    * copy/paste from neo/test/iotest/test_exampleio.py
-
-
-
+Author: Julia Sprenger
 """
 
 from .baserawio import (BaseRawIO, _signal_channel_dtype, _signal_stream_dtype,
@@ -49,73 +22,64 @@ except:
     HAS_PYEDF = False
 
 
-class EdfRawIO(BaseRawIO):
+class EDFRawIO(BaseRawIO):
     """
-    Class for "reading" fake data from an imaginary file.
-
-    For the user, it gives access to raw data (signals, event, spikes) as they
-    are in the (fake) file int16 and int64.
-
-    For a developer, it is just an example showing guidelines for someone who wants
-    to develop a new IO module.
-
-    Two rules for developers:
-      * Respect the :ref:`neo_rawio_API`
-      * Follow the :ref:`io_guiline`
-
-    This fake IO:
-        * has 2 blocks
-        * blocks have 2 and 3 segments
-        * has  2 signals streams  of 8 channel each (sample_rate = 10000) so 16 channels in total
-        * has 3 spike_channels
-        * has 2 event channels: one has *type=event*, the other has
-          *type=epoch*
-
+    Class for reading European Data Format files (EDF and EDF+).
+    Currently only continuous EDF+ files (EDF+C) and original EDF files (EDF) are supported
 
     Usage:
         >>> import neo.rawio
-        >>> r = neo.rawio.ExampleRawIO(filename='itisafake.nof')
+        >>> r = neo.rawio.EdfRawIO(filename='file.edf')
         >>> r.parse_header()
         >>> print(r)
         >>> raw_chunk = r.get_analogsignal_chunk(block_index=0, seg_index=0,
-                            i_start=0, i_stop=1024,  channel_names=channel_names)
+                            i_start=0, i_stop=1024, stream_index=0, channel_indexes=range(10))
         >>> float_chunk = reader.rescale_signal_raw_to_float(raw_chunk, dtype='float64',
                             channel_indexes=[0, 3, 6])
-        >>> spike_timestamp = reader.spike_timestamps(spike_channel_index=0,
-                            t_start=None, t_stop=None)
-        >>> spike_times = reader.rescale_spike_timestamp(spike_timestamp, 'float64')
-        >>> ev_timestamps, _, ev_labels = reader.event_timestamps(event_channel_index=0)
-
     """
-    extensions = ['fake']
+
+    extensions = ['edf']
     rawmode = 'one-file'
 
     def __init__(self, filename=''):
         if not HAS_PYEDF:
             raise ValueError('Requires pyedflib')
         BaseRawIO.__init__(self)
-        # note that this filename is ued in self._source_name
+
+        # note that this filename is used in self._source_name
         self.filename = filename
+
+        self.signals = None
+        self.signal_headers = []
+        self.header = {}
 
     def _source_name(self):
         return self.filename
 
     def _parse_header(self):
 
-        signal_streams = []
+        # read basic header
+        with open(self.filename, 'rb') as f:
+            f.seek(192)
+            file_version_header = f.read(44).decode('ascii')
+            # only accepting basic EDF files (no 'EDF+' in header)
+            # or continuous EDF+ files ('EDF+C' in header)
+            if ('EDF+' in file_version_header) and ('EDF+C' not in file_version_header):
+                raise ValueError('Only continuous EDF+ files are currently supported.')
 
-        signal_channels = []
+        # read a edf file content using pyedflib
+        self.signals, self.signal_headers, self.edf_header = highlevel.read_edf(self.filename)
+
+        # 1 edf file = 1 stream
+        signal_streams = [('edf stream', 0)]
         signal_streams = np.array(signal_streams, dtype=_signal_stream_dtype)
 
-        # read an edf file
-        signals, signal_headers, header = highlevel.read_edf(self.filename)
-
         signal_channels = []
-        for ch_idx, sig_dict in enumerate(signal_headers):
+        for ch_idx, sig_dict in enumerate(self.signal_headers):
             ch_name = sig_dict['label']
             chan_id = ch_idx
             sr = sig_dict['sample_rate']  # Hz
-            dtype = signals.dtype.str
+            dtype = self.signals.dtype.str
             units = sig_dict['dimension']
             physical_range = sig_dict['physical_max'] - sig_dict['physical_min']
             digital_range = sig_dict['digital_max']-sig_dict['digital_min']
@@ -123,6 +87,8 @@ class EdfRawIO(BaseRawIO):
             offset = -1 * sig_dict['digital_min'] * gain + sig_dict['physical_min']
             stream_id = 0  # file contains only a single stream
             signal_channels.append((ch_name, chan_id, sr, dtype, units, gain, offset, stream_id))
+
+        signal_channels = np.array(signal_channels, dtype=_signal_channel_dtype)
 
         # no unit/epoch information contained in edf
         spike_channels = []
@@ -132,223 +98,85 @@ class EdfRawIO(BaseRawIO):
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         self.header = {}
-        self.header['nb_block'] = 2
-        self.header['nb_segment'] = [2, 3]
+        self.header['nb_block'] = 1
+        self.header['nb_segment'] = [1]  # we only accept continuous edf files
         self.header['signal_streams'] = signal_streams
         self.header['signal_channels'] = signal_channels
         self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
         self._generate_minimal_annotations()
-        # this pprint lines really help for understand the nested (and complicated sometimes) dict
-        from pprint import pprint
-        pprint(self.raw_annotations)
 
-        # Until here all mandatory operations for setting up a rawio are implemented.
-        # The following lines provide additional, recommended annotations for the
-        # final neo objects.
+        # Add custom annotations for neo objects
         bl_ann = self.raw_annotations['blocks'][0]
         bl_ann['name'] = 'EDF Data Block'
-        bl_ann.update(header)
+        bl_ann.update(self.edf_header)
         seg_ann = bl_ann['segments'][0]
         seg_ann['name'] = 'Seg #0 Block #0'
+
+        # extract keys for array_annotations common to all signals and not already used
         ignore_annotations = ['label', 'dimension', 'sample_rate', 'physical_min', 'physical_max',
                               'digital_min', 'digital_max']
-        array_keys = [k for k in signal_headers[0]
-                      if all([k in h for h in signal_headers.values()])]
+        array_keys = [k for k in self.signal_headers[0]
+                      if k not in ignore_annotations and all([k in h for h in self.signal_headers])]
+
         for array_key in array_keys:
-            array_values = [v[array_key] for v in signal_headers.values]
-            seg_ann['signals'][ch_idx]['__array_annotations__'][array_key] = array_values
+            array_anno = {array_key: [h[array_key] for h in self.signal_headers]}
+        seg_ann['signals'].append({'__array_annotations__': array_anno})
 
     def _segment_t_start(self, block_index, seg_index):
-        # this must return an float scale in second
-        # this t_start will be shared by all object in the segment
-        # except AnalogSignal
-        all_starts = [[0., 15.], [0., 20., 60.]]
-        return all_starts[block_index][seg_index]
+        # no time offset provided by EDF format
+        return 0  # in seconds
 
     def _segment_t_stop(self, block_index, seg_index):
+        t_stop = self.signals.shape[1] / self.signal_headers[0]['sample_rate']
         # this must return an float scale in second
-        all_stops = [[10., 25.], [10., 30., 70.]]
-        return all_stops[block_index][seg_index]
+        return t_stop
 
     def _get_signal_size(self, block_index, seg_index, stream_index):
-        # We generate fake data in which the two stream signals have the same shape
-        # across all segments (10.0 seconds)
-        # This is not the case for real data, instead you should return the signal
-        # size depending on the block_index and segment_index
-        # this must return an int = the number of sample
-
-        # Note that channel_indexes can be ignored for most cases
-        # except for several sampling rate.
-        return 100000
+        return self.signals.shape[1]
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
-        # This give the t_start of signals.
-        # Very often this equal to _segment_t_start but not
-        # always.
-        # this must return an float scale in second
-
-        # Note that channel_indexes can be ignored for most cases
-        # except for several sampling rate.
-
-        # Here this is the same.
-        # this is not always the case
-        return self._segment_t_start(block_index, seg_index)
+        return 0  # EDF does not provide temporal offset information
 
     def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop,
                                 stream_index, channel_indexes):
-        # this must return a signal chunk in a signal stream
-        # limited with i_start/i_stop (can be None)
-        # channel_indexes can be None (=all channel in the stream) or a list or numpy.array
-        # This must return a numpy array 2D (even with one channel).
-        # This must return the orignal dtype. No conversion here.
-        # This must as fast as possible.
-        # To speed up this call all preparatory calculations should be implemented
-        # in _parse_header().
-
-        # Here we are lucky:  our signals is always zeros!!
-        # it is not always the case :)
-        # internally signals are int16
-        # convertion to real units is done with self.header['signal_channels']
+        # only dealing with single segment, single stream edf files
+        assert (block_index, seg_index, stream_index) == (0, 0, 0)
 
         if i_start is None:
             i_start = 0
         if i_stop is None:
-            i_stop = 100000
+            i_stop = self.signals.shape[1]
 
-        if i_start < 0 or i_stop > 100000:
-            # some check
-            raise IndexError("I don't like your jokes")
-
+        # keep all channels if none are selected
         if channel_indexes is None:
-            nb_chan = 8
-        elif isinstance(channel_indexes, slice):
-            channel_indexes = np.arange(8, dtype='int')[channel_indexes]
-            nb_chan = len(channel_indexes)
-        else:
-            channel_indexes = np.asarray(channel_indexes)
-            if any(channel_indexes < 0):
-                raise IndexError('bad boy')
-            if any(channel_indexes >= 8):
-                raise IndexError('big bad wolf')
-            nb_chan = len(channel_indexes)
+            channel_indexes = slice(None)
 
-        raw_signals = np.zeros((i_stop - i_start, nb_chan), dtype='int16')
-        return raw_signals
+        raw_signals = self.signals[channel_indexes, i_start:i_stop]
+        return raw_signals.T
 
     def _spike_count(self, block_index, seg_index, spike_channel_index):
-        # Must return the nb of spikes for given (block_index, seg_index, spike_channel_index)
-        # we are lucky:  our units have all the same nb of spikes!!
-        # it is not always the case
-        nb_spikes = 20
-        return nb_spikes
+        return None
 
     def _get_spike_timestamps(self, block_index, seg_index, spike_channel_index, t_start, t_stop):
-        # In our IO, timestamp are internally coded 'int64' and they
-        # represent the index of the signals 10kHz
-        # we are lucky: spikes have the same discharge in all segments!!
-        # incredible neuron!! This is not always the case
-
-        # the same clip t_start/t_start must be used in _spike_raw_waveforms()
-
-        ts_start = (self._segment_t_start(block_index, seg_index) * 10000)
-
-        spike_timestamps = np.arange(0, 10000, 500) + ts_start
-
-        if t_start is not None or t_stop is not None:
-            # restricte spikes to given limits (in seconds)
-            lim0 = int(t_start * 10000)
-            lim1 = int(t_stop * 10000)
-            mask = (spike_timestamps >= lim0) & (spike_timestamps <= lim1)
-            spike_timestamps = spike_timestamps[mask]
-
-        return spike_timestamps
+        return None
 
     def _rescale_spike_timestamp(self, spike_timestamps, dtype):
-        # must rescale to second a particular spike_timestamps
-        # with a fixed dtype so the user can choose the precisino he want.
-        spike_times = spike_timestamps.astype(dtype)
-        spike_times /= 10000.  # because 10kHz
-        return spike_times
+        return None
 
-    def _get_spike_raw_waveforms(self, block_index, seg_index, spike_channel_index,
-                                 t_start, t_stop):
-        # this must return a 3D numpy array (nb_spike, nb_channel, nb_sample)
-        # in the original dtype
-        # this must be as fast as possible.
-        # the same clip t_start/t_start must be used in _spike_timestamps()
-
-        # If there there is no waveform supported in the
-        # IO them _spike_raw_waveforms must return None
-
-        # In our IO waveforms come from all channels
-        # they are int16
-        # convertion to real units is done with self.header['spike_channels']
-        # Here, we have a realistic case: all waveforms are only noise.
-        # it is not always the case
-        # we 20 spikes with a sweep of 50 (5ms)
-
-        # trick to get how many spike in the slice
-        ts = self._get_spike_timestamps(block_index, seg_index,
-                                        spike_channel_index, t_start, t_stop)
-        nb_spike = ts.size
-
-        np.random.seed(2205)  # a magic number (my birthday)
-        waveforms = np.random.randint(low=-2**4, high=2**4, size=nb_spike * 50, dtype='int16')
-        waveforms = waveforms.reshape(nb_spike, 1, 50)
-        return waveforms
+    def _get_spike_raw_waveforms(self, block_index, seg_index, spike_channel_index, t_start,
+                                 t_stop):
+        return None
 
     def _event_count(self, block_index, seg_index, event_channel_index):
-        # event and spike are very similar
-        # we have 2 event channels
-        if event_channel_index == 0:
-            # event channel
-            return 6
-        elif event_channel_index == 1:
-            # epoch channel
-            return 10
+        return None
 
     def _get_event_timestamps(self, block_index, seg_index, event_channel_index, t_start, t_stop):
-        # the main difference between spike channel and event channel
-        # is that for here we have 3 numpy array timestamp, durations, labels
-        # durations must be None for 'event'
-        # label must a dtype ='U'
-
-        # in our IO event are directly coded in seconds
-        seg_t_start = self._segment_t_start(block_index, seg_index)
-        if event_channel_index == 0:
-            timestamp = np.arange(0, 6, dtype='float64') + seg_t_start
-            durations = None
-            labels = np.array(['trigger_a', 'trigger_b'] * 3, dtype='U12')
-        elif event_channel_index == 1:
-            timestamp = np.arange(0, 10, dtype='float64') + .5 + seg_t_start
-            durations = np.ones((10), dtype='float64') * .25
-            labels = np.array(['zoneX'] * 5 + ['zoneZ'] * 5, dtype='U12')
-
-        if t_start is not None:
-            keep = timestamp >= t_start
-            timestamp, labels = timestamp[keep], labels[keep]
-            if durations is not None:
-                durations = durations[keep]
-
-        if t_stop is not None:
-            keep = timestamp <= t_stop
-            timestamp, labels = timestamp[keep], labels[keep]
-            if durations is not None:
-                durations = durations[keep]
-
-        return timestamp, durations, labels
+        return None
 
     def _rescale_event_timestamp(self, event_timestamps, dtype, event_channel_index):
-        # must rescale to second a particular event_timestamps
-        # with a fixed dtype so the user can choose the precisino he want.
-
-        # really easy here because in our case it is already seconds
-        event_times = event_timestamps.astype(dtype)
-        return event_times
+        return None
 
     def _rescale_epoch_duration(self, raw_duration, dtype, event_channel_index):
-        # really easy here because in our case it is already seconds
-        durations = raw_duration.astype(dtype)
-        return durations
+        return None

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -223,5 +223,21 @@ class EDFRawIO(BaseRawIO):
     def _rescale_epoch_duration(self, raw_duration, dtype, event_channel_index):
         return None
 
+    def __enter__(self):
+        return self
+
+    def __del__(self):
+        self._close_reader()
+
+    def __exit__(self, exc_type, exc_val, ex_tb):
+        self._close_reader()
+
     def close(self):
-        self.edf_reader.close()
+        """
+        Closes the file handler
+        """
+        self._close_reader()
+
+    def _close_reader(self):
+        if hasattr(self, 'edf_reader'):
+            self.edf_reader.close()

--- a/neo/test/iotest/test_edfio.py
+++ b/neo/test/iotest/test_edfio.py
@@ -43,8 +43,12 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
         io = EDFIO(self.filename)
         seg = io.read_segment(time_slice=None)
 
+        # data file does not contain spike, event or epoch timestamps
         self.assertEqual(len(seg.spiketrains), 0)
-        self.assertEqual(len(seg.events), 0)
+        self.assertEqual(len(seg.events), 1)
+        self.assertEqual(len(seg.events[0]), 0)
+        self.assertEqual(len(seg.epochs), 1)
+        self.assertEqual(len(seg.epochs[0]), 0)
         for asig in seg.analogsignals:
             self.assertEqual(asig.shape[0], 256)
         n_channels = sum(a.shape[-1] for a in seg.analogsignals)
@@ -68,7 +72,7 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
         self.assertEqual(len(anasigs), 5)  # all channels have different units, so expecting 5
         for aidx, anasig in enumerate(anasigs):
             # comparing raw data to original values
-            ana_data = anasigs[0].load(magnitude_mode='raw')
+            ana_data = anasig.load(magnitude_mode='raw')
             np.testing.assert_array_equal(ana_data.magnitude, plain_data[:, aidx:aidx + 1])
 
             # comparing floating data to original values * gain factor
@@ -78,7 +82,7 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
             digital_range = ch_head['digital_max'] - ch_head['digital_min'] + 1
 
             gain = physical_range / digital_range
-            ana_data = anasigs[0].load(magnitude_mode='rescaled')
+            ana_data = anasig.load(magnitude_mode='rescaled')
             rescaled_data = plain_data[:, aidx:aidx + 1] * gain
             np.testing.assert_array_equal(ana_data.magnitude, rescaled_data)
 

--- a/neo/test/iotest/test_edfio.py
+++ b/neo/test/iotest/test_edfio.py
@@ -21,14 +21,14 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
 
     def setUp(self):
         super().setUp()
-        filename = self.get_local_path('edf/edf+C.edf')
-        self.io = EDFIO(filename)
+        self.filename = self.get_local_path('edf/edf+C.edf')
 
     def test_read_block(self):
         """
         Test reading the complete block and general annotations
         """
-        bl = self.io.read_block()
+        io = EDFIO(self.filename)
+        bl = io.read_block()
         self.assertTrue(bl.annotations)
 
         seg = bl.segments[0]
@@ -40,7 +40,8 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
         """
         Test loading of a time slice and check resulting times
         """
-        seg = self.io.read_segment(time_slice=None)
+        io = EDFIO(self.filename)
+        seg = io.read_segment(time_slice=None)
 
         self.assertEqual(len(seg.spiketrains), 0)
         self.assertEqual(len(seg.events), 0)
@@ -50,7 +51,7 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
         self.assertEqual(n_channels, 5)
 
         t_start, t_stop = 500 * pq.ms, 800 * pq.ms
-        seg = self.io.read_segment(time_slice=(t_start, t_stop))
+        seg = io.read_segment(time_slice=(t_start, t_stop))
 
         self.assertAlmostEqual(seg.t_start.rescale(t_start.units), t_start, delta=5.)
         self.assertAlmostEqual(seg.t_stop.rescale(t_stop.units), t_stop, delta=5.)
@@ -59,9 +60,9 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
         """
         Compare data from AnalogSignal with plain data stored in text file
         """
-
-        plain_data = np.loadtxt(self.io.filename.replace('.edf', '.txt'))
-        seg = self.io.read_segment(signal_group_mode='split-all')
+        io = EDFIO(self.filename)
+        plain_data = np.loadtxt(io.filename.replace('.edf', '.txt'))
+        seg = io.read_segment(signal_group_mode='split-all')
 
         anasigs = seg.analogsignals
 
@@ -69,7 +70,7 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
             ana_data = anasig.magnitude.flatten()
 
             # reverting gain and offset conversion
-            sig_dict = self.io.signal_headers[aidx]
+            sig_dict = io.signal_headers[aidx]
             physical_range = sig_dict['physical_max'] - sig_dict['physical_min']
             digital_range = sig_dict['digital_max'] - sig_dict['digital_min']
             gain = physical_range / digital_range

--- a/neo/test/iotest/test_edfio.py
+++ b/neo/test/iotest/test_edfio.py
@@ -31,21 +31,7 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
         bl = self.io.read_block()
         self.assertTrue(bl.annotations)
 
-    def test_read_segment_lazy(self):
-        """
-        Test lazy loading of object structure and loading of data in a 2nd step
-        """
-        seg = self.io.read_segment(lazy=True)
-        for ana in seg.analogsignals:
-            assert isinstance(ana, AnalogSignalProxy)
-            ana = ana.load()
-            assert isinstance(ana, AnalogSignal)
-
-        seg = self.io.read_segment(lazy=False)
-        for anasig in seg.analogsignals:
-            assert isinstance(ana, AnalogSignal)
-            self.assertTrue(any(anasig.shape))
-
+        seg = bl.segments[0]
         assert seg.name == 'Seg #0 Block #0'
         for anasig in seg.analogsignals:
             assert anasig.name is not None

--- a/neo/test/iotest/test_edfio.py
+++ b/neo/test/iotest/test_edfio.py
@@ -69,7 +69,7 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
         for aidx, anasig in enumerate(anasigs):
             # comparing raw data to original values
             ana_data = anasigs[0].load(magnitude_mode='raw')
-            np.testing.assert_array_equal(ana_data.magnitude, plain_data[:, aidx:aidx+1])
+            np.testing.assert_array_equal(ana_data.magnitude, plain_data[:, aidx:aidx + 1])
 
             # comparing floating data to original values * gain factor
             ch_head = io.edf_reader.getSignalHeader(aidx)
@@ -79,7 +79,7 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
 
             gain = physical_range / digital_range
             ana_data = anasigs[0].load(magnitude_mode='rescaled')
-            rescaled_data = plain_data[:, aidx:aidx+1] * gain
+            rescaled_data = plain_data[:, aidx:aidx + 1] * gain
             np.testing.assert_array_equal(ana_data.magnitude, rescaled_data)
 
 

--- a/neo/test/iotest/test_edfio.py
+++ b/neo/test/iotest/test_edfio.py
@@ -1,0 +1,98 @@
+"""
+Tests of neo.io.edfio
+"""
+
+import unittest
+import numpy as np
+import quantities as pq
+
+from neo.io.edfio import EDFIO
+from neo.test.iotest.common_io_test import BaseTestIO
+from neo.io.proxyobjects import AnalogSignalProxy
+from neo import AnalogSignal
+
+
+class TestEDFIO(BaseTestIO, unittest.TestCase, ):
+    ioclass = EDFIO
+    entities_to_download = ['edf']
+    entities_to_test = [
+        'edf/edf+C.edf',
+    ]
+
+    def setUp(self):
+        super().setUp()
+        filename = self.get_local_path('edf/edf+C.edf')
+        self.io = EDFIO(filename)
+
+    def test_read_block(self):
+        """
+        Test reading the complete block and general annotations
+        """
+        bl = self.io.read_block()
+        self.assertTrue(bl.annotations)
+
+    def test_read_segment_lazy(self):
+        """
+        Test lazy loading of object structure and loading of data in a 2nd step
+        """
+        seg = self.io.read_segment(lazy=True)
+        for ana in seg.analogsignals:
+            assert isinstance(ana, AnalogSignalProxy)
+            ana = ana.load()
+            assert isinstance(ana, AnalogSignal)
+
+        seg = self.io.read_segment(lazy=False)
+        for anasig in seg.analogsignals:
+            assert isinstance(ana, AnalogSignal)
+            self.assertTrue(any(anasig.shape))
+
+        assert seg.name == 'Seg #0 Block #0'
+        for anasig in seg.analogsignals:
+            assert anasig.name is not None
+
+    def test_read_segment_with_time_slice(self):
+        """
+        Test loading of a time slice and check resulting times
+        """
+        seg = self.io.read_segment(time_slice=None)
+
+        self.assertEqual(len(seg.spiketrains), 0)
+        self.assertEqual(len(seg.events), 0)
+        for asig in seg.analogsignals:
+            self.assertEqual(asig.shape[0], 256)
+        n_channels = sum(a.shape[-1] for a in seg.analogsignals)
+        self.assertEqual(n_channels, 5)
+
+        t_start, t_stop = 500 * pq.ms, 800 * pq.ms
+        seg = self.io.read_segment(time_slice=(t_start, t_stop))
+
+        self.assertAlmostEqual(seg.t_start.rescale(t_start.units), t_start, delta=5.)
+        self.assertAlmostEqual(seg.t_stop.rescale(t_stop.units), t_stop, delta=5.)
+
+    def test_compare_data(self):
+        """
+        Compare data from AnalogSignal with plain data stored in text file
+        """
+
+        plain_data = np.loadtxt(self.io.filename.replace('.edf', '.txt'))
+        seg = self.io.read_segment(signal_group_mode='split-all')
+
+        anasigs = seg.analogsignals
+
+        for aidx, anasig in enumerate(anasigs):
+            ana_data = anasig.magnitude.flatten()
+
+            # reverting gain and offset conversion
+            sig_dict = self.io.signal_headers[aidx]
+            physical_range = sig_dict['physical_max'] - sig_dict['physical_min']
+            digital_range = sig_dict['digital_max'] - sig_dict['digital_min']
+            gain = physical_range / digital_range
+            offset = -1 * sig_dict['digital_min'] * gain + sig_dict['physical_min']
+
+            ana_data = (ana_data - offset) / gain
+            # allow for some floating imprecision between calculations
+            np.testing.assert_array_almost_equal(ana_data, plain_data[:, aidx], decimal=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/neo/test/rawiotest/test_edfrawio.py
+++ b/neo/test/rawiotest/test_edfrawio.py
@@ -1,0 +1,49 @@
+"""
+Tests of neo.rawio.examplerawio
+
+Note for dev:
+if you write a new RawIO class your need to put some file
+to be tested at g-node portal, Ask neuralensemble list for that.
+The file need to be small.
+
+Then you have to copy/paste/renamed the TestExampleRawIO
+class and a full test will be done to test if the new coded IO
+is compliant with the RawIO API.
+
+If you have problems, do not hesitate to ask help github (prefered)
+of neuralensemble list.
+
+Note that same mechanism is used a neo.io API so files are tested
+several time with neo.rawio (numpy buffer) and neo.io (neo object tree).
+See neo.test.iotest.*
+
+
+Author: Samuel Garcia
+
+"""
+
+import unittest
+
+from neo.rawio.edfrawio import EdfRawIO
+
+from neo.test.rawiotest.common_rawio_test import BaseTestRawIO
+
+
+class TestExampleRawIO(BaseTestRawIO, unittest.TestCase, ):
+    rawioclass = EdfRawIO
+    # here obliviously there is nothing to download:
+    entities_to_download = []
+
+    # here we will test 1 fake file
+    # note that for IOs based on directory names you can put the directory
+    # name here instead of the filename.
+    entities_to_test = ['fake1']
+
+    def test_parse_header(self):
+        io = self.rawioclass('/home/sprengerj/projects/neo_test_files/edf/B1_breathing_resting_anon.edf')
+
+        io.parse_header()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/neo/test/rawiotest/test_edfrawio.py
+++ b/neo/test/rawiotest/test_edfrawio.py
@@ -1,48 +1,19 @@
 """
-Tests of neo.rawio.examplerawio
-
-Note for dev:
-if you write a new RawIO class your need to put some file
-to be tested at g-node portal, Ask neuralensemble list for that.
-The file need to be small.
-
-Then you have to copy/paste/renamed the TestExampleRawIO
-class and a full test will be done to test if the new coded IO
-is compliant with the RawIO API.
-
-If you have problems, do not hesitate to ask help github (prefered)
-of neuralensemble list.
-
-Note that same mechanism is used a neo.io API so files are tested
-several time with neo.rawio (numpy buffer) and neo.io (neo object tree).
-See neo.test.iotest.*
-
-
-Author: Samuel Garcia
-
+Tests of neo.rawio.edfrawio
 """
 
 import unittest
 
-from neo.rawio.edfrawio import EdfRawIO
-
+from neo.rawio.edfrawio import EDFRawIO
 from neo.test.rawiotest.common_rawio_test import BaseTestRawIO
 
 
 class TestExampleRawIO(BaseTestRawIO, unittest.TestCase, ):
-    rawioclass = EdfRawIO
-    # here obliviously there is nothing to download:
-    entities_to_download = []
-
-    # here we will test 1 fake file
-    # note that for IOs based on directory names you can put the directory
-    # name here instead of the filename.
-    entities_to_test = ['fake1']
-
-    def test_parse_header(self):
-        io = self.rawioclass('/home/sprengerj/projects/neo_test_files/edf/B1_breathing_resting_anon.edf')
-
-        io.parse_header()
+    rawioclass = EDFRawIO
+    entities_to_download = ['edf']
+    entities_to_test = [
+        'edf/edf+C.edf',
+    ]
 
 
 if __name__ == "__main__":

--- a/neo/test/rawiotest/test_edfrawio.py
+++ b/neo/test/rawiotest/test_edfrawio.py
@@ -24,7 +24,6 @@ class TestExampleRawIO(BaseTestRawIO, unittest.TestCase, ):
         with open(filename) as f:
             pass
 
-
     def test_close(self):
         filename = self.get_local_path('edf/edf+C.edf')
 

--- a/neo/test/rawiotest/test_edfrawio.py
+++ b/neo/test/rawiotest/test_edfrawio.py
@@ -15,6 +15,29 @@ class TestExampleRawIO(BaseTestRawIO, unittest.TestCase, ):
         'edf/edf+C.edf',
     ]
 
+    def test_context_handler(self):
+        filename = self.get_local_path('edf/edf+C.edf')
+        with EDFRawIO(filename) as io:
+            io.parse_header()
+
+        # Check that file was closed properly and can be opened again
+        with open(filename) as f:
+            pass
+
+
+    def test_close(self):
+        filename = self.get_local_path('edf/edf+C.edf')
+
+        # Open file and close it again
+        io1 = EDFRawIO(filename)
+        io1.parse_header()
+        io1.close()
+
+        # Check that file was closed properly and can be opened again
+        io2 = EDFRawIO(filename)
+        io2.parse_header()
+        io2.close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -2,6 +2,7 @@ pytest
 pytest-cov
 datalad==0.14.8  # 0.15. is incompatible with default apt git-annex version
 scipy>=1.0.0
+pyedflib
 h5py
 igor
 klusta

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ extras_require = {
     'neomatlabio': ['scipy>=1.0.0'],
     'nixio': ['nixio>=1.5.0'],
     'stimfitio': ['stfio'],
-    'tiffio': ['pillow']
+    'tiffio': ['pillow'],
+    'edf': ['pyedflib']
 }
 
 with open("neo/version.py") as fp:


### PR DESCRIPTION
This IO supports reading files in the European Data Format (EDF, https://www.edfplus.info/). For now only original EDF files and EDF+ files with continuous data (EDF+C) are accepted. The IO is based on the pyedflib package.
