### PR TITLE
0.10.1 release updates

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.8"
 
 sphinx:
    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements_docs.txt 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2021, Neo authors and contributors
+Copyright (c) 2010-2022, Neo authors and contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ For installation instructions, see doc/source/install.rst
 
 To cite Neo in publications, see CITATION.txt
 
-:copyright: Copyright 2010-2021 by the Neo team, see doc/source/authors.rst.
+:copyright: Copyright 2010-2022 by the Neo team, see doc/source/authors.rst.
 :license: 3-Clause Revised BSD License, see LICENSE.txt for details.
 
 Funding

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -51,7 +51,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Neo'
-copyright = '2010-2021, ' + AUTHORS
+copyright = '2010-2022, ' + AUTHORS
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/source/releases/0.10.1.rst
+++ b/doc/source/releases/0.10.1.rst
@@ -2,7 +2,7 @@
 Neo 0.10.1 release notes
 ========================
 
-3rd March 2022
+2nd March 2022
 
 
 Bug fixes and improvements in IO modules
@@ -11,6 +11,11 @@ Bug fixes and improvements in IO modules
 * :class:`NeuralynxIO` memory performace was improved during initialization [#998](https://github.com/NeuralEnsemble/python-neo/pull/990) and new arguments for file selection were added [#1023](https://github.com/NeuralEnsemble/python-neo/pull/1023) [#1043](https://github.com/NeuralEnsemble/python-neo/pull/1043)
 * :class:`TdtIO` can load single block tdt datasets [#1057](https://github.com/NeuralEnsemble/python-neo/pull/1057)
 * :class:`SpikeGLXIO` supports neuropixel 2.0 format [#1045](https://github.com/NeuralEnsemble/python-neo/pull/1045) and uses corrected gain values [#1069](https://github.com/NeuralEnsemble/python-neo/pull/1069)
+* :class:`NixIO` some bug fix related to nixio module
+* :class:`NwbIO` various improvement [#1052](https://github.com/NeuralEnsemble/python-neo/pull/1052) [#1054](https://github.com/NeuralEnsemble/python-neo/pull/1054)
+* :class:`OpenEphysIO` small bug fix [#1062](https://github.com/NeuralEnsemble/python-neo/pull/1062)
+* :class:`MaxwellIO` bug fix [#1074](https://github.com/NeuralEnsemble/python-neo/pull/1074)
+* :class:`NeuroscopeIO` bug fix [#1078](https://github.com/NeuralEnsemble/python-neo/pull/1078)
 * The IO modules of this release have been tested with version 0.1.1 of the `ephy_testing_data`_.
 
 Documentation

--- a/doc/source/releases/0.10.1.rst
+++ b/doc/source/releases/0.10.1.rst
@@ -1,0 +1,28 @@
+========================
+Neo 0.10.1 release notes
+========================
+
+3rd March 2022
+
+
+Bug fixes and improvements in IO modules
+----------------------------------------
+
+* :class:`NeuralynxIO` memory performace was improved during initialization [#998](https://github.com/NeuralEnsemble/python-neo/pull/990) and new arguments for file selection were added [#1023](https://github.com/NeuralEnsemble/python-neo/pull/1023) [#1043](https://github.com/NeuralEnsemble/python-neo/pull/1043)
+* :class:`TdtIO` can load single block tdt datasets [#1057](https://github.com/NeuralEnsemble/python-neo/pull/1057)
+* :class:`SpikeGLXIO` supports neuropixel 2.0 format [#1045](https://github.com/NeuralEnsemble/python-neo/pull/1045) and uses corrected gain values [#1069](https://github.com/NeuralEnsemble/python-neo/pull/1069)
+* The IO modules of this release have been tested with version 0.1.1 of the `ephy_testing_data`_.
+
+Documentation
+-------------
+A project governance guide has been added [#1048](https://github.com/NeuralEnsemble/python-neo/pull/1048)
+
+
+Acknowledgements
+----------------
+
+Thanks to Samuel Garcia, Julia Sprenger, Andrew Davison, Alessio Buccino, Ben Dichter,
+Elodie Legouée, Eric Larson and Heberto Mayorquin for their contributions to this release.
+
+.. _`ephy_testing_data`: https://gin.g-node.org/NeuralEnsemble/ephy_testing_data/src/v0.1.1
+

--- a/doc/source/whatisnew.rst
+++ b/doc/source/whatisnew.rst
@@ -6,6 +6,7 @@ Release notes
 .. toctree::
    :maxdepth: 1
 
+   releases/0.10.1.rst
    releases/0.10.0.rst
    releases/0.9.0.rst
    releases/0.8.0.rst

--- a/neo/version.py
+++ b/neo/version.py
@@ -1,1 +1,1 @@
-version = '0.11.0.dev0'
+version = '0.10.1'


### PR DESCRIPTION
Currently the documentation is not building due to the documentation requirements being unaccessible. For me it seems the file is there (https://readthedocs.org/projects/neo/builds/16245520/). @samuelgarcia Any idea?