### PR TITLE
[CI] use conda environment for IO tests

### DIFF
--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -20,11 +20,11 @@ jobs:
         # "macos-latest", "windows-latest"
         os: ["ubuntu-latest", ]
         python-version: ['3.8', ]
+    defaults:
+      # by default run in bash mode (required for conda usage)
+      run:
+        shell: bash -l {0}
     steps:
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -33,49 +33,51 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m')"
 
-      - uses: actions/cache@v2
-        # the cache for python package is reset:
-        #   * every month
-        #   * when requirements/requirements_testing change
-        id: cache-venv
-        with:
-          path: ~/test_env
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/requirements_testing.txt') }}-${{ steps.date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-venv-
-
-      - name: Install dependencies
-        run: |
-          # this is for datalad and download testing datasets
-          sudo apt install git git-annex
-          # needed for correct operation of git/git-annex/DataLad
-          git config --global user.email "neo_ci@fake_mail.com"
-          git config --global user.name "neo CI"
-          # create an environment and install everything
-          python -m venv ~/test_env
-          source ~/test_env/bin/activate
-          python -m pip install --upgrade pip
-          # pip install -r requirements.txt
-          pip install -r requirements_testing.txt
-          pip install -e .
-
       - name: Get ephy_testing_data current head hash
-        # the key depend on the last comit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git
+        # the key depend on the last commit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git
         id: vars
         run: |
           echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
+        # Loading cache of ephys_testing_dataset
         id: cache-datasets
         with:
           path: ~/ephy_testing_data
           key: ${{ runner.os }}-datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
-          restore-keys: |
-            ${{ runner.os }}-datasets
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: neo-test-env
+          python-version: ${{ matrix.python-version }}
+          clean-patched-environment-file: false
+
+      - uses: actions/cache@v3
+        # the cache for python package is reset:
+        #   * every month
+        #   * when requirements/requirements_testing change
+        id: cache-conda-env
+        with:
+          path: /usr/share/miniconda/envs/neo-test-env
+          key: ${{ runner.os }}-conda-env-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/requirements_testing.txt') }}-${{ hashFiles('**/environment_testing.txt') }}-${{ steps.date.outputs.date }}
+
+      - name: Install testing dependencies
+        # testing environment is only installed if no cache was found
+        if: steps.cache-conda-env.outputs.cache-hit != 'true'
+        run: |
+          conda env update neo-test-env --file environment_testing.yml
+
+      - name: Configure git
+        run: |
+          git config --global user.email "neo_ci@fake_mail.com"
+          git config --global user.name "neo CI"
+
+      - name: Install neo
+        run: |
+          pip install --upgrade -e .
 
       - name: Test with pytest
         run: |
-          source ~/test_env/bin/activate
           # only neo.rawio and neo.io
           pytest --cov=neo neo/test/rawiotest
           pytest --cov=neo neo/test/iotest

--- a/environment_testing.yml
+++ b/environment_testing.yml
@@ -1,0 +1,8 @@
+name: neo-test-env
+channels:
+  - conda-forge
+dependencies:
+  - datalad
+  - pip
+  - pip:
+    - -r requirements_testing.txt

--- a/neo/test/iotest/test_edfio.py
+++ b/neo/test/iotest/test_edfio.py
@@ -27,64 +27,64 @@ class TestEDFIO(BaseTestIO, unittest.TestCase, ):
         """
         Test reading the complete block and general annotations
         """
-        io = EDFIO(self.filename)
-        bl = io.read_block()
-        self.assertTrue(bl.annotations)
+        with EDFIO(self.filename) as io:
+            bl = io.read_block()
+            self.assertTrue(bl.annotations)
 
-        seg = bl.segments[0]
-        assert seg.name == 'Seg #0 Block #0'
-        for anasig in seg.analogsignals:
-            assert anasig.name is not None
+            seg = bl.segments[0]
+            assert seg.name == 'Seg #0 Block #0'
+            for anasig in seg.analogsignals:
+                assert anasig.name is not None
 
     def test_read_segment_with_time_slice(self):
         """
         Test loading of a time slice and check resulting times
         """
-        io = EDFIO(self.filename)
-        seg = io.read_segment(time_slice=None)
+        with EDFIO(self.filename) as io:
+            seg = io.read_segment(time_slice=None)
 
-        # data file does not contain spike, event or epoch timestamps
-        self.assertEqual(len(seg.spiketrains), 0)
-        self.assertEqual(len(seg.events), 1)
-        self.assertEqual(len(seg.events[0]), 0)
-        self.assertEqual(len(seg.epochs), 1)
-        self.assertEqual(len(seg.epochs[0]), 0)
-        for asig in seg.analogsignals:
-            self.assertEqual(asig.shape[0], 256)
-        n_channels = sum(a.shape[-1] for a in seg.analogsignals)
-        self.assertEqual(n_channels, 5)
+            # data file does not contain spike, event or epoch timestamps
+            self.assertEqual(len(seg.spiketrains), 0)
+            self.assertEqual(len(seg.events), 1)
+            self.assertEqual(len(seg.events[0]), 0)
+            self.assertEqual(len(seg.epochs), 1)
+            self.assertEqual(len(seg.epochs[0]), 0)
+            for asig in seg.analogsignals:
+                self.assertEqual(asig.shape[0], 256)
+            n_channels = sum(a.shape[-1] for a in seg.analogsignals)
+            self.assertEqual(n_channels, 5)
 
-        t_start, t_stop = 500 * pq.ms, 800 * pq.ms
-        seg = io.read_segment(time_slice=(t_start, t_stop))
+            t_start, t_stop = 500 * pq.ms, 800 * pq.ms
+            seg = io.read_segment(time_slice=(t_start, t_stop))
 
-        self.assertAlmostEqual(seg.t_start.rescale(t_start.units), t_start, delta=5.)
-        self.assertAlmostEqual(seg.t_stop.rescale(t_stop.units), t_stop, delta=5.)
+            self.assertAlmostEqual(seg.t_start.rescale(t_start.units), t_start, delta=5.)
+            self.assertAlmostEqual(seg.t_stop.rescale(t_stop.units), t_stop, delta=5.)
 
     def test_compare_data(self):
         """
         Compare data from AnalogSignal with plain data stored in text file
         """
-        io = EDFIO(self.filename)
-        plain_data = np.loadtxt(io.filename.replace('.edf', '.txt'), dtype=np.int16)
-        seg = io.read_segment(lazy=True)
+        with EDFIO(self.filename) as io:
+            plain_data = np.loadtxt(io.filename.replace('.edf', '.txt'), dtype=np.int16)
+            seg = io.read_segment(lazy=True)
 
-        anasigs = seg.analogsignals
-        self.assertEqual(len(anasigs), 5)  # all channels have different units, so expecting 5
-        for aidx, anasig in enumerate(anasigs):
-            # comparing raw data to original values
-            ana_data = anasig.load(magnitude_mode='raw')
-            np.testing.assert_array_equal(ana_data.magnitude, plain_data[:, aidx:aidx + 1])
+            anasigs = seg.analogsignals
+            self.assertEqual(len(anasigs), 5)  # all channels have different units, so expecting 5
+            for aidx, anasig in enumerate(anasigs):
+                # comparing raw data to original values
+                ana_data = anasig.load(magnitude_mode='raw')
+                np.testing.assert_array_equal(ana_data.magnitude, plain_data[:, aidx:aidx + 1])
 
-            # comparing floating data to original values * gain factor
-            ch_head = io.edf_reader.getSignalHeader(aidx)
-            physical_range = ch_head['physical_max'] - ch_head['physical_min']
-            # number of digital values used (+1 to account for '0' value)
-            digital_range = ch_head['digital_max'] - ch_head['digital_min'] + 1
+                # comparing floating data to original values * gain factor
+                ch_head = io.edf_reader.getSignalHeader(aidx)
+                physical_range = ch_head['physical_max'] - ch_head['physical_min']
+                # number of digital values used (+1 to account for '0' value)
+                digital_range = ch_head['digital_max'] - ch_head['digital_min'] + 1
 
-            gain = physical_range / digital_range
-            ana_data = anasig.load(magnitude_mode='rescaled')
-            rescaled_data = plain_data[:, aidx:aidx + 1] * gain
-            np.testing.assert_array_equal(ana_data.magnitude, rescaled_data)
+                gain = physical_range / digital_range
+                ana_data = anasig.load(magnitude_mode='rescaled')
+                rescaled_data = plain_data[:, aidx:aidx + 1] * gain
+                np.testing.assert_array_equal(ana_data.magnitude, rescaled_data)
 
 
 if __name__ == "__main__":

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-cov
-datalad==0.14.8  # 0.15. is incompatible with default apt git-annex version
+# datalad   # this dependency is covered by conda (environment_testing.yml)
 scipy>=1.0.0
 pyedflib
 h5py


### PR DESCRIPTION
This should fix #1115, by installing more recent versions of datalad and git-annex.

Analogous to the current version, the conda environment is cached and only rebuild when one of the requirement files changes or a new month started. The execution time of the tests when everything is already cached is the same as before (~12 minutes).