### PR TITLE
unpin nixio version as fix was released in version 1.5.3

### DIFF
--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -6,7 +6,7 @@ h5py
 igor
 klusta
 tqdm
-nixio==1.5.1
+nixio
 matplotlib
 ipython
 coverage


### PR DESCRIPTION
See original pinning, see #1063

Closes #1085 
