### PR TITLE
Add a document describing project governance

### DIFF
--- a/doc/source/developers_guide.rst
+++ b/doc/source/developers_guide.rst
@@ -235,8 +235,7 @@ Tag the release in the Git repository and push it::
     $ git push --tags upstream
 
 
-To upload the package to `PyPI`_ (currently Samuel Garcia,  Andrew Davison,
-Michael Denker and Julia Sprenger have the necessary permissions to do this)::
+To upload the package to `PyPI`_ (the members of the `maintainers team`_ have the necessary permissions to do this)::
 
     $ twine upload dist/neo-0.X.Y.tar.gz
 
@@ -252,6 +251,11 @@ If you want to develop your own IO module
 
 See :ref:`io_dev_guide` for implementation of a new IO.
 
+
+Project governance
+------------------
+
+The :doc:`governance` document describes how decisions about the project are taken.
 
 
 
@@ -276,3 +280,4 @@ See :ref:`io_dev_guide` for implementation of a new IO.
 .. _pep8: https://pypi.org/project/pep8/
 .. _flake8: https://pypi.org/project/flake8/
 .. _pyflakes: https://pypi.org/project/pyflakes/
+.. _`maintainers team`: https://github.com/orgs/NeuralEnsemble/teams/neo-maintainers

--- a/doc/source/governance.rst
+++ b/doc/source/governance.rst
@@ -1,0 +1,34 @@
+==========
+Governance
+==========
+
+Neo is a community-developed project,
+we welcome contributions from anyone who is interested in the project.
+The project maintainers are the members of the `Neo maintainers team`_.
+All contributors agree to abide by the Code of Conduct, see the file `CODE_OF_CONDUCT.md`_.
+
+Contributions
+=============
+
+All contributions must be by pull request,
+with the exception of quick bug fixes affecting fewer than ten lines of code.
+Normally, pull requests may be approved and merged by any maintainer,
+although anyone is welcome to join in the discussion.
+In case of disagreement with a decision, we will try to reach a consensus between maintainers,
+taking account of any input from the wider community.
+If consensus cannot be reached, decisions will be based on a majority vote among the maintainers,
+with the caveats that (i) only one vote per institution is allowed (i.e. in the case where several
+maintainers belong to the same institution they will have to agree among themselves how to vote)
+and (ii) a quorum of three maintainers must be achieved.
+
+Maintainers
+===========
+
+Any contributor who has had at least three pull requests accepted may be nominated as a maintainer.
+Nominations must be approved by at least two existing maintainers, with no dissenting maintainer.
+In case of disagreement, decisions on accepting new maintainers will be based on a majority vote
+as above. Decisions on removing maintainers from the list are based on majority vote.
+
+
+.. _`Neo maintainers team`: https://github.com/orgs/NeuralEnsemble/teams/neo-maintainers
+.. _`CODE_OF_CONDUCT.md`: https://github.com/NeuralEnsemble/python-neo/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
The purpose of this document is to formalise how decisions are taken in the project, so that people who may wish to contribute to the project have clear expectations.
