### PR TITLE
Fixes from SpikeInterface CI

### DIFF
--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -302,7 +302,7 @@ class AxonaRawIO(BaseRawIO):
             i_start = 0
         if i_stop is None:
             i_stop = bin_dict['num_total_samples']
-        if channel_indexes is None:
+        if channel_indexes is None or isinstance(channel_indexes, slice):
             channel_indexes = [i for i in range(bin_dict['num_channels'])]
 
         num_samples = (i_stop - i_start)

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -302,8 +302,11 @@ class AxonaRawIO(BaseRawIO):
             i_start = 0
         if i_stop is None:
             i_stop = bin_dict['num_total_samples']
-        if channel_indexes is None or isinstance(channel_indexes, slice):
+        if channel_indexes is None:
             channel_indexes = [i for i in range(bin_dict['num_channels'])]
+        if isinstance(channel_indexes, slice):
+            channel_indexes_all = [i for i in range(bin_dict['num_channels'])]
+            channel_indexes = channel_indexes_all[channel_indexes]
 
         num_samples = (i_stop - i_start)
 

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -304,7 +304,7 @@ class AxonaRawIO(BaseRawIO):
             i_stop = bin_dict['num_total_samples']
         if channel_indexes is None:
             channel_indexes = [i for i in range(bin_dict['num_channels'])]
-        if isinstance(channel_indexes, slice):
+        elif isinstance(channel_indexes, slice):
             channel_indexes_all = [i for i in range(bin_dict['num_channels'])]
             channel_indexes = channel_indexes_all[channel_indexes]
 

--- a/neo/rawio/biocamrawio.py
+++ b/neo/rawio/biocamrawio.py
@@ -112,9 +112,11 @@ class BiocamRawIO(BaseRawIO):
             i_start = 0
         if i_stop is None:
             i_stop = self._num_frames
-
         data = self._read_function(self._filehandle, i_start, i_stop, self._num_channels)
-        return data[:, channel_indexes]
+        if channel_indexes is None:
+            return data
+        else:
+            return data[:, channel_indexes]
 
 
 def open_biocam_file_header(filename):

--- a/neo/rawio/biocamrawio.py
+++ b/neo/rawio/biocamrawio.py
@@ -114,7 +114,7 @@ class BiocamRawIO(BaseRawIO):
             i_stop = self._num_frames
 
         data = self._read_function(self._filehandle, i_start, i_stop, self._num_channels)
-        return np.squeeze(data[:, channel_indexes])
+        return data[:, channel_indexes]
 
 
 def open_biocam_file_header(filename):

--- a/neo/rawio/biocamrawio.py
+++ b/neo/rawio/biocamrawio.py
@@ -112,11 +112,10 @@ class BiocamRawIO(BaseRawIO):
             i_start = 0
         if i_stop is None:
             i_stop = self._num_frames
-        data = self._read_function(self._filehandle, i_start, i_stop, self._num_channels)
         if channel_indexes is None:
-            return data
-        else:
-            return data[:, channel_indexes]
+            channel_indexes = slice(None)
+        data = self._read_function(self._filehandle, i_start, i_stop, self._num_channels)
+        return data[:, channel_indexes]
 
 
 def open_biocam_file_header(filename):


### PR DESCRIPTION
A couple of small fixes that came up when addin tests in SI:

- BiocamRawIO: remove squeeze when returning traces
- AxonaRawIO: construct list of channels also when `channel_indexes` is a `slice`