### PR TITLE
[DOC] - Small fixes to documentation

### DIFF
--- a/doc/source/core.rst
+++ b/doc/source/core.rst
@@ -31,7 +31,7 @@ Container objects
 
 There is a simple hierarchy of containers:
 
-  * :py:class:`Segment`: A container for heterogeneous discrete or continous data sharing a common
+  * :py:class:`Segment`: A container for heterogeneous discrete or continuous data sharing a common
     clock (time basis) but not necessarily the same sampling rate, start time or end time.
     A :py:class:`Segment` can be considered as equivalent to a "trial", "episode", "run",
     "recording", etc., depending on the experimental context.
@@ -165,7 +165,7 @@ the channels on which that neuron spiked::
     # ...
 
 
-Now each putative neuron is represented by a :class:`Group` containing the spiktrains of that neuron
+Now each putative neuron is represented by a :class:`Group` containing the spiketrains of that neuron
 and a view of the signal selecting only those channels from which the spikes were obtained.
 
 

--- a/doc/source/developers_guide.rst
+++ b/doc/source/developers_guide.rst
@@ -38,7 +38,7 @@ a GitHub account and then set to watch the repository at `GitHub Repository`_
 Requirements
 ------------
 
-    * Python_ 3.5 or later
+    * Python_ 3.7 or later
     * numpy_ >= 1.11.0
     * quantities_ >= 0.12.1
     * nose_ >= 1.1.2 (for running tests)
@@ -193,7 +193,7 @@ open a pull request on GitHub
 Python version
 --------------
 
-Neo should work with Python 3.5 or newer. If you need support for Python 2.7,
+Neo should work with Python 3.7 or newer. If you need support for Python 2.7,
 use Neo v0.8.0 or earlier.
 
 
@@ -201,7 +201,7 @@ Coding standards and style
 --------------------------
 
 All code should conform as much as possible to `PEP 8`_, and should run with
-Python 3.5 or newer.
+Python 3.7 or newer.
 
 You can use the `pep8`_ program to check the code for PEP 8 conformity.
 You can also use `flake8`_, which combines pep8 and pyflakes.

--- a/doc/source/grouping.rst
+++ b/doc/source/grouping.rst
@@ -149,5 +149,5 @@ Using :class:`ChannelView` and :class:`Group`::
     block.groups.extend(units)
 
 
-Now each putative neuron is represented by a :class:`Group` containing the spiktrains of that neuron
+Now each putative neuron is represented by a :class:`Group` containing the spiketrains of that neuron
 and a view of the signal selecting only those channels from which the spikes were obtained.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,7 +11,7 @@ writing to a subset of these formats plus non-proprietary formats including Kwik
 The goal of Neo is to improve interoperability between Python tools for
 analyzing, visualizing and generating electrophysiology data, by providing a common,
 shared object model. In order to be as lightweight a dependency as possible,
-Neo is deliberately limited to represention of data, with no functions for data
+Neo is deliberately limited to representation of data, with no functions for data
 analysis or visualization.
 
 Neo is used by a number of other software tools, including
@@ -53,7 +53,7 @@ Documentation
 License
 -------
 
-Neo is free software, distributed under a 3-clause Revised BSD licence (BSD-3-Clause).
+Neo is free software, distributed under a 3-clause Revised BSD license (BSD-3-Clause).
 
 
 Support

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -63,7 +63,7 @@ An IO module can be based on a single file, a directory containing files, or a d
 This is described in the :attr:`mode` attribute of the IO class.
 
     >>> from neo.io import MyFormatIO
-    >>> print MyFormatIO.mode
+    >>> print(MyFormatIO.mode)
     'file'
 
 
@@ -105,7 +105,7 @@ The first element of the previous list is the highest level for reading the file
 All IOs have a read() method that returns a list of :class:`Block` objects (representing the whole content of the file)::
 
     >>> bl = reader.read()
-    >>> print bl[0].segments[0]
+    >>> print(bl[0].segments[0])
     neo.core.Segment
 
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -25,13 +25,13 @@ to a more standard format when you want to share/collaborate.
 Introduction
 ============
 
-There is an intrinsic structure in the different Neo objects, that could be seen as a hierachy with cross-links. See :doc:`core`.
+There is an intrinsic structure in the different Neo objects, that could be seen as a hierarchy with cross-links. See :doc:`core`.
 The highest level object is the :class:`Block` object, which is the high level container able to encapsulate all the others.
 
 A :class:`Block` has therefore a list of :class:`Segment` objects, that can, in some file formats, be accessed individually.
 Depending on the file format, i.e. if it is streamable or not, the whole :class:`Block` may need to be loaded, but sometimes
 particular :class:`Segment` objects can be accessed individually.
-Within a :class:`Segment`, the same hierarchical organisation applies.
+Within a :class:`Segment`, the same hierarchical organization applies.
 A :class:`Segment` embeds several objects, such as :class:`SpikeTrain`,
 :class:`AnalogSignal`, :class:`IrregularlySampledSignal`, :class:`Epoch`, :class:`Event`
 (basically, all the different Neo objects).
@@ -114,7 +114,7 @@ Read a time slice of Segment
 
 Some objects support the ``time_slice`` argument in ``read_segment()``.
 This is useful to read only a subset of a dataset clipped in time.
-By default  ``time_slice=None`` meaning load eveything.
+By default  ``time_slice=None`` meaning load everything.
 
 This reads everything::
 
@@ -132,7 +132,7 @@ Lazy option and proxy objects
 
 In some cases you may not want to load everything in memory because it could be too big.
 For this scenario, some IOs implement ``lazy=True/False``.
-Since neo 0.7, a new lazy sytem have been added for some IO modules (all IO classes that inherit from rawio).
+Since neo 0.7, a new lazy system has been added for some IO modules (all IO classes that inherit from rawio).
 To know if a class supports lazy mode use ``ClassIO.support_lazy``.
 
 With ``lazy=True`` all data objects (AnalogSignal/SpikeTrain/Event/Epoch) are replaced by
@@ -197,7 +197,7 @@ The :mod:`neo.io` API is designed to be simple and intuitive:
     - each file format has an IO class (for example for Spike2 files you have a :class:`Spike2IO` class).
     - each IO class inherits from the :class:`BaseIO` class.
     - each IO class can read or write directly one or several Neo objects (for example :class:`Segment`, :class:`Block`, ...): see the :attr:`readable_objects` and :attr:`writable_objects` attributes of the IO class.
-    - each IO class supports part of the :mod:`neo.core` hierachy, though not necessarily all of it (see :attr:`supported_objects`).
+    - each IO class supports part of the :mod:`neo.core` hierarchy, though not necessarily all of it (see :attr:`supported_objects`).
     - each IO class has a :meth:`read()` method that returns a list of :class:`Block` objects. If the IO only supports :class:`Segment` reading, the list will contain one block with all segments from the file.
     - each IO class that supports writing has a :meth:`write()` method that takes as a parameter a list of blocks, a single block or a single segment, depending on the IO's :attr:`writable_objects`.
     - some IO are able to do a *lazy* load: all metadata (e.g. :attr:`sampling_rate`) are read, but not the actual numerical data.

--- a/doc/source/io_developers_guide.rst
+++ b/doc/source/io_developers_guide.rst
@@ -38,7 +38,7 @@ Miscellaneous
 =============
 
     * If your IO supports several versions of a format (like ABF1, ABF2), upload to the gin.g-node.org test file repository all file versions possible. (for test coverage).
-    * :py:func:`neo.core.Block.create_many_to_one_relationship` offers a utility to complete the hierachy when all one-to-many relationships have been created.
+    * :py:func:`neo.core.Block.create_many_to_one_relationship` offers a utility to complete the hierarchy when all one-to-many relationships have been created.
     * In the docstring, explain where you obtained the file format specification if it is a closed one.
     * If your IO is based on a database mapper, keep in mind that the returned object MUST be detached,
       because this object can be written to another url for copying.
@@ -51,7 +51,7 @@ Tests
 To use these you need to upload some sample data files at `gin-gnode`_. They will be publicly accessible for testing Neo.
 These tests:
 
-  * check the compliance with the schema: hierachy, attribute types, ...
+  * check the compliance with the schema: hierarchy, attribute types, ...
   * For IO modules able to both write and read data, it compares a generated dataset with the same data after a write/read cycle.
 
 The test scripts download all files from `gin-gnode`_ and stores them locally in ``/tmp/files_for_tests/``.

--- a/doc/source/rawio.rst
+++ b/doc/source/rawio.rst
@@ -34,7 +34,7 @@ also available in :mod:`neo.io`.
 
 Possible uses of the :mod:`neo.rawio` API are:
     * fast reading chunks of signals in int16 and do the scaling of units (uV)
-      on a GPU while scaling the zoom. This should improve bandwith HD to RAM
+      on a GPU while scaling the zoom. This should improve bandwidth HD to RAM
       and RAM to GPU memory.
     * load only some small chunk of data for heavy computations. For instance
       the spike sorting module tridesclous_ does this.
@@ -42,7 +42,7 @@ Possible uses of the :mod:`neo.rawio` API are:
 
 The :mod:`neo.rawio` API is less flexible than :mod:`neo.io` and has some limitations:
   * read-only
-  * AnalogSignals must have the same characteristcs across all Blocks and Segments:
+  * AnalogSignals must have the same characteristics across all Blocks and Segments:
     ``sampling_rate``, ``shape[1]``, ``dtype``
   * AnalogSignals should all have the same value of ``sampling_rate``, otherwise they won't be read
     at the same time.

--- a/doc/source/usecases.rst
+++ b/doc/source/usecases.rst
@@ -190,7 +190,7 @@ how you could iterate over the contained signals and extract spike times.
     # extract spike trains from all channels
     st_list = []
     for signal in seg.analogsignals:
-        # use a simple threshhold detector
+        # use a simple threshold detector
         spike_mask = np.where(np.min(signal.magnitude, axis=1) < -1.0)[0]
 
         # create a spike train

--- a/doc/source/whatisnew.rst
+++ b/doc/source/whatisnew.rst
@@ -68,7 +68,7 @@ Version 0.3.0
 
   * various bug fixes in neo.io
   * added ElphyIO
-  * SpikeTrain performence improved
+  * SpikeTrain performance improved
   * An IO class now can return a list of Block (see read_all_blocks in IOs)
   * python3 compatibility improved
 
@@ -96,7 +96,7 @@ New features compared to neo 0.1:
  * Neuron is now Unit
  * use the quantities_ module for everything that can have units.
  * Some objects directly inherit from Quantity: SpikeTrain, AnalogSignal, AnalogSignalArray, instead of having an attribute for data.
- * Attributes are classifyed in 3 categories: necessary, recommended, free.
+ * Attributes are classified in 3 categories: necessary, recommended, free.
  * lazy and cascade keywords are added to all IOs
  * Python 3 support
  * better tests


### PR DESCRIPTION
This is a quick sweep of the documentation for some quick fixes:
- fixes some examples that showed python2 style print
- update the minimum python version listed in the developers guide that lagged behind current requirement
- fix typos in the doc pages