### PR TITLE
[CI] pin datalad version

### DIFF
--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-cov
-datalad
+datalad==0.14.8  # 0.15. is incompatible with default apt git-annex version
 scipy>=1.0.0
 h5py
 igor


### PR DESCRIPTION
Datalad version 0.15.0 and later requires a git-annex version that is not in the ubuntu default packages yet.
See also https://github.com/datalad/datalad/commit/315911ca76687ef0b8a529f0dfa99bf25fe040ba