### PR TITLE
import datatlad only when running download_dataset()

### DIFF
--- a/neo/utils/__init__.py
+++ b/neo/utils/__init__.py
@@ -5,5 +5,4 @@ Utils package
 from .misc import (get_events, get_epochs, add_epoch,
     match_events, cut_block_by_epochs, cut_segment_by_epoch,
     is_block_rawio_compatible)
-from .datasets import (download_dataset,
-    get_local_testing_data_folder, HAVE_DATALAD)
+from .datasets import download_dataset, get_local_testing_data_folder

--- a/neo/utils/datasets.py
+++ b/neo/utils/datasets.py
@@ -4,14 +4,6 @@ Utility functions to retrieve public datasets.
 import os
 from pathlib import Path
 
-try:
-    import datalad.api
-    from datalad.support.gitrepo import GitRepo
-
-    HAVE_DATALAD = True
-except:
-    HAVE_DATALAD = False
-
 default_testing_repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
 
 global local_testing_data_folder
@@ -59,7 +51,8 @@ def download_dataset(repo=default_testing_repo, remote_path=None,
     local_path:
         The local path of the downloaded file or folder
     """
-    assert HAVE_DATALAD, 'You need to install datalad'
+    import datalad.api
+    from datalad.support.gitrepo import GitRepo
 
     if local_folder is None:
         global local_testing_data_folder


### PR DESCRIPTION
This remove the systematic import od datalad which can be annoying in notebook for some version because it trigger lot of errors.
datalad will be now imported on demand only.