### PR TITLE
Fix exception raised when calling pyplot.plot(sig.times, sig) if the signal has array annotations

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -265,8 +265,11 @@ class AnalogSignal(BaseSignal):
                     raise TypeError("%s not supported" % type(j))
                 if isinstance(k, (int, np.integer)):
                     obj = obj.reshape(-1, 1)
-                if k is not None:  # matplotlib _check_1d() calls__getitem__ with (:, None)
-                    obj.array_annotate(**deepcopy(self.array_annotations_at_index(k)))
+                elif k is None:
+                    # matplotlib _check_1d() calls__getitem__ with (:, None) and
+                    # reacts appropriately if an IndexError or ValueError is raised
+                    raise IndexError("Cannot add dimensions to an AnalogSignal")
+                obj.array_annotate(**deepcopy(self.array_annotations_at_index(k)))
         elif isinstance(i, slice):
             obj = super().__getitem__(i)
             if i.start:

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -265,7 +265,8 @@ class AnalogSignal(BaseSignal):
                     raise TypeError("%s not supported" % type(j))
                 if isinstance(k, (int, np.integer)):
                     obj = obj.reshape(-1, 1)
-                obj.array_annotate(**deepcopy(self.array_annotations_at_index(k)))
+                if k is not None:  # matplotlib _check_1d() calls__getitem__ with (:, None)
+                    obj.array_annotate(**deepcopy(self.array_annotations_at_index(k)))
         elif isinstance(i, slice):
             obj = super().__getitem__(i)
             if i.start:

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -639,6 +639,10 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.assertTrue(hasattr(self.signal1[9, 3], 'units'))
         self.assertRaises(IndexError, self.signal1.__getitem__, (99, 73))
 
+    def test__getitem__with_tuple_slice_none(self):
+        item = self.signal1[:, None]
+        # we're just testing no error is raised
+
     def test__time_index(self):
         # scalar arguments
         self.assertEqual(self.signal2.time_index(2.0 * pq.s), 2)

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -640,8 +640,7 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
         self.assertRaises(IndexError, self.signal1.__getitem__, (99, 73))
 
     def test__getitem__with_tuple_slice_none(self):
-        item = self.signal1[:, None]
-        # we're just testing no error is raised
+        self.assertRaises(IndexError, self.signal1.__getitem__, (slice(None), None))
 
     def test__time_index(self):
         # scalar arguments


### PR DESCRIPTION

The traceback was:
```
  File "/Users/andrew/dev/simulation/PyNN/pyNN/utility/plotting.py", line 89, in plot_signals
    ax.plot(signal.times.rescale(ms), signal, label=label, **options)
  File "/Users/andrew/.conda/envs/simulation/lib/python3.9/site-packages/matplotlib/axes/_axes.py", line 1743, in plot
    lines = [*self._get_lines(*args, data=data, **kwargs)]
  File "/Users/andrew/.conda/envs/simulation/lib/python3.9/site-packages/matplotlib/axes/_base.py", line 273, in __call__
    yield from self._plot_args(this, kwargs)
  File "/Users/andrew/.conda/envs/simulation/lib/python3.9/site-packages/matplotlib/axes/_base.py", line 389, in _plot_args
    y = _check_1d(tup[-1])
  File "/Users/andrew/.conda/envs/simulation/lib/python3.9/site-packages/matplotlib/cbook/__init__.py", line 1318, in _check_1d
    ndim = x[:, None].ndim
  File "/Users/andrew/dev/analysis/neo/neo/core/analogsignal.py", line 270, in __getitem__
    obj.array_annotate(**deepcopy(self.array_annotations_at_index(k)))
  File "/Users/andrew/dev/analysis/neo/neo/core/dataobject.py", line 188, in array_annotate
    self.array_annotations.update(array_annotations)
  File "/Users/andrew/dev/analysis/neo/neo/core/dataobject.py", line 400, in update
    self[key] = other[key]
  File "/Users/andrew/dev/analysis/neo/neo/core/dataobject.py", line 389, in __setitem__
    value = self.check_function({key: value}, self.length)[key]
  File "/Users/andrew/dev/analysis/neo/neo/core/dataobject.py", line 39, in _normalize_array_annotations
    value[key] = _normalize_array_annotations(value[key], length)
  File "/Users/andrew/dev/analysis/neo/neo/core/dataobject.py", line 98, in _normalize_array_annotations
    _check_single_elem(value[0])
  File "/Users/andrew/dev/analysis/neo/neo/core/dataobject.py", line 81, in _check_single_elem
    raise ValueError("Array annotations should only be 1-dimensional")
ValueError: Array annotations should only be 1-dimensional
```