### PR TITLE
Feature/new filter

### DIFF
--- a/doc/source/authors.rst
+++ b/doc/source/authors.rst
@@ -60,6 +60,7 @@ and may not be the current affiliation of a contributor.
 * Etienne Combrisson [6]
 * Ben Dichter [24]
 * Elodie Legouée [21]
+* Oliver Kloss [13]
 
 1. Centre de Recherche en Neuroscience de Lyon, CNRS UMR5292 - INSERM U1028 - Universite Claude Bernard Lyon 1
 2. Unité de Neuroscience, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France

--- a/neo/core/__init__.py
+++ b/neo/core/__init__.py
@@ -10,7 +10,9 @@ or more class from this module.
 Classes:
 
 .. autoclass:: Block
+.. automethod:: Block.filter
 .. autoclass:: Segment
+.. automethod:: Segment.filter
 .. autoclass:: Group
 
 .. autoclass:: AnalogSignal

--- a/neo/core/__init__.py
+++ b/neo/core/__init__.py
@@ -37,6 +37,8 @@ from neo.core.segment import Segment
 from neo.core.analogsignal import AnalogSignal
 from neo.core.irregularlysampledsignal import IrregularlySampledSignal
 
+from neo.core.container import FilterEqual, FilterIsIn, FilterIsNot, FilterInRange, FilterGreaterThan, FilterLessThan, FilterGreaterThanEqual, FilterLessThanEqual
+
 from neo.core.event import Event
 from neo.core.epoch import Epoch
 

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -77,7 +77,7 @@ def filterdata(data, targdict=None, objects=None, **kwargs):
                         all([obj is not res for res in results])):
                     results.append(obj)
                 elif (key in obj.annotations and value.test(obj.annotations[key]) and
-                          all([obj is not res for res in results])):    #Benchmark -> hauefigkeit, time
+                          all([obj is not res for res in results])):
                     results.append(obj)
 
     # keep only objects of the correct classes

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -76,7 +76,7 @@ def filterdata(data, targdict=None, objects=None, **kwargs):
                 if (hasattr(obj, key) and getattr(obj, key) == value and
                         all([obj is not res for res in results])):
                     results.append(obj)
-                elif (key in obj.annotations and obj.annotations[key] == value and
+                elif (key in obj.annotations and obj.annotations[key].test(key) and #elif (key in obj.annotations and obj.annotations[key].test(key) and AttributeError: 'int' object has no attribute 'test'
                           all([obj is not res for res in results])):
                     results.append(obj)
 
@@ -98,14 +98,6 @@ class FilterCondition():
     def test(self, x):
         return True
 
-class less_than(FilterCondition):
-
-    def __init__(self, z):
-        self.control = z
-
-    def test(self, x):
-        return x < self.control
-
 class equal(FilterCondition):
 
     def __init__(self, z):
@@ -114,7 +106,49 @@ class equal(FilterCondition):
     def test(self, x):
         return x == self.control
 
-    
+class less_than(FilterCondition):
+
+    def __init__(self, z):
+        self.control = z
+
+    def test(self, x):
+        return x < self.control
+
+class more_than(FilterCondition):
+
+    def __init__(self, z):
+        self.control=z
+
+    def test(self, x):
+        return x > self.control
+
+class is_in(FilterCondition):
+
+    def __init__(self, z):
+        self.control = z
+
+    def test(self, x):
+        if(type(x) == list):
+            return x.contains(self.control)
+        elif(type(x) == int):
+            return x == self.control
+        else:
+            raise SyntaxError('parameter not of type list or int')
+
+class in_range(FilterCondition):
+
+    def __init__(self, a: int, b: int):
+        if(type(a) != int or type(b) != int):
+            raise SyntaxError("parameters not of type int")
+        else:
+            self.control=[]
+            for num in range(a, b+1):
+                self.control.append(num)
+
+    def test(self, x):
+        is_in(self.control)
+
+
 
 class Container(BaseNeo):
     """

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -76,8 +76,8 @@ def filterdata(data, targdict=None, objects=None, **kwargs):
                 if (hasattr(obj, key) and getattr(obj, key) == value and
                         all([obj is not res for res in results])):
                     results.append(obj)
-                elif (key in obj.annotations and obj.annotations[key].test(key) and #elif (key in obj.annotations and obj.annotations[key].test(key) and AttributeError: 'int' object has no attribute 'test'
-                          all([obj is not res for res in results])):
+                elif (key in obj.annotations and value.test(obj.annotations[key]) and
+                          all([obj is not res for res in results])):    #Benchmark -> hauefigkeit, time
                     results.append(obj)
 
     # keep only objects of the correct classes
@@ -106,6 +106,27 @@ class equal(FilterCondition):
     def test(self, x):
         return x == self.control
 
+class is_not(FilterCondition):
+    def __init__(self, z):
+        self.control = z
+
+    def test(self, x):
+        return x != self.control
+
+class less_than_equal(FilterCondition):
+    def __init__(self, z):
+        self.control = z
+
+    def test(self, x):
+        return x <= self.control
+
+class greater_than_equal(FilterCondition):
+    def __init__(self, z):
+        self.control = z
+
+    def test(self, x):
+        return x >= self.control
+
 class less_than(FilterCondition):
 
     def __init__(self, z):
@@ -114,7 +135,7 @@ class less_than(FilterCondition):
     def test(self, x):
         return x < self.control
 
-class more_than(FilterCondition):
+class greater_than(FilterCondition):
 
     def __init__(self, z):
         self.control=z
@@ -128,25 +149,34 @@ class is_in(FilterCondition):
         self.control = z
 
     def test(self, x):
-        if(type(x) == list):
-            return x.contains(self.control)
-        elif(type(x) == int):
+        if(type(self.control) == list):
+            return x in self.control
+        elif(type(self.control) == int):
             return x == self.control
         else:
             raise SyntaxError('parameter not of type list or int')
 
 class in_range(FilterCondition):
 
-    def __init__(self, a: int, b: int):
+    def __init__(self, a, b, left_closed=False, right_closed=False):
         if(type(a) != int or type(b) != int):
             raise SyntaxError("parameters not of type int")
         else:
-            self.control=[]
-            for num in range(a, b+1):
-                self.control.append(num)
+            self.a = a
+            self.b = b
+            self.left_closed = left_closed
+            self.right_closed = right_closed
 
     def test(self, x):
-        is_in(self.control)
+        if (not self.left_closed and not self.right_closed):
+            return (x >= self.a and x <= self.b)
+        elif (not self.left_closed and self.right_closed):
+            return (x >= self.a and x < self.b)
+        elif (self.left_closed and not self.right_closed):
+            return (x > self.a and x <= self.b)
+        else:
+            return (x > self.a and x < self.b)
+
 
 
 

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -76,9 +76,12 @@ def filterdata(data, targdict=None, objects=None, **kwargs):
                 if (hasattr(obj, key) and getattr(obj, key) == value and
                         all([obj is not res for res in results])):
                     results.append(obj)
-                elif (key in obj.annotations and value.test(obj.annotations[key]) and
+                elif(isinstance(value, FilterCondition)):
+                    if (key in obj.annotations and value.test(obj.annotations[key]) and
                           all([obj is not res for res in results])):
-                    results.append(obj)
+                        results.append(obj)
+                elif (key in obj.annotations and obj.annotations[key] == value and all([obj is not res for res in results])):
+                        results.append(obj)
 
     # keep only objects of the correct classes
     if objects:

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -28,7 +28,7 @@ def filterdata(data, targdict=None, objects=None, **kwargs):
         provided as keyword arguments or a dictionary, either as a positional
         argument after data or to the argument targdict.
         A key of a provided dictionary is the name of the requested annotation and the value is a FilterCondition object.
-        E.g.: equal(x), less_than(x), in_range(x, y).
+        E.g.: FilterEqual(x), FilterLessThan(x), FilterInRange(x, y).
 
         targdict can also
         be a list of dictionaries, in which case the filters are applied
@@ -110,7 +110,7 @@ class FilterCondition():
     def test(self, x):
         return True
 
-class equal(FilterCondition):
+class FilterEqual(FilterCondition):
 
     def __init__(self, z):
         self.control = z
@@ -118,7 +118,7 @@ class equal(FilterCondition):
     def test(self, x):
         return x == self.control
 
-class is_not(FilterCondition):
+class FilterIsNot(FilterCondition):
 
     def __init__(self, z):
         self.control = z
@@ -126,7 +126,7 @@ class is_not(FilterCondition):
     def test(self, x):
         return x != self.control
 
-class less_than_equal(FilterCondition):
+class FilterLessThanEqual(FilterCondition):
 
     def __init__(self, z):
         self.control = z
@@ -134,14 +134,14 @@ class less_than_equal(FilterCondition):
     def test(self, x):
         return x <= self.control
 
-class greater_than_equal(FilterCondition):
+class FilterGreaterThanEqual(FilterCondition):
     def __init__(self, z):
         self.control = z
 
     def test(self, x):
         return x >= self.control
 
-class less_than(FilterCondition):
+class FilterLessThan(FilterCondition):
 
     def __init__(self, z):
         self.control = z
@@ -149,7 +149,7 @@ class less_than(FilterCondition):
     def test(self, x):
         return x < self.control
 
-class greater_than(FilterCondition):
+class FilterGreaterThan(FilterCondition):
 
     def __init__(self, z):
         self.control=z
@@ -157,7 +157,7 @@ class greater_than(FilterCondition):
     def test(self, x):
         return x > self.control
 
-class is_in(FilterCondition):
+class FilterIsIn(FilterCondition):
 
     def __init__(self, z):
         self.control = z
@@ -170,7 +170,7 @@ class is_in(FilterCondition):
         else:
             raise SyntaxError('parameter not of type list or int')
 
-class in_range(FilterCondition):
+class FilterInRange(FilterCondition):
 
     def __init__(self, a, b, left_closed=False, right_closed=False):
         if(type(a) != int or type(b) != int):
@@ -485,7 +485,7 @@ class Container(BaseNeo):
         provided as keyword arguments or a dictionary, either as a positional
         argument after data or to the argument targdict.
         A key of a provided dictionary is the name of the requested annotation and the value is a FilterCondition object.
-        E.g.: equal(x), less_than(x), in_range(x, y).
+        E.g.: equal(x), less_than(x), FilterInRange(x, y).
 
         targdict can also
         be a list of dictionaries, in which case the filters are applied
@@ -515,8 +515,8 @@ class Container(BaseNeo):
             >>> obj.filter(name="Vm")
             >>> obj.filter(objects=neo.SpikeTrain)
             >>> obj.filter(targdict={'myannotation':3})
-            >>> obj.filter(name=neo.core.container.equal(5))
-            >>> obj.filter({'name': neo.core.container.less_than(5)})
+            >>> obj.filter(name=neo.core.container.FilterEqual(5))
+            >>> obj.filter({'name': neo.core.container.FilterLessThan(5)})
         """
 
         if isinstance(targdict, str):

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -515,6 +515,8 @@ class Container(BaseNeo):
             >>> obj.filter(name="Vm")
             >>> obj.filter(objects=neo.SpikeTrain)
             >>> obj.filter(targdict={'myannotation':3})
+            >>> obj.filter(name=neo.core.container.equal(5))
+            >>> obj.filter({'name': neo.core.container.less_than(5)})
         """
 
         if isinstance(targdict, str):

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -23,21 +23,23 @@ def unique_objs(objs):
 
 def filterdata(data, targdict=None, objects=None, **kwargs):
     """
-    Return a list of the objects in data matching *any* of the search terms
-    in either their attributes or annotations.  Search terms can be
-    provided as keyword arguments or a dictionary, either as a positional
-    argument after data or to the argument targdict.  targdict can also
-    be a list of dictionaries, in which case the filters are applied
-    sequentially.  If targdict and kwargs are both supplied, the
-    targdict filters are applied first, followed by the kwarg filters.
-    A targdict of None or {} and objects = None corresponds to no filters
-    applied, therefore returning all child objects.
-    Default targdict and objects is None.
+        Return a list of child objects matching *any* of the search terms
+        in either their attributes or annotations.  Search terms can be
+        provided as keyword arguments or a dictionary, either as a positional
+        argument after data or to the argument targdict.
+        A key of a provided dictionary is the name of the requested annotation and the value is a FilterCondition object.
+        E.g.: equal(x), less_than(x), in_range(x, y).
 
+        targdict can also
+        be a list of dictionaries, in which case the filters are applied
+        sequentially.
 
-    objects (optional) should be the name of a Neo object type,
-    a neo object class, or a list of one or both of these.  If specified,
-    only these objects will be returned.
+        A list of disctionaries is handled as follows: [ { or } and { or } ]
+        If targdict and kwargs are both supplied, the
+        targdict filters are applied first, followed by the kwarg filters.
+        A targdict of None or {} corresponds to no filters applied, therefore
+        returning all child objects. Default targdict is None.
+
     """
 
     # if objects are specified, get the classes
@@ -95,6 +97,13 @@ def filterdata(data, targdict=None, objects=None, **kwargs):
         return results
 
 class FilterCondition():
+    """
+        FilterCondition object is given as parameter to container.filter():
+
+        example.filter(annotation=<FilterCondition>) or
+        example=filter({'annotation': <FilterCondition>})
+    """
+
     def __init__(self, z):
         pass
 
@@ -110,6 +119,7 @@ class equal(FilterCondition):
         return x == self.control
 
 class is_not(FilterCondition):
+
     def __init__(self, z):
         self.control = z
 
@@ -117,6 +127,7 @@ class is_not(FilterCondition):
         return x != self.control
 
 class less_than_equal(FilterCondition):
+
     def __init__(self, z):
         self.control = z
 
@@ -472,9 +483,16 @@ class Container(BaseNeo):
         Return a list of child objects matching *any* of the search terms
         in either their attributes or annotations.  Search terms can be
         provided as keyword arguments or a dictionary, either as a positional
-        argument after data or to the argument targdict.  targdict can also
+        argument after data or to the argument targdict.
+        A key of a provided dictionary is the name of the requested annotation and the value is a FilterCondition object.
+        E.g.: equal(x), less_than(x), in_range(x, y).
+
+        targdict can also
         be a list of dictionaries, in which case the filters are applied
-        sequentially.  If targdict and kwargs are both supplied, the
+        sequentially.
+
+        A list of disctionaries is handled as follows: [ { or } and { or } ]
+        If targdict and kwargs are both supplied, the
         targdict filters are applied first, followed by the kwarg filters.
         A targdict of None or {} corresponds to no filters applied, therefore
         returning all child objects. Default targdict is None.

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -91,6 +91,30 @@ def filterdata(data, targdict=None, objects=None, **kwargs):
     else:
         return results
 
+class FilterCondition():
+    def __init__(self, z):
+        pass
+
+    def test(self, x):
+        return True
+
+class less_than(FilterCondition):
+
+    def __init__(self, z):
+        self.control = z
+
+    def test(self, x):
+        return x < self.control
+
+class equal(FilterCondition):
+
+    def __init__(self, z):
+        self.control = z
+
+    def test(self, x):
+        return x == self.control
+
+    
 
 class Container(BaseNeo):
     """

--- a/neo/test/coretest/test_container.py
+++ b/neo/test/coretest/test_container.py
@@ -4,7 +4,11 @@ Tests of the neo.core.container.Container class
 
 import unittest
 
+import quantities as q
+
 import numpy as np
+
+import neo.core
 
 try:
     from IPython.lib.pretty import pretty
@@ -101,6 +105,20 @@ class TestContainerNeo(unittest.TestCase):
     def test_filter(self):
         container = Container()
         self.assertRaises(TypeError, container.filter, "foo")
+
+        seg = neo.core.Segment()
+        st1 = neo.core.SpikeTrain([1, 2]*q.ms, t_stop=10)
+        st1.annotate(test=5)
+        seg.spiketrains.append(st1)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.equal(5))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.less_than(6))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.greater_than(4))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.is_not(1))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.is_in([1, 2, 5]))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.in_range(1, 5))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.greater_than_equal(5))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.less_than_equal(5))[0].annotations)
+
 
 
 class Test_Container_merge(unittest.TestCase):

--- a/neo/test/coretest/test_container.py
+++ b/neo/test/coretest/test_container.py
@@ -129,6 +129,9 @@ class TestContainerNeo(unittest.TestCase):
 
 
     def test_filter_equal(self):
+        '''
+            Tests FilterCondition object "equal".
+        '''
 
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
@@ -141,6 +144,9 @@ class TestContainerNeo(unittest.TestCase):
         self.assertEqual(0, len(seg.filter(test=neo.core.container.equal(1))))
 
     def test_filter_is_not(self):
+        '''
+            Tests FilterCondition object "is_not".
+        '''
 
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2]*q.ms, t_stop=10)
@@ -155,6 +161,9 @@ class TestContainerNeo(unittest.TestCase):
         self.assertEqual(0, len(seg.filter([{"test":neo.core.container.is_not(5)}, {"test":neo.core.container.is_not(6)}])))
 
     def test_filter_less_than(self):
+        '''
+            Tests FilterCondition object "less_than".
+        '''
 
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
@@ -169,6 +178,9 @@ class TestContainerNeo(unittest.TestCase):
         self.assertEqual(2, len(seg.filter(test=neo.core.container.less_than(7))))
 
     def test_filter_less_than_equal(self):
+        '''
+            Tests FilterCondition object "less_than_equal".
+        '''
 
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
@@ -183,6 +195,9 @@ class TestContainerNeo(unittest.TestCase):
         self.assertEqual(2, len(seg.filter(test=neo.core.container.less_than_equal(6))))
 
     def test_filter_greater_than(self):
+        '''
+            Tests FilterCondition object "greater_than".
+        '''
 
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
@@ -197,6 +212,9 @@ class TestContainerNeo(unittest.TestCase):
         self.assertEqual(2, len(seg.filter(test=neo.core.container.greater_than(4))))
 
     def test_filter_greater_than_equal(self):
+        '''
+            Tests FilterCondition object "greater_than_equal".
+        '''
 
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
@@ -211,6 +229,9 @@ class TestContainerNeo(unittest.TestCase):
         self.assertEqual(2, len(seg.filter(test=neo.core.container.greater_than_equal(5))))
 
     def test_filter_is_in(self):
+        '''
+        Tests FilterCondition object "is_in".
+        '''
 
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
@@ -225,7 +246,9 @@ class TestContainerNeo(unittest.TestCase):
         self.assertEqual(2, len(seg.filter(test=neo.core.container.is_in([5, 6, 10]))))
 
     def test_filter_in_range(self):
-
+        '''
+        Tests FilterCondition object "in_range".
+        '''
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
         st1.annotate(test=5)
@@ -240,7 +263,9 @@ class TestContainerNeo(unittest.TestCase):
         self.assertEqual(0, len(seg.filter(test=neo.core.container.in_range(5, 6, True, True))))
 
     def test_filter_connectivity(self):
-
+        '''
+        Tests old functionality with new filter method.
+        '''
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
         st1.annotate(test=5)

--- a/neo/test/coretest/test_container.py
+++ b/neo/test/coretest/test_container.py
@@ -102,14 +102,22 @@ class TestContainerNeo(unittest.TestCase):
         container.create_many_to_many_relationship()
         container.create_relationship()
 
-    def test_filter(self):
+    def test_filter_input(self):  #verschiedene tests
         container = Container()
         self.assertRaises(TypeError, container.filter, "foo")
+
+
+    def test_filter_results(self):  #(test fuer filterCondition)
 
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2]*q.ms, t_stop=10)
         st1.annotate(test=5)
+        st2 = neo.core.SpikeTrain([3, 4]*q.ms, t_stop=10)
+        st2.annotate(test=6)
         seg.spiketrains.append(st1)
+        seg.spiketrains.append(st2)
+
+        #Tests behalten?
         self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.equal(5))[0].annotations)
         self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.less_than(6))[0].annotations)
         self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.greater_than(4))[0].annotations)
@@ -118,6 +126,73 @@ class TestContainerNeo(unittest.TestCase):
         self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.in_range(1, 5))[0].annotations)
         self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.greater_than_equal(5))[0].annotations)
         self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.less_than_equal(5))[0].annotations)
+
+
+        #Neue Tests, aufteilen?
+        self.assertEqual(1, len(seg.filter(test=neo.core.container.equal(5))))
+        self.assertEqual(0, len(seg.filter(test=neo.core.container.equal(1))))
+
+        self.assertEqual(2, len(seg.filter(test=neo.core.container.is_not(1))))
+        self.assertEqual(1, len(seg.filter(test=neo.core.container.is_not(5))))
+        self.assertEqual(0, len(seg.filter([{"test":neo.core.container.is_not(5)}, {"test":neo.core.container.is_not(6)}])))
+
+        self.assertEqual(0, len(seg.filter(test=neo.core.container.less_than(5))))
+        self.assertEqual(1, len(seg.filter(test=neo.core.container.less_than(6))))
+        self.assertEqual(2, len(seg.filter(test=neo.core.container.less_than(7))))
+
+        self.assertEqual(0, len(seg.filter(test=neo.core.container.less_than_equal(4))))
+        self.assertEqual(1, len(seg.filter(test=neo.core.container.less_than_equal(5))))
+        self.assertEqual(2, len(seg.filter(test=neo.core.container.less_than_equal(6))))
+
+        self.assertEqual(0, len(seg.filter(test=neo.core.container.greater_than(6))))
+        self.assertEqual(1, len(seg.filter(test=neo.core.container.greater_than(5))))
+        self.assertEqual(2, len(seg.filter(test=neo.core.container.greater_than(4))))
+
+        self.assertEqual(0, len(seg.filter(test=neo.core.container.greater_than_equal(7))))
+        self.assertEqual(1, len(seg.filter(test=neo.core.container.greater_than_equal(6))))
+        self.assertEqual(2, len(seg.filter(test=neo.core.container.greater_than_equal(5))))
+
+        self.assertEqual(0, len(seg.filter(test=neo.core.container.is_in([4, 7, 10]))))
+        self.assertEqual(1, len(seg.filter(test=neo.core.container.is_in([5, 7, 10]))))
+        self.assertEqual(2, len(seg.filter(test=neo.core.container.is_in([5, 6, 10]))))
+
+        self.assertEqual(2, len(seg.filter(test=neo.core.container.in_range(5, 6, False, False))))
+        self.assertEqual(1, len(seg.filter(test=neo.core.container.in_range(5, 6, True, False))))
+        self.assertEqual(1, len(seg.filter(test=neo.core.container.in_range(5, 6, False, True))))
+        self.assertEqual(0, len(seg.filter(test=neo.core.container.in_range(5, 6, True, True))))
+
+    def test_filter_connectivity(self):
+
+        seg = neo.core.Segment()
+        st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
+        st1.annotate(test=5)
+        st2 = neo.core.SpikeTrain([3, 4]*q.ms, t_stop=10)
+        st2.annotate(filt=6)
+        st2.name('st_num_1')
+        seg.spiketrains.append(st1)
+        seg.spiketrains.append(st2)
+
+        self.assertEqual(2, len(seg.filter({'test': neo.core.container.equal(5), 'filt': neo.core.container.equal(6)})))
+        self.assertEqual(0, len(seg.filter([{'test': neo.core.container.equal(5)}, {'filt': neo.core.container.equal(6)}])))
+        #self.assertEqual(1, len(seg.filter(name='st_num_1')))
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/neo/test/coretest/test_container.py
+++ b/neo/test/coretest/test_container.py
@@ -118,19 +118,19 @@ class TestContainerNeo(unittest.TestCase):
         seg.spiketrains.append(st2)
 
         #Tests behalten?
-        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.equal(5))[0].annotations)
-        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.less_than(6))[0].annotations)
-        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.greater_than(4))[0].annotations)
-        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.is_not(1))[0].annotations)
-        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.is_in([1, 2, 5]))[0].annotations)
-        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.in_range(1, 5))[0].annotations)
-        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.greater_than_equal(5))[0].annotations)
-        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.less_than_equal(5))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.FilterEqual(5))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.FilterLessThan(6))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.FilterGreaterThan(4))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.FilterIsNot(1))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.FilterIsIn([1, 2, 5]))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.FilterInRange(1, 5))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.FilterGreaterThanEqual(5))[0].annotations)
+        self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.FilterLessThanEqual(5))[0].annotations)
 
 
     def test_filter_equal(self):
         '''
-            Tests FilterCondition object "equal".
+            Tests FilterCondition object "FilterEqual".
         '''
 
         seg = neo.core.Segment()
@@ -140,12 +140,12 @@ class TestContainerNeo(unittest.TestCase):
         st2.annotate(test=6)
         seg.spiketrains.append(st1)
         seg.spiketrains.append(st2)
-        self.assertEqual(1, len(seg.filter(test=neo.core.container.equal(5))))
-        self.assertEqual(0, len(seg.filter(test=neo.core.container.equal(1))))
+        self.assertEqual(1, len(seg.filter(test=neo.FilterEqual(5))))
+        self.assertEqual(0, len(seg.filter(test=neo.FilterEqual(1))))
 
     def test_filter_is_not(self):
         '''
-            Tests FilterCondition object "is_not".
+            Tests FilterCondition object "FilterIsNot".
         '''
 
         seg = neo.core.Segment()
@@ -156,13 +156,13 @@ class TestContainerNeo(unittest.TestCase):
         seg.spiketrains.append(st1)
         seg.spiketrains.append(st2)
 
-        self.assertEqual(2, len(seg.filter(test=neo.core.container.is_not(1))))
-        self.assertEqual(1, len(seg.filter(test=neo.core.container.is_not(5))))
-        self.assertEqual(0, len(seg.filter([{"test":neo.core.container.is_not(5)}, {"test":neo.core.container.is_not(6)}])))
+        self.assertEqual(2, len(seg.filter(test=neo.FilterIsNot(1))))
+        self.assertEqual(1, len(seg.filter(test=neo.FilterIsNot(5))))
+        self.assertEqual(0, len(seg.filter([{"test":neo.FilterIsNot(5)}, {"test":neo.FilterIsNot(6)}])))
 
     def test_filter_less_than(self):
         '''
-            Tests FilterCondition object "less_than".
+            Tests FilterCondition object "FilterLessThan".
         '''
 
         seg = neo.core.Segment()
@@ -173,13 +173,13 @@ class TestContainerNeo(unittest.TestCase):
         seg.spiketrains.append(st1)
         seg.spiketrains.append(st2)
 
-        self.assertEqual(0, len(seg.filter(test=neo.core.container.less_than(5))))
-        self.assertEqual(1, len(seg.filter(test=neo.core.container.less_than(6))))
-        self.assertEqual(2, len(seg.filter(test=neo.core.container.less_than(7))))
+        self.assertEqual(0, len(seg.filter(test=neo.FilterLessThan(5))))
+        self.assertEqual(1, len(seg.filter(test=neo.FilterLessThan(6))))
+        self.assertEqual(2, len(seg.filter(test=neo.FilterLessThan(7))))
 
     def test_filter_less_than_equal(self):
         '''
-            Tests FilterCondition object "less_than_equal".
+            Tests FilterCondition object "FilterLessThanEqual".
         '''
 
         seg = neo.core.Segment()
@@ -190,13 +190,13 @@ class TestContainerNeo(unittest.TestCase):
         seg.spiketrains.append(st1)
         seg.spiketrains.append(st2)
 
-        self.assertEqual(0, len(seg.filter(test=neo.core.container.less_than_equal(4))))
-        self.assertEqual(1, len(seg.filter(test=neo.core.container.less_than_equal(5))))
-        self.assertEqual(2, len(seg.filter(test=neo.core.container.less_than_equal(6))))
+        self.assertEqual(0, len(seg.filter(test=neo.FilterLessThanEqual(4))))
+        self.assertEqual(1, len(seg.filter(test=neo.FilterLessThanEqual(5))))
+        self.assertEqual(2, len(seg.filter(test=neo.FilterLessThanEqual(6))))
 
     def test_filter_greater_than(self):
         '''
-            Tests FilterCondition object "greater_than".
+            Tests FilterCondition object "FilterGreaterThan".
         '''
 
         seg = neo.core.Segment()
@@ -207,13 +207,13 @@ class TestContainerNeo(unittest.TestCase):
         seg.spiketrains.append(st1)
         seg.spiketrains.append(st2)
 
-        self.assertEqual(0, len(seg.filter(test=neo.core.container.greater_than(6))))
-        self.assertEqual(1, len(seg.filter(test=neo.core.container.greater_than(5))))
-        self.assertEqual(2, len(seg.filter(test=neo.core.container.greater_than(4))))
+        self.assertEqual(0, len(seg.filter(test=neo.FilterGreaterThan(6))))
+        self.assertEqual(1, len(seg.filter(test=neo.FilterGreaterThan(5))))
+        self.assertEqual(2, len(seg.filter(test=neo.FilterGreaterThan(4))))
 
     def test_filter_greater_than_equal(self):
         '''
-            Tests FilterCondition object "greater_than_equal".
+            Tests FilterCondition object "FilterGreaterThanEqual".
         '''
 
         seg = neo.core.Segment()
@@ -224,13 +224,13 @@ class TestContainerNeo(unittest.TestCase):
         seg.spiketrains.append(st1)
         seg.spiketrains.append(st2)
 
-        self.assertEqual(0, len(seg.filter(test=neo.core.container.greater_than_equal(7))))
-        self.assertEqual(1, len(seg.filter(test=neo.core.container.greater_than_equal(6))))
-        self.assertEqual(2, len(seg.filter(test=neo.core.container.greater_than_equal(5))))
+        self.assertEqual(0, len(seg.filter(test=neo.FilterGreaterThanEqual(7))))
+        self.assertEqual(1, len(seg.filter(test=neo.FilterGreaterThanEqual(6))))
+        self.assertEqual(2, len(seg.filter(test=neo.FilterGreaterThanEqual(5))))
 
     def test_filter_is_in(self):
         '''
-        Tests FilterCondition object "is_in".
+        Tests FilterCondition object "FilterIsIn".
         '''
 
         seg = neo.core.Segment()
@@ -241,13 +241,13 @@ class TestContainerNeo(unittest.TestCase):
         seg.spiketrains.append(st1)
         seg.spiketrains.append(st2)
 
-        self.assertEqual(0, len(seg.filter(test=neo.core.container.is_in([4, 7, 10]))))
-        self.assertEqual(1, len(seg.filter(test=neo.core.container.is_in([5, 7, 10]))))
-        self.assertEqual(2, len(seg.filter(test=neo.core.container.is_in([5, 6, 10]))))
+        self.assertEqual(0, len(seg.filter(test=neo.FilterIsIn([4, 7, 10]))))
+        self.assertEqual(1, len(seg.filter(test=neo.FilterIsIn([5, 7, 10]))))
+        self.assertEqual(2, len(seg.filter(test=neo.FilterIsIn([5, 6, 10]))))
 
     def test_filter_in_range(self):
         '''
-        Tests FilterCondition object "in_range".
+        Tests FilterCondition object "FilterInRange".
         '''
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
@@ -257,10 +257,10 @@ class TestContainerNeo(unittest.TestCase):
         seg.spiketrains.append(st1)
         seg.spiketrains.append(st2)
 
-        self.assertEqual(2, len(seg.filter(test=neo.core.container.in_range(5, 6, False, False))))
-        self.assertEqual(1, len(seg.filter(test=neo.core.container.in_range(5, 6, True, False))))
-        self.assertEqual(1, len(seg.filter(test=neo.core.container.in_range(5, 6, False, True))))
-        self.assertEqual(0, len(seg.filter(test=neo.core.container.in_range(5, 6, True, True))))
+        self.assertEqual(2, len(seg.filter(test=neo.FilterInRange(5, 6, False, False))))
+        self.assertEqual(1, len(seg.filter(test=neo.FilterInRange(5, 6, True, False))))
+        self.assertEqual(1, len(seg.filter(test=neo.FilterInRange(5, 6, False, True))))
+        self.assertEqual(0, len(seg.filter(test=neo.FilterInRange(5, 6, True, True))))
 
     def test_filter_connectivity(self):
         '''
@@ -275,8 +275,8 @@ class TestContainerNeo(unittest.TestCase):
         seg.spiketrains.append(st1)
         seg.spiketrains.append(st2)
 
-        self.assertEqual(2, len(seg.filter({'test': neo.core.container.equal(5), 'filt': neo.core.container.equal(6)})))
-        self.assertEqual(0, len(seg.filter([{'test': neo.core.container.equal(5)}, {'filt': neo.core.container.equal(6)}])))
+        self.assertEqual(2, len(seg.filter({'test': neo.FilterEqual(5), 'filt': neo.FilterEqual(6)})))
+        self.assertEqual(0, len(seg.filter([{'test': neo.FilterEqual(5)}, {'filt': neo.FilterEqual(6)}])))
         self.assertEqual(1, len(seg.filter(name='st_num_1')))
 
 

--- a/neo/test/coretest/test_container.py
+++ b/neo/test/coretest/test_container.py
@@ -102,12 +102,12 @@ class TestContainerNeo(unittest.TestCase):
         container.create_many_to_many_relationship()
         container.create_relationship()
 
-    def test_filter_input(self):  #verschiedene tests
+    def test_filter_input(self):
         container = Container()
         self.assertRaises(TypeError, container.filter, "foo")
 
 
-    def test_filter_results(self):  #(test fuer filterCondition)
+    def test_filter_results(self):
 
         seg = neo.core.Segment()
         st1 = neo.core.SpikeTrain([1, 2]*q.ms, t_stop=10)
@@ -128,33 +128,111 @@ class TestContainerNeo(unittest.TestCase):
         self.assertEqual(st1.annotations, seg.filter(test=neo.core.container.less_than_equal(5))[0].annotations)
 
 
-        #Neue Tests, aufteilen?
+    def test_filter_equal(self):
+
+        seg = neo.core.Segment()
+        st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
+        st1.annotate(test=5)
+        st2 = neo.core.SpikeTrain([3, 4] * q.ms, t_stop=10)
+        st2.annotate(test=6)
+        seg.spiketrains.append(st1)
+        seg.spiketrains.append(st2)
         self.assertEqual(1, len(seg.filter(test=neo.core.container.equal(5))))
         self.assertEqual(0, len(seg.filter(test=neo.core.container.equal(1))))
+
+    def test_filter_is_not(self):
+
+        seg = neo.core.Segment()
+        st1 = neo.core.SpikeTrain([1, 2]*q.ms, t_stop=10)
+        st1.annotate(test=5)
+        st2 = neo.core.SpikeTrain([3, 4]*q.ms, t_stop=10)
+        st2.annotate(test=6)
+        seg.spiketrains.append(st1)
+        seg.spiketrains.append(st2)
 
         self.assertEqual(2, len(seg.filter(test=neo.core.container.is_not(1))))
         self.assertEqual(1, len(seg.filter(test=neo.core.container.is_not(5))))
         self.assertEqual(0, len(seg.filter([{"test":neo.core.container.is_not(5)}, {"test":neo.core.container.is_not(6)}])))
 
+    def test_filter_less_than(self):
+
+        seg = neo.core.Segment()
+        st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
+        st1.annotate(test=5)
+        st2 = neo.core.SpikeTrain([3, 4] * q.ms, t_stop=10)
+        st2.annotate(test=6)
+        seg.spiketrains.append(st1)
+        seg.spiketrains.append(st2)
+
         self.assertEqual(0, len(seg.filter(test=neo.core.container.less_than(5))))
         self.assertEqual(1, len(seg.filter(test=neo.core.container.less_than(6))))
         self.assertEqual(2, len(seg.filter(test=neo.core.container.less_than(7))))
+
+    def test_filter_less_than_equal(self):
+
+        seg = neo.core.Segment()
+        st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
+        st1.annotate(test=5)
+        st2 = neo.core.SpikeTrain([3, 4] * q.ms, t_stop=10)
+        st2.annotate(test=6)
+        seg.spiketrains.append(st1)
+        seg.spiketrains.append(st2)
 
         self.assertEqual(0, len(seg.filter(test=neo.core.container.less_than_equal(4))))
         self.assertEqual(1, len(seg.filter(test=neo.core.container.less_than_equal(5))))
         self.assertEqual(2, len(seg.filter(test=neo.core.container.less_than_equal(6))))
 
+    def test_filter_greater_than(self):
+
+        seg = neo.core.Segment()
+        st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
+        st1.annotate(test=5)
+        st2 = neo.core.SpikeTrain([3, 4] * q.ms, t_stop=10)
+        st2.annotate(test=6)
+        seg.spiketrains.append(st1)
+        seg.spiketrains.append(st2)
+
         self.assertEqual(0, len(seg.filter(test=neo.core.container.greater_than(6))))
         self.assertEqual(1, len(seg.filter(test=neo.core.container.greater_than(5))))
         self.assertEqual(2, len(seg.filter(test=neo.core.container.greater_than(4))))
+
+    def test_filter_greater_than_equal(self):
+
+        seg = neo.core.Segment()
+        st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
+        st1.annotate(test=5)
+        st2 = neo.core.SpikeTrain([3, 4] * q.ms, t_stop=10)
+        st2.annotate(test=6)
+        seg.spiketrains.append(st1)
+        seg.spiketrains.append(st2)
 
         self.assertEqual(0, len(seg.filter(test=neo.core.container.greater_than_equal(7))))
         self.assertEqual(1, len(seg.filter(test=neo.core.container.greater_than_equal(6))))
         self.assertEqual(2, len(seg.filter(test=neo.core.container.greater_than_equal(5))))
 
+    def test_filter_is_in(self):
+
+        seg = neo.core.Segment()
+        st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
+        st1.annotate(test=5)
+        st2 = neo.core.SpikeTrain([3, 4] * q.ms, t_stop=10)
+        st2.annotate(test=6)
+        seg.spiketrains.append(st1)
+        seg.spiketrains.append(st2)
+
         self.assertEqual(0, len(seg.filter(test=neo.core.container.is_in([4, 7, 10]))))
         self.assertEqual(1, len(seg.filter(test=neo.core.container.is_in([5, 7, 10]))))
         self.assertEqual(2, len(seg.filter(test=neo.core.container.is_in([5, 6, 10]))))
+
+    def test_filter_in_range(self):
+
+        seg = neo.core.Segment()
+        st1 = neo.core.SpikeTrain([1, 2] * q.ms, t_stop=10)
+        st1.annotate(test=5)
+        st2 = neo.core.SpikeTrain([3, 4] * q.ms, t_stop=10)
+        st2.annotate(test=6)
+        seg.spiketrains.append(st1)
+        seg.spiketrains.append(st2)
 
         self.assertEqual(2, len(seg.filter(test=neo.core.container.in_range(5, 6, False, False))))
         self.assertEqual(1, len(seg.filter(test=neo.core.container.in_range(5, 6, True, False))))
@@ -168,32 +246,13 @@ class TestContainerNeo(unittest.TestCase):
         st1.annotate(test=5)
         st2 = neo.core.SpikeTrain([3, 4]*q.ms, t_stop=10)
         st2.annotate(filt=6)
-        st2.name('st_num_1')
+        st2.annotate(name='st_num_1')
         seg.spiketrains.append(st1)
         seg.spiketrains.append(st2)
 
         self.assertEqual(2, len(seg.filter({'test': neo.core.container.equal(5), 'filt': neo.core.container.equal(6)})))
         self.assertEqual(0, len(seg.filter([{'test': neo.core.container.equal(5)}, {'filt': neo.core.container.equal(6)}])))
-        #self.assertEqual(1, len(seg.filter(name='st_num_1')))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        self.assertEqual(1, len(seg.filter(name='st_num_1')))
 
 
 class Test_Container_merge(unittest.TestCase):


### PR DESCRIPTION
Until now it was not so easy to filter for multiple values with the filter function in neo. To solve this problem, I introduced "FilterConditions". These can be provided to the filter function as the value of a dictionary. 

An example of the syntax: 

seg.filter({“electrode_id”: FilterCondition) or seg.filter(electrode_id = FilterCondition) 

In order to be able to filter for several electrode_ids, there are some objects that inherit from FilterCondition and provide different filtering options. 

For example, seg.filter({"electrode_id": neo.FilterIsIn([0, 1, 5]) can be used to filter for all objects with electrode_id 0, 1 or 5. 


List of all currently added FilterConditions: 

-FilterEqual(x), returns id == x 

-FilterIsNot(x), returns id != x 

-FilterLessThan(x), returns id < x 

-FilterLessThanEqual(x), returns id <= x 

-FilterGreaterThan(x), returns id > x 

-FilterGreaterThanEqual(x), returns id >= x 

-FilterIsIn([x, y, z]), returns id == x or id == y or id == z 

-FilterInRange(a, b), returns a <= id <= b 

 
Additional FilterConditions can be added at any time and without much effort.  