### PR TITLE
auto push to pypi on push tags

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,34 @@
+name:  Release to PyPI
+
+on:
+  push:
+    tags:
+       - '*'
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies for testing
+        run: |
+          pip install pytest pytest-cov
+          pip install setuptools wheel twine
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Test core with pytest
+        run: |
+          pytest --cov=neo neo/test/coretest
+      - name: Publish on PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*


### PR DESCRIPTION
@JuliaSprenger @apdavison @mdenker : have a look.
This auto push to pypi when we tag.
We have the same on spikeinertface.
Here we don't run the full io test which too long. Only the neo.core.
I think this is enough.