### PR TITLE
Fix gains for SpikeGLX

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -284,18 +284,18 @@ def scan_files(dirname):
                         v = meta['imroTbl'][c].split(' ')[index_imroTbl]
                         per_channel_gain[c] = 1. / float(v)
                     gain_factor = float(meta['imAiRangeMax']) / 512
-                    channel_gains = gain_factor / per_channel_gain * 1e6
+                    channel_gains = gain_factor * per_channel_gain * 1e6
                 elif meta['imDatPrb_type'] in ('21', '24') and signal_kind == 'ap':
                     # This wirk with NP 2.0 case with different metadata versions
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_20.md#channel-entries-by-type
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_20.md#imec
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_30.md#imec
-                    per_channel_gain[:-1] = 80.
+                    per_channel_gain[:-1] = 1 / 80.
                     gain_factor = float(meta['imAiRangeMax']) / 8192
-                    channel_gains = gain_factor / per_channel_gain * 1e6
+                    channel_gains = gain_factor * per_channel_gain * 1e6
                 else:
                     raise NotImplementedError('This meta file version of spikeglx'
-                                             'is not implemented')
+                                              'is not implemented')
             else:
                 signal_kind = ''
                 stream_name = device

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -284,7 +284,7 @@ def scan_files(dirname):
                         v = meta['imroTbl'][c].split(' ')[index_imroTbl]
                         per_channel_gain[c] = 1. / float(v)
                     gain_factor = float(meta['imAiRangeMax']) / 512
-                    channel_gains = per_channel_gain * gain_factor * 1e6
+                    channel_gains = gain_factor / per_channel_gain * 1e6
                 elif meta['imDatPrb_type'] in ('21', '24') and signal_kind == 'ap':
                     # This wirk with NP 2.0 case with different metadata versions
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_20.md#channel-entries-by-type
@@ -292,7 +292,7 @@ def scan_files(dirname):
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_30.md#imec
                     per_channel_gain[:-1] = 80.
                     gain_factor = float(meta['imAiRangeMax']) / 8192
-                    channel_gains = per_channel_gain * gain_factor * 1e6
+                    channel_gains = gain_factor / per_channel_gain * 1e6
                 else:
                     raise NotImplementedError('This meta file version of spikeglx'
                                              'is not implemented')

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -272,7 +272,7 @@ def scan_files(dirname):
                 # except for the last fake channel
                 per_channel_gain = np.ones(num_chan, dtype='float64')
                 if 'imDatPrb_type' not in meta or meta['imDatPrb_type'] == '0':
-                    # This wirk with NP 1.0 case with different metadata versions
+                    # This work with NP 1.0 case with different metadata versions
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_3A.md#imec
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_3B1.md#imec
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_3B2.md#imec
@@ -286,7 +286,7 @@ def scan_files(dirname):
                     gain_factor = float(meta['imAiRangeMax']) / 512
                     channel_gains = gain_factor * per_channel_gain * 1e6
                 elif meta['imDatPrb_type'] in ('21', '24') and signal_kind == 'ap':
-                    # This wirk with NP 2.0 case with different metadata versions
+                    # This work with NP 2.0 case with different metadata versions
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_20.md#channel-entries-by-type
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_20.md#imec
                     # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_30.md#imec
@@ -305,8 +305,8 @@ def scan_files(dirname):
                 # there are differents kinds of channels with different gain values
                 mn, ma, xa, dw = [int(e) for e in meta['snsMnMaXaDw'].split(sep=',')]
                 per_channel_gain = np.ones(num_chan, dtype='float64')
-                per_channel_gain[0:mn] = float(meta['niMNGain'])
-                per_channel_gain[mn:mn + ma] = float(meta['niMAGain'])
+                per_channel_gain[0:mn] = 1. / float(meta['niMNGain'])
+                per_channel_gain[mn:mn + ma] = 1. / float(meta['niMAGain'])
                 # this scaling come from the code in this zip
                 # https://billkarsh.github.io/SpikeGLX/Support/SpikeGLX_Datafile_Tools.zip
                 # in file readSGLX.py line76


### PR DESCRIPTION
In the SpikeGLX parser, gains are wrongly set.

In the SpikeGLX documentation (https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_20.md#channel-entries-by-type):
`g = Vmax / Imax / gain`
but in the code it was set as (https://github.com/NeuralEnsemble/python-neo/blob/master/neo/rawio/spikeglxrawio.py#L287):
`g = gain * Vmax / Imax` 

where `Vmax / Imax` is `gain_factor `. Instead, it should be:
`g = Vmax / Imax / gain`

This is tested on a NP2 file, where the computed gainwas over 4000! With the corrected gain, it is now ~0.7, which gives more reasonable uV values.

