### PR TITLE
Assign a default value to group-less channels in NeuroScopeRawIO 

### DIFF
--- a/neo/rawio/neuroscoperawio.py
+++ b/neo/rawio/neuroscoperawio.py
@@ -69,12 +69,11 @@ class NeuroScopeRawIO(BaseRawIO):
 
         # one unique stream
         signal_streams = np.array([('Signals', '0')], dtype=_signal_stream_dtype)
-        
+
         # signals
         sig_channels = []
         for c in range(nb_channel):
             name = 'ch{}grp{}'.format(c, channel_group.get(c, 'none'))
- 
             chan_id = str(c)
             units = 'mV'
             offset = 0.

--- a/neo/rawio/neuroscoperawio.py
+++ b/neo/rawio/neuroscoperawio.py
@@ -69,11 +69,12 @@ class NeuroScopeRawIO(BaseRawIO):
 
         # one unique stream
         signal_streams = np.array([('Signals', '0')], dtype=_signal_stream_dtype)
-
+        
         # signals
         sig_channels = []
         for c in range(nb_channel):
-            name = 'ch{}grp{}'.format(c, channel_group[c])
+            name = 'ch{}grp{}'.format(c, channel_group.get(c, 'none'))
+ 
             chan_id = str(c)
             units = 'mV'
             offset = 0.


### PR DESCRIPTION
This should fix #1077 

As described, the loop in the diff assigns groups to channels assuming that everyone channel as a group name. As described in #1077 this is not the case. The code provides a simple default for those cases.