### PR TITLE
[nix] pin nixio to avoid buggy 1.5.2 version

### DIFF
--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -6,7 +6,7 @@ h5py
 igor
 klusta
 tqdm
-nixio>=1.5.0
+nixio==1.5.1
 matplotlib
 ipython
 coverage


### PR DESCRIPTION
The latest nixio version (1.5.2) raises an error when rewriting string annotations.
This should be resolved on the nixio level.