### PR TITLE
BUG: Dont hold the exception

### DIFF
--- a/neo/io/stimfitio.py
+++ b/neo/io/stimfitio.py
@@ -32,15 +32,6 @@ import quantities as pq
 from neo.io.baseio import BaseIO
 from neo.core import Block, Segment, AnalogSignal
 
-try:
-    import stfio
-except ImportError as err:
-    HAS_STFIO = False
-    STFIO_ERR = err
-else:
-    HAS_STFIO = True
-    STFIO_ERR = None
-
 
 class StimfitIO(BaseIO):
     """
@@ -99,8 +90,9 @@ class StimfitIO(BaseIO):
         Arguments:
             filename : Either a filename or a stfio Recording object
         """
-        if not HAS_STFIO:
-            raise STFIO_ERR
+        # We need this module, so try importing now so that it fails on
+        # instantiation rather than read_block
+        import stfio  # noqa
 
         BaseIO.__init__(self)
 
@@ -112,6 +104,7 @@ class StimfitIO(BaseIO):
             self.filename = None
 
     def read_block(self, lazy=False):
+        import stfio
         assert not lazy, 'Do not support lazy'
 
         if self.filename is not None:

--- a/neo/test/iotest/test_stimfitio.py
+++ b/neo/test/iotest/test_stimfitio.py
@@ -8,8 +8,14 @@ import sys
 import unittest
 
 from neo.io import StimfitIO
-from neo.io.stimfitio import HAS_STFIO
 from neo.test.iotest.common_io_test import BaseTestIO
+
+try:
+    import stfio
+except Exception:
+    HAS_STFIO = False
+else:
+    HAS_STFIO = True
 
 
 @unittest.skipIf(sys.version_info[0] > 2, "not Python 3 compatible")


### PR DESCRIPTION
This PR fixes a particularly elusive bug observed when a MNE-Python example that uses `neo` was being built by sphinx-gallery but its namespace variables were not able to be cleared by calling `gc.collect()` after example execution completed. The root cause turned out to be that the `import neo` in the example led to an import of `neo.io.stimfitio` (okay by itself), which in turn tried to import `stfio` which failed (okay by itself), which in turn kept the variables in memory in the traceback frame of the exception so that they could not be garbage collected (bad!). Or, in simplified-example form, this was problematic:
```
>>> import numpy as np
>>> x = np.ones(123456789)
>>> import neo
>>> print(neo.io.stimfitio.STFIO_ERR.__traceback__.tb_frame.f_back.f_back
          .f_back.f_back.f_back.f_back.f_back.f_back.f_back.f_back.f_back
          .f_back.f_back.f_back.f_back.f_back.f_back.f_back.f_locals['x'].size)
123456789
```
Storing the `STFIO_ERR` during `import neo` does not seem to have any real benefit over trying the import at instantiation of the `StimfitIO` object itself -- since this is where the error gets re-raised anyway in `master` -- so this PR simplifies things just by trying the import during `__init__` directly rather than at the module level.

If you want, I could also wrap the `import stfio` in `__init__` in a `try/except Exception as exc` that raises a more informative error like `f'StimfitIO requires the stfio module but it could not be imported: {exc}'` if it would help. We usually do this sort of thing in MNE-Python at least to make it explicit that there is some problem with the user's Python setup that they should try to fix regarding the missing module.