### PR TITLE
[DOC] - Update readme test badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,8 @@ A project with similar aims but for neuroimaging file formats is `NiBabel`_.
 Code status
 -----------
 
-.. image:: https://travis-ci.org/NeuralEnsemble/python-neo.png?branch=master
-   :target: https://travis-ci.org/NeuralEnsemble/python-neo
-   :alt: Core Unit Test Status (TravisCI)
-.. image:: https://github.com/NeuralEnsemble/python-neo/actions/workflows/full-test.yml/badge.svg?event=push&branch=master
-   :target: https://github.com/NeuralEnsemble/python-neo/actions?query=event%3Apush+branch%3Amaster
+.. image:: https://github.com/NeuralEnsemble/python-neo/actions/workflows/core-test.yml/badge.svg
+   :target: https://github.com/NeuralEnsemble/python-neo/actions?query=event
    :alt: IO Unit Test Status (Github Actions)
 .. image:: https://coveralls.io/repos/NeuralEnsemble/python-neo/badge.png
    :target: https://coveralls.io/r/NeuralEnsemble/python-neo


### PR DESCRIPTION
On the current version of the README, the badges for the tests seem to be a bit outdated - one points to a dead link (outdated?) on Travis, and the Github actions link doesn't seem to render properly. This PR fixes those. 

I linked the Github Actions to the `core-test`, though it could also / instead link to the `io-test` (?).

I _think_ the badge & link to coverage is also outdated, though I'm unclear on if there is a new coverage tracker to redirect to?