### PR TITLE
[tdt] fix border id handling for chunk loading

### DIFF
--- a/neo/rawio/tdtrawio.py
+++ b/neo/rawio/tdtrawio.py
@@ -389,7 +389,9 @@ class TdtRawIO(BaseRawIO):
                     # right border
                     # be careful that bl could be both bl0 and bl1!!
                     border = data.size - (i_stop % sample_per_chunk)
-                    data = data[:-border]
+                    # cut data if not all samples are requested
+                    if border != len(data):
+                        data = data[:-border]
                 if bl == bl0:
                     # left border
                     border = i_start % sample_per_chunk


### PR DESCRIPTION
Currently if a the last data block of a chunk is loaded and all of it's samples are valid (need to be included), then None is included, due to wrong indexing (`data[:-length]` instead of `data[:]`)