### PR TITLE
Update CI matrix for core tests

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -19,13 +19,14 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        # "macos-latest", 
-        python-version: ['3.7', '3.8', '3.9']
-        numpy-version: ['1.16.6', '1.17.5', '1.18.5', '1.19.5', '1.20.3', '1.21.5', '1.22.3']
+        # "macos-latest",
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        numpy-version: ['1.18.5', '1.19.5', '1.20.3', '1.21.6', '1.22.4', '1.23.0']
         exclude:
            - python-version: '3.7'
-             numpy-version: '1.22.3'
-
+             numpy-version: '1.22.4'
+           - python-version: '3.7'
+             numpy-version: '1.23.0'
     steps:
         - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v2

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # "macos-latest",
@@ -31,6 +31,8 @@ jobs:
              numpy-version: '1.18.5'
            - python-version: '3.10'
              numpy-version: '1.19.5'
+           - python-version: '3.10'
+             numpy-version: '1.20.3'
     steps:
         - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v2

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # "macos-latest",

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -27,6 +27,10 @@ jobs:
              numpy-version: '1.22.4'
            - python-version: '3.7'
              numpy-version: '1.23.0'
+           - python-version: '3.10'
+             numpy-version: '1.18.5'
+           - python-version: '3.10'
+             numpy-version: '1.19.5'
     steps:
         - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v2

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -12,7 +12,7 @@ Dependencies
 ------------
 
     * Python_ >= 3.7
-    * numpy_ >= 1.16.1
+    * numpy_ >= 1.18.5
     * quantities_ >= 0.12.1
 
 You can install the latest published version of Neo and its dependencies using::

--- a/neo/test/tools.py
+++ b/neo/test/tools.py
@@ -189,6 +189,8 @@ def assert_same_sub_schema(ob1, ob2, equal_almost=True, threshold=1e-10, exclude
                  the comparison
 
     '''
+    if isinstance(ob1, SpikeTrainList) and isinstance(ob2, list):  # for debugging occasional test failure
+        raise Exception("items={}\nspike_time_array={}\nlist length: {}".format(str(ob1._items), str(ob1._spike_time_array), len(ob2)))
     assert type(ob1) == type(ob2), 'type({}) != type({})'.format(type(ob1), type(ob2))
     classname = ob1.__class__.__name__
 

--- a/neo/test/tools.py
+++ b/neo/test/tools.py
@@ -189,8 +189,10 @@ def assert_same_sub_schema(ob1, ob2, equal_almost=True, threshold=1e-10, exclude
                  the comparison
 
     '''
-    if isinstance(ob1, SpikeTrainList) and isinstance(ob2, list):  # for debugging occasional test failure
-        raise Exception("items={}\nspike_time_array={}\nlist length: {}".format(str(ob1._items), str(ob1._spike_time_array), len(ob2)))
+    if isinstance(ob1, SpikeTrainList) and isinstance(ob2, list):
+        # for debugging occasional test failure
+        raise Exception("items={}\nspike_time_array={}\nlist length: {}".format(
+            str(ob1._items), str(ob1._spike_time_array), len(ob2)))
     assert type(ob1) == type(ob2), 'type({}) != type({})'.format(type(ob1), type(ob2))
     classname = ob1.__class__.__name__
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import os
 
 long_description = open("README.rst").read()
-install_requires = ['numpy>=1.16.1',
+install_requires = ['numpy>=1.18.5',
                     'quantities>=0.12.1']
 extras_require = {
     'igorproio': ['igor'],
@@ -46,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Scientific/Engineering']
 )


### PR DESCRIPTION
following the [NEP](https://numpy.org/neps/nep-0029-deprecation_policy.html)+1 policy (upcoming July 26th change)