### PR TITLE
[tdt] Add new entities to tdt tests and fix file header parsing

### DIFF
--- a/neo/rawio/tdtrawio.py
+++ b/neo/rawio/tdtrawio.py
@@ -522,7 +522,8 @@ def read_tbk(tbk_filename):
 
         # parse into a dict
         info = OrderedDict()
-        pattern = br'NAME=(\S+);TYPE=(\S+);VALUE=(\S+);'
+        # name and type have to be words, but value can contain floating numbers
+        pattern = br'NAME=(\w+);TYPE=(\w+);VALUE=(\S+);'
         r = re.findall(pattern, chan_grp_header)
         for name, _type, value in r:
             info[name.decode('ascii')] = value

--- a/neo/rawio/tdtrawio.py
+++ b/neo/rawio/tdtrawio.py
@@ -389,7 +389,9 @@ class TdtRawIO(BaseRawIO):
                     # right border
                     # be careful that bl could be both bl0 and bl1!!
                     border = data.size - (i_stop % sample_per_chunk)
-                    data = data[:-border]
+                    # cut data if not all samples are requested
+                    if border != len(data):
+                        data = data[:-border]
                 if bl == bl0:
                     # left border
                     border = i_start % sample_per_chunk

--- a/neo/test/iotest/test_tdtio.py
+++ b/neo/test/iotest/test_tdtio.py
@@ -14,7 +14,12 @@ class TestTdtIO(BaseTestIO, unittest.TestCase, ):
         'tdt'
     ]
     entities_to_test = [
-        'tdt/aep_05'
+        # test structure directory with multiple blocks
+        'tdt/aep_05',
+        # test single block
+        'tdt/dataset_0_single_block/512ch_reconly_all-181123_B24_rest.Tdx',
+        'tdt/dataset_1_single_block/ECTest-220207-135355_ECTest_B1.Tdx'
+        'tdt/aep_05/Block-1/aep_05_Block-1.Tdx'
     ]
 
     def test_signal_group_mode(self):

--- a/neo/test/iotest/test_tdtio.py
+++ b/neo/test/iotest/test_tdtio.py
@@ -18,7 +18,7 @@ class TestTdtIO(BaseTestIO, unittest.TestCase, ):
         'tdt/aep_05',
         # test single block
         'tdt/dataset_0_single_block/512ch_reconly_all-181123_B24_rest.Tdx',
-        'tdt/dataset_1_single_block/ECTest-220207-135355_ECTest_B1.Tdx'
+        'tdt/dataset_1_single_block/ECTest-220207-135355_ECTest_B1.Tdx',
         'tdt/aep_05/Block-1/aep_05_Block-1.Tdx'
     ]
 

--- a/neo/test/rawiotest/test_tdtrawio.py
+++ b/neo/test/rawiotest/test_tdtrawio.py
@@ -16,7 +16,7 @@ class TestTdtRawIO(BaseTestRawIO, unittest.TestCase, ):
         'tdt/aep_05',
         # test single block
         'tdt/dataset_0_single_block/512ch_reconly_all-181123_B24_rest.Tdx',
-        'tdt/dataset_1_single_block/ECTest-220207-135355_ECTest_B1.Tdx'
+        'tdt/dataset_1_single_block/ECTest-220207-135355_ECTest_B1.Tdx',
         'tdt/aep_05/Block-1/aep_05_Block-1.Tdx'
     ]
 

--- a/neo/test/rawiotest/test_tdtrawio.py
+++ b/neo/test/rawiotest/test_tdtrawio.py
@@ -12,7 +12,11 @@ class TestTdtRawIO(BaseTestRawIO, unittest.TestCase, ):
         'tdt'
     ]
     entities_to_test = [
+        # test structure directory with multiple blocks
         'tdt/aep_05',
+        # test single block
+        'tdt/dataset_0_single_block/512ch_reconly_all-181123_B24_rest.Tdx',
+        'tdt/dataset_1_single_block/ECTest-220207-135355_ECTest_B1.Tdx'
         'tdt/aep_05/Block-1/aep_05_Block-1.Tdx'
     ]
 


### PR DESCRIPTION
This PR includes the recently added TDT testdatasets into the neo tests. (https://gin.g-node.org/NeuralEnsemble/ephy_testing_data/pulls/73 and https://gin.g-node.org/NeuralEnsemble/ephy_testing_data/pulls/74)

To parse these new files correctly also the header parsing regex needed to be restricted to not accept non-ascii characters in name or type strings.

This PR is building on top of #1070.