### PR TITLE
[DOC] - Maintenance of in-code comments and docstrings

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -2,7 +2,7 @@
 This module implements :class:`AnalogSignal`, an array of analog signals.
 
 :class:`AnalogSignal` inherits from :class:`basesignal.BaseSignal` which
-derives from :class:`BaseNeo`, and from :class:`quantites.Quantity`which
+derives from :class:`BaseNeo`, and from :class:`quantities.Quantity`which
 in turn inherits from :class:`numpy.array`.
 
 Inheritance from :class:`numpy.array` is explained here:

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -481,13 +481,13 @@ class AnalogSignal(BaseSignal):
         """
         Shifts a :class:`AnalogSignal` to start at a new time.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         t_shift: Quantity (time)
             Amount of time by which to shift the :class:`AnalogSignal`.
 
-        Returns:
-        --------
+        Returns
+        -------
         new_sig: :class:`AnalogSignal`
             New instance of a :class:`AnalogSignal` object starting at t_shift later than the
             original :class:`AnalogSignal` (the original :class:`AnalogSignal` is not modified).
@@ -538,19 +538,19 @@ class AnalogSignal(BaseSignal):
         arguments, except for specifying the axis of resampling, which is fixed to the first axis
         here.
 
-        Parameters:
-        -----------
-        downsampling_factor: integer
+        Parameters
+        ----------
+        downsampling_factor: int
             Factor used for decimation of samples. Scipy recommends to call decimate multiple times
             for downsampling factors higher than 13 when using IIR downsampling (default).
 
-        Returns:
-        --------
+        Returns
+        -------
         downsampled_signal: :class:`AnalogSignal`
             New instance of a :class:`AnalogSignal` object containing the resampled data points.
             The original :class:`AnalogSignal` is not modified.
 
-        Note:
+        Notes
         -----
         For resampling the signal with a fixed number of samples, see `resample` method.
         """
@@ -581,19 +581,19 @@ class AnalogSignal(BaseSignal):
         arguments, except for specifying the axis of resampling which is fixed to the first axis
         here, and the sample positions. .
 
-        Parameters:
-        -----------
-        sample_count: integer
+        Parameters
+        ----------
+        sample_count: int
             Number of desired samples. The resulting signal starts at the same sample as the
             original and is sampled regularly.
 
-        Returns:
-        --------
+        Returns
+        -------
         resampled_signal: :class:`AnalogSignal`
             New instance of a :class:`AnalogSignal` object containing the resampled data points.
             The original :class:`AnalogSignal` is not modified.
 
-        Note:
+        Notes
         -----
         For reducing the number of samples to a fraction of the original, see `downsample` method
         """
@@ -625,8 +625,8 @@ class AnalogSignal(BaseSignal):
         This method is a wrapper of numpy.absolute() and accepts the same set of keyword
         arguments.
 
-        Returns:
-        --------
+        Returns
+        -------
         resampled_signal: :class:`AnalogSignal`
             New instance of a :class:`AnalogSignal` object containing the rectified data points.
             The original :class:`AnalogSignal` is not modified.

--- a/neo/core/basesignal.py
+++ b/neo/core/basesignal.py
@@ -311,4 +311,4 @@ class BaseSignal(DataObject):
             If `other` object has incompatible attributes.
         '''
 
-        NotImplementedError('Patching need to be implemented in sublcasses')
+        NotImplementedError('Patching need to be implemented in subclasses')

--- a/neo/core/block.py
+++ b/neo/core/block.py
@@ -1,6 +1,6 @@
 '''
 This module defines :class:`Block`, the main container gathering all the data,
-whether discrete or continous, for a given recording session. base class
+whether discrete or continuous, for a given recording session. base class
 used by all :module:`neo.core` classes.
 
 :class:`Block` derives from :class:`Container`,
@@ -14,7 +14,7 @@ from neo.core.container import Container, unique_objs
 
 class Block(Container):
     '''
-    Main container gathering all the data, whether discrete or continous, for a
+    Main container gathering all the data, whether discrete or continuous, for a
     given recording session.
 
     A block is not necessarily temporally homogeneous, in contrast to :class:`Segment`.
@@ -78,7 +78,7 @@ class Block(Container):
                  file_datetime=None, rec_datetime=None, index=None,
                  **annotations):
         '''
-        Initalize a new :class:`Block` instance.
+        Initialize a new :class:`Block` instance.
         '''
         super().__init__(name=name, description=description,
                                     file_origin=file_origin, **annotations)

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -228,7 +228,7 @@ class Container(BaseNeo):
     def __init__(self, name=None, description=None, file_origin=None,
                  **annotations):
         """
-        Initalize a new :class:`Container` instance.
+        Initialize a new :class:`Container` instance.
         """
         super().__init__(name=name, description=description,
                          file_origin=file_origin, **annotations)
@@ -466,7 +466,7 @@ class Container(BaseNeo):
         that this method will link up.
 
         If force is True overwrite any existing relationships
-        If recursive is True desecend into child objects and create
+        If recursive is True descend into child objects and create
         relationships there
         """
         parent_name = _reference_name(self.__class__.__name__)
@@ -485,7 +485,7 @@ class Container(BaseNeo):
         of this type, put the current object in the parent list.
 
         If append is True add it to the list, otherwise overwrite the list.
-        If recursive is True desecend into child objects and create
+        If recursive is True descend into child objects and create
         relationships there
         """
         parent_name = _container_name(self.__class__.__name__)
@@ -517,7 +517,7 @@ class Container(BaseNeo):
 
         If force is True overwrite any existing relationships
         If append is True add it to the list, otherwise overwrite the list.
-        If recursive is True desecend into child objects and create
+        If recursive is True descend into child objects and create
         relationships there
         """
         self.create_many_to_one_relationship(force=force, recursive=False)

--- a/neo/core/dataobject.py
+++ b/neo/core/dataobject.py
@@ -18,16 +18,22 @@ def _normalize_array_annotations(value, length):
     Recursively check that value is either an array or list containing only "simple" types
     (number, string, date/time) or is a dict of those.
 
-    Args:
-        :value: (np.ndarray, list or dict) value to be checked for consistency
-        :length: (int) required length of the array annotation
+    Parameters
+    ----------
+    value : np.ndarray or list or dict
+        Value to be checked for consistency.
+    length : int
+        Required length of the array annotation.
 
-    Returns:
-        np.ndarray The array_annotations from value in correct form
+    Returns
+    -------
+    np.ndarray
+        The array_annotations from value in correct form
 
-    Raises:
-        ValueError: In case value is not accepted as array_annotation(s)
-
+    Raises
+    ------
+    ValueError
+        In case value is not accepted as array_annotation(s)
     """
 
     # First stage, resolve dict of annotations into single annotations

--- a/neo/core/dataobject.py
+++ b/neo/core/dataobject.py
@@ -124,7 +124,7 @@ def _normalize_array_annotations(value, length):
 
             # Check the first element for correctness
             # If its type is correct for annotations, all others are correct as well
-            # Note: Emtpy lists cannot reach this point
+            # Note: Empty lists cannot reach this point
             _check_single_elem(value[0])
 
     return value

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -318,13 +318,13 @@ class Epoch(DataObject):
         """
         Shifts an :class:`Epoch` by an amount of time.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         t_shift: Quantity (time)
             Amount of time by which to shift the :class:`Epoch`.
 
-        Returns:
-        --------
+        Returns
+        -------
         epoch: :class:`Epoch`
             New instance of an :class:`Epoch` object starting at t_shift later than the
             original :class:`Epoch` (the original :class:`Epoch` is not modified).

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -287,13 +287,13 @@ class Event(DataObject):
         """
         Shifts an :class:`Event` by an amount of time.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         t_shift: Quantity (time)
             Amount of time by which to shift the :class:`Event`.
 
-        Returns:
-        --------
+        Returns
+        -------
         epoch: Event
             New instance of an :class:`Event` object starting at t_shift later than the
             original :class:`Event` (the original :class:`Event` is not modified).

--- a/neo/core/imagesequence.py
+++ b/neo/core/imagesequence.py
@@ -2,7 +2,7 @@
 This module implements :class:`ImageSequence`, a 3D array.
 
 :class:`ImageSequence` inherits from :class:`basesignal.BaseSignal` which
-derives from :class:`BaseNeo`, and from :class:`quantites.Quantity`which
+derives from :class:`BaseNeo`, and from :class:`quantities.Quantity`which
 in turn inherits from :class:`numpy.array`.
 
 Inheritance from :class:`numpy.array` is explained here:

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -356,14 +356,14 @@ class IrregularlySampledSignal(BaseSignal):
         arguments, except for specifying the axis of resampling which is fixed to the first axis
         here, and the sample positions. .
 
-        Parameters:
-        -----------
-        sample_count: integer
+        Parameters
+        ----------
+        sample_count: int
             Number of desired samples. The resulting signal starts at the same sample as the
             original and is sampled regularly.
 
-        Returns:
-        --------
+        Returns
+        -------
         resampled_signal: :class:`AnalogSignal`
             New instance of a :class:`AnalogSignal` object containing the resampled data points.
             The original :class:`AnalogSignal` is not modified.
@@ -431,13 +431,13 @@ class IrregularlySampledSignal(BaseSignal):
         """
         Shifts a :class:`IrregularlySampledSignal` to start at a new time.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         t_shift: Quantity (time)
             Amount of time by which to shift the :class:`IrregularlySampledSignal`.
 
-        Returns:
-        --------
+        Returns
+        -------
         new_sig: :class:`SpikeTrain`
             New instance of a :class:`IrregularlySampledSignal` object
             starting at t_shift later than the original :class:`IrregularlySampledSignal`

--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -145,25 +145,22 @@ class Segment(Container):
         Creates a time slice of a Segment containing slices of all child
         objects.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         t_start: Quantity
             Starting time of the sliced time window.
         t_stop: Quantity
             Stop time of the sliced time window.
-        reset_time: bool
+        reset_time: bool, optional, default: False
             If True the time stamps of all sliced objects are set to fall
             in the range from t_start to t_stop.
             If False, original time stamps are retained.
-            Default is False.
-
-        Keyword Arguments:
-        ------------------
+        **kwargs
             Additional keyword arguments used for initialization of the sliced
             Segment object.
 
-        Returns:
-        --------
+        Returns
+        -------
         subseg: Segment
             Temporal slice of the original Segment from t_start to t_stop.
         """

--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -20,7 +20,7 @@ class Segment(Container):
     '''
     A container for data sharing a common time basis.
 
-    A :class:`Segment` is a heterogeneous container for discrete or continous
+    A :class:`Segment` is a heterogeneous container for discrete or continuous
     data sharing a common clock (time basis) but not necessary the same
     sampling rate, start or end time.
 

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -640,13 +640,13 @@ class SpikeTrain(DataObject):
         """
         Shifts a :class:`SpikeTrain` to start at a new time.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         t_shift: Quantity (time)
             Amount of time by which to shift the :class:`SpikeTrain`.
 
-        Returns:
-        --------
+        Returns
+        -------
         spiketrain: :class:`SpikeTrain`
             New instance of a :class:`SpikeTrain` object starting at t_shift later than the
             original :class:`SpikeTrain` (the original :class:`SpikeTrain` is not modified).

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -2,7 +2,7 @@
 This module implements :class:`SpikeTrain`, an array of spike times.
 
 :class:`SpikeTrain` derives from :class:`BaseNeo`, from
-:module:`neo.core.baseneo`, and from :class:`quantites.Quantity`, which
+:module:`neo.core.baseneo`, and from :class:`quantities.Quantity`, which
 inherits from :class:`numpy.array`.
 
 Inheritance from :class:`numpy.array` is explained here:
@@ -261,13 +261,13 @@ class SpikeTrain(DataObject):
                 t_start=0.0 * pq.s, waveforms=None, left_sweep=None, name=None, file_origin=None,
                 description=None, array_annotations=None, **annotations):
         '''
-        Constructs a new :clas:`Spiketrain` instance from data.
+        Constructs a new :class:`Spiketrain` instance from data.
 
         This is called whenever a new :class:`SpikeTrain` is created from the
         constructor, but not when slicing.
         '''
         if len(times) != 0 and waveforms is not None and len(times) != waveforms.shape[0]:
-            # len(times)!=0 has been used to workaround a bug occuring during neo import
+            # len(times)!=0 has been used to workaround a bug occurring during neo import
             raise ValueError("the number of waveforms should be equal to the number of spikes")
 
         if dtype is not None and hasattr(times, 'dtype') and times.dtype != dtype:
@@ -382,7 +382,7 @@ class SpikeTrain(DataObject):
         constructor, and these are set in __new__. Then they are just
         copied over here.
 
-        Note that the :attr:`waveforms` attibute is not sliced here. Nor is
+        Note that the :attr:`waveforms` attribute is not sliced here. Nor is
         :attr:`t_start` or :attr:`t_stop` modified.
         '''
         # This calls Quantity.__array_finalize__ which deals with

--- a/neo/io/axonio.py
+++ b/neo/io/axonio.py
@@ -28,9 +28,9 @@ class AxonIO(AxonRawIO, BaseFromRaw):
      - `AxonIO._sampling_rate`
 
     The current AxonIO.read_protocol() method utilizes a subset of these.
-    In particular I know it doesn't consider `nDigitalEnable`, `EpochInfo`, or `nActiveDACChannel` and it doesn't account 
+    In particular I know it doesn't consider `nDigitalEnable`, `EpochInfo`, or `nActiveDACChannel` and it doesn't account
     for different types of Epochs offered by Clampex/pClamp other than discrete steps (such as ramp, pulse train, etc and
-    encoded by `nEpochType` in the EpochInfoPerDAC section). I'm currently parsing a superset of the properties used 
+    encoded by `nEpochType` in the EpochInfoPerDAC section). I'm currently parsing a superset of the properties used
     by read_protocol() in my analysis scripts, but that code still doesn't parse the full information and isn't in a state
     where it could be committed and I can't currently prioritize putting together all the code that would parse the full
     set of data. The `AxonIO._axon_info['EpochInfo']` section doesn't currently exist.
@@ -47,8 +47,11 @@ class AxonIO(AxonRawIO, BaseFromRaw):
         Read the protocol waveform of the file, if present;
         function works with ABF2 only. Protocols can be reconstructed
         from the ABF1 header.
-        Returns: list of segments (one for every episode)
-                 with list of analog signls (one for every DAC).
+
+        Returns
+        -------
+        segments : list of segments
+            Segments, one for every episode, with list of analog signls (one for every DAC).
         """
         sigs_by_segments, sig_names, sig_units = self.read_raw_protocol()
         segments = []

--- a/neo/io/elphyio.py
+++ b/neo/io/elphyio.py
@@ -3811,8 +3811,10 @@ class ElphyIO(BaseIO):
         """
         Return :class:`Block`.
 
-        Parameters:
-             lazy : postpone actual reading of the file.
+        Parameters
+        ----------
+        lazy : bool
+            Postpone actual reading of the file.
         """
         assert not lazy, 'Do not support lazy'
 
@@ -4211,9 +4213,11 @@ class ElphyIO(BaseIO):
     def read_segment(self, episode):
         """
         Internal method used to return :class:`Segment` data to the main read method.
-        Parameters:
-            elphy_file : is the elphy object.
-            episode : number of elphy episode, roughly corresponding to a segment
+
+        Parameters
+        ----------
+        episode : int
+            Number of elphy episode, roughly corresponding to a segment
         """
         # print "name:",self.elphy_file.layout.get_episode_name(episode)
         episode_name = self.elphy_file.layout.get_episode_name(episode)
@@ -4254,10 +4258,12 @@ class ElphyIO(BaseIO):
         Internal method used to return a list of elphy :class:`EventArray` acquired from event
         channels.
 
-        Parameters:
-            elphy_file : is the elphy object.
-            episode : number of elphy episode, roughly corresponding to a segment.
-            evt : index of the event.
+        Parameters
+        ----------
+        episode : int
+            Number of elphy episode, roughly corresponding to a segment.
+        evt : int
+            Index of the event.
         """
         event = self.elphy_file.get_event(episode, evt)
         neo_event = Event(
@@ -4270,10 +4276,12 @@ class ElphyIO(BaseIO):
         """
         Internal method used to return an elphy object :class:`SpikeTrain`.
 
-        Parameters:
-            elphy_file : is the elphy object.
-            episode : number of elphy episode, roughly corresponding to a segment.
-            spk : index of the spike array.
+        Parameters
+        ----------
+        episode : int
+            Number of elphy episode, roughly corresponding to a segment.
+        spk : int
+            Index of the spike array.
         """
         block = self.elphy_file.layout.episode_block(episode)
         spike = self.elphy_file.get_spiketrain(episode, spk)

--- a/neo/io/igorproio.py
+++ b/neo/io/igorproio.py
@@ -173,15 +173,21 @@ def key_value_string_parser(itemsep=";", kvsep=":"):
     """
     Parses a string into a dict.
 
-    Arguments:
-        itemsep - character which separates items
-        kvsep - character which separates the key and value within an item
+    Parameters
+    ----------
+    itemsep : str
+        Character which separates items
+    kvsep : str
+        Character which separates the key and value within an item
 
-    Returns:
+    Returns
+    -------
+    callable
         a function which takes the string to be parsed as the sole argument
         and returns a dict.
 
-    Example:
+    Examples
+    --------
 
         >>> parse = key_value_string_parser(itemsep=";", kvsep=":")
         >>> parse("a:2;b:3")

--- a/neo/io/kwikio.py
+++ b/neo/io/kwikio.py
@@ -95,7 +95,8 @@ class KwikIO(BaseIO):
         """
         Reads a block with segments and groups
 
-        Parameters:
+        Parameters
+        ----------
         get_waveforms: bool, default = False
             Wether or not to get the waveforms
         get_raw_data: bool, default = False
@@ -152,7 +153,8 @@ class KwikIO(BaseIO):
         """
         Reads analogsignals
 
-        Parameters:
+        Parameters
+        ----------
         units: str, default = "uV"
             SI units of the raw trace according to voltage_gain given to klusta
         """
@@ -172,7 +174,8 @@ class KwikIO(BaseIO):
         """
         Reads sorted spiketrains
 
-        Parameters:
+        Parameters
+        ----------
         get_waveforms: bool, default = False
             Wether or not to get the waveforms
         cluster_id: int,

--- a/neo/io/neuroshareapiio.py
+++ b/neo/io/neuroshareapiio.py
@@ -181,11 +181,14 @@ class NeuroshareapiIO(BaseIO):
         Return a Segment containing all analog and spike channels, as well as
         all trigger events.
 
-        Parameters:
-            segment_duration :is the size in secend of the segment.
-            num_analogsignal : number of AnalogSignal in this segment
-            num_spiketrain : number of SpikeTrain in this segment
-
+        Parameters
+        ----------
+        segment_duration : float
+            The size in seconds of the segment.
+        num_analogsignal : int
+            Number of AnalogSignal in this segment.
+        num_spiketrain : int
+            Number of SpikeTrain in this segment.
         """
         assert not lazy, 'Do not support lazy'
 

--- a/neo/rawio/alphaomegarawio.py
+++ b/neo/rawio/alphaomegarawio.py
@@ -102,7 +102,7 @@ class AlphaOmegaRawIO(BaseRawIO):
 
     def _explore_folder(self):
         """
-        If class was instanciated with lsx_files (list of .lsx files), load only
+        If class was instantiated with lsx_files (list of .lsx files), load only
         the files referenced in these lsx files otherwise, load all *.mpx files
         in `dirname`.
         It does not explores the subfolders.
@@ -114,7 +114,7 @@ class AlphaOmegaRawIO(BaseRawIO):
                 with open(index_file, "r") as f:
                     for line in f:
                         # a line is a Microsoft Windows path. As we cannot
-                        # instanciate a WindowsPath on other OS than MS
+                        # instantiate a WindowsPath on other OS than MS
                         # Windows, we use the PureWindowsPath class
                         filename = PureWindowsPath(line.strip())
                         filename = self.dirname / filename.name
@@ -145,7 +145,7 @@ class AlphaOmegaRawIO(BaseRawIO):
         :param prune_channels: Remove references to channels and ports which
             doesn't contain any data recorded. Be careful when using this option
             with multiple-file data since it could theoretically leads to
-            expection raised when data recorded in further files are merged into
+            exception raised when data recorded in further files are merged into
             the first file pruned from these channels.
         :type prune_channels: bool
         """
@@ -1127,7 +1127,7 @@ Then if is_analog and is_input:
     - mode_spike (2 bytes): read as hex data 0xMCCC:
         - M: 1=Master, 2=Slave
         - CCC: linked channel
-        Be carefull here, the first byte cover MC and the second byte the last
+        Be careful here, the first byte cover MC and the second byte the last
         part of the linked channel CC
 """
 SDefContinAnalog = struct.Struct("<fh")

--- a/neo/rawio/axographrawio.py
+++ b/neo/rawio/axographrawio.py
@@ -66,7 +66,7 @@ Acquisition modes:
     data appears before the second column's. As an aside, because of this
     design choice AxoGraph cannot write data to disk as it is collected but
     must store it all in memory until data acquisition ends. This also affected
-    how file slicing was implmented for this RawIO: Instead of using a single
+    how file slicing was implemented for this RawIO: Instead of using a single
     memmap to address into a 2-dimensional block of data, AxographRawIO
     constructs multiple 1-dimensional memmaps, one for each column, each with
     its own offset.
@@ -127,7 +127,7 @@ Acquisition modes:
     Segments in Neo. Certain criteria have to be met, such as all groups
     containing equal numbers of traces and each group having homogeneous signal
     parameters. If trace grouping was modified by the user after data
-    acquisition, this may result in the file being interpretted as
+    acquisition, this may result in the file being interpreted as
     non-episodic. Older versions of the AxoGraph file format lack group headers
     entirely, so these files are never deemed safe to interpret as episodic,
     even if the column names follow a repeating sequence as described above.
@@ -397,7 +397,7 @@ class AxographRawIO(BaseRawIO):
 
     def _safe_to_treat_as_episodic(self):
         """
-        The purpose of this fuction is to determine if the file contains any
+        The purpose of this function is to determine if the file contains any
         irregularities in its grouping of traces such that it cannot be treated
         as episodic. Even "continuous" recordings can be treated as
         single-episode recordings and could be identified as safe by this
@@ -627,7 +627,7 @@ class AxographRawIO(BaseRawIO):
                 # COLUMN TYPE
 
                 # depending on the format version, data columns may have a type
-                # - prior to verion 3, column types did not exist and data was
+                # - prior to version 3, column types did not exist and data was
                 #   stored in a fixed pattern
                 # - beginning with version 3, several data types are available
                 #   as documented in AxoGraph_ReadWrite.h

--- a/neo/rawio/axonarawio.py
+++ b/neo/rawio/axonarawio.py
@@ -288,7 +288,7 @@ class AxonaRawIO(BaseRawIO):
         and three samples of 2 bytes each for 64 channels (384 bytes), which
         are jumbled up in a strange order. Each channel is remapped to a
         certain position (see get_channel_offset), and a channel's samples are
-        allcoated as follows (example for channel 7):
+        allocated as follows (example for channel 7):
 
         sample 1: 32b (head) + 2*38b (remappedID) and 2*38b + 1b (2nd byte)
         sample 2: 32b (head) + 128 (all chan. 1st entry) + 2*38b and ...

--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -305,8 +305,10 @@ class AxonRawIO(BaseRawIO):
         function works with ABF2 only. Protocols can be reconstructed
         from the ABF1 header.
 
-        Returns: list of segments (one for every episode)
-                 with list of analog signals (one for every DAC).
+        Returns
+        -------
+        segments : list of segments
+            Segments, one for every episode, with list of analog signls (one for every DAC).
 
         Author:  JS Nowacki
         """

--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -23,7 +23,7 @@ ABF1 (clampfit <=9) and ABF2 (clampfit >10)
 All possible mode are possible :
     - event-driven variable-length mode 1 -> return several Segments per Block
     - event-driven fixed-length mode 2 or 5 -> return several Segments
-    - gap free mode -> return one (or sevral) Segment in the Block
+    - gap free mode -> return one (or several) Segment in the Block
 
 Supported : Read
 
@@ -277,8 +277,8 @@ class AxonRawIO(BaseRawIO):
         return self._raw_ev_timestamps.size
 
     def _get_event_timestamps(self, block_index, seg_index, event_channel_index, t_start, t_stop):
-        # In ABF timstamps are not attached too any particular segment
-        # so each segmetn acees all event
+        # In ABF timestamps are not attached too any particular segment
+        # so each segment accesses all events
         timestamp = self._raw_ev_timestamps
         labels = self._ev_labels
         durations = None
@@ -306,7 +306,7 @@ class AxonRawIO(BaseRawIO):
         from the ABF1 header.
 
         Returns: list of segments (one for every episode)
-                 with list of analog signls (one for every DAC).
+                 with list of analog signals (one for every DAC).
 
         Author:  JS Nowacki
         """
@@ -447,9 +447,9 @@ def parse_axon_soup(filename):
             # hack for reading channels names and units
             # this section is not very detailed and so the code
             # not very robust. The idea is to remove the first
-            # part by find ing one of th fowoling KEY
-            # unfortunatly the later part contains a the file
-            # taht can contain by accident also one of theses keys...
+            # part by finding one of th following KEY
+            # unfortunately the later part contains a the file
+            # that can contain by accident also one of theses keys...
             f.seek(sections['StringsSection']['uBlockIndex'] * BLOCKSIZE)
             big_string = f.read(sections['StringsSection']['uBytes'])
             goodstart = -1

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -47,7 +47,7 @@ of the sections of the channels for a Block and Segment of a stream.
 So this handles **only** one simplified but very frequent case of dataset:
     * Only one channel set  for AnalogSignal stable along Segment
     * Only one channel set  for SpikeTrain stable along Segment
-    * AnalogSignal have all the same sampling_rate acroos all Segment
+    * AnalogSignal have all the same sampling_rate across all Segment
     * t_start/t_stop are the same for many object (SpikeTrain, Event) inside a Segment
 
 Signal channels are handled by group of "stream".
@@ -448,7 +448,7 @@ class BaseRawIO:
             # also check that channel_id is unique inside a stream
             channel_ids = signal_channels[mask]['id']
             assert np.unique(channel_ids).size == channel_ids.size, \
-                f'signal_channels dont have unique ids for stream {stream_index}'
+                f'signal_channels do not have unique ids for stream {stream_index}'
 
         self._several_channel_groups = signal_streams.size > 1
 
@@ -733,7 +733,7 @@ class BaseRawIO:
         d = dict(ressource_name=resource_name, mtime=os.path.getmtime(resource_name))
         hash = joblib.hash(d, hash_name='md5')
 
-        # name is constructed from the real_n,ame and the hash
+        # name is constructed from the resource_name and the hash
         name = '{}_{}'.format(os.path.basename(resource_name), hash)
         self.cache_filename = os.path.join(dirname, name)
 

--- a/neo/rawio/biocamrawio.py
+++ b/neo/rawio/biocamrawio.py
@@ -29,7 +29,7 @@ class BiocamRawIO(BaseRawIO):
         >>> r.parse_header()
         >>> print(r)
         >>> raw_chunk = r.get_analogsignal_chunk(block_index=0, seg_index=0,
-                                                 i_start=0, i_stop=1024,  
+                                                 i_start=0, i_stop=1024,
                                                  channel_names=channel_names)
         >>> float_chunk = r.rescale_signal_raw_to_float(raw_chunk, dtype='float64',
                                                         channel_indexes=[0, 3, 6])
@@ -119,7 +119,7 @@ class BiocamRawIO(BaseRawIO):
 
 
 def open_biocam_file_header(filename):
-    """Open a Biocam hdf5 file, read and return the recording info, pick te correct method to access raw data,
+    """Open a Biocam hdf5 file, read and return the recording info, pick the correct method to access raw data,
     and return this to the caller."""
     assert HAVE_H5PY, 'h5py is not installed'
 

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -106,7 +106,7 @@ class BlackrockRawIO(BaseRawIO):
             IDs of nsX file from which to load data, e.g., if set to
             5 only data from the ns5 file are loaded.
             If 'all', then all nsX will be loaded.
-            Contrary to previsous version of the IO  (<0.7), nsx_to_load
+            Contrary to previous version of the IO  (<0.7), nsx_to_load
             must be set at the init before parse_header().
 
     Examples:
@@ -371,7 +371,7 @@ class BlackrockRawIO(BaseRawIO):
                         units = chan['units']
                     sig_dtype = 'int16'
                     # max_analog_val/min_analog_val/max_digital_val/min_analog_val are int16!!!!!
-                    # dangarous situation so cast to float everyone
+                    # dangerous situation so cast to float everyone
                     if np.isnan(float(chan['min_analog_val'])):
                         gain = 1
                         offset = 0
@@ -387,7 +387,7 @@ class BlackrockRawIO(BaseRawIO):
             # check nb segment per nsx
             nb_segments_for_nsx = [len(self.nsx_datas[nsx_nb]) for nsx_nb in self.nsx_to_load]
             assert all(nb == nb_segments_for_nsx[0] for nb in nb_segments_for_nsx),\
-                   'Segment nb not consistanent across nsX files'
+                   'Segment nb not consistent across nsX files'
             self._nb_segment = nb_segments_for_nsx[0]
 
             self.__delete_empty_segments()
@@ -494,7 +494,7 @@ class BlackrockRawIO(BaseRawIO):
             seg_ann['description'] = "Segment containing data from t_start to t_stop"
             if seg_index == 0:
                 # if more than 1 segment means pause
-                # so datetime is valide only for seg_index=0
+                # so datetime is valid only for seg_index=0
                 seg_ann['rec_datetime'] = rec_datetime
 
             for c in range(signal_streams.size):
@@ -768,7 +768,7 @@ class BlackrockRawIO(BaseRawIO):
         # basic header (file_id: NEURALCD)
         dt0 = [
             ('file_id', 'S8'),
-            # label of sampling groun (e.g. "1kS/s" or "LFP Low")
+            # label of sampling group (e.g. "1kS/s" or "LFP Low")
             ('label', 'S16'),
             # number of 1/30000 seconds between data points
             # (e.g., if sampling rate "1 kS/s", period equals "30")
@@ -1119,7 +1119,7 @@ class BlackrockRawIO(BaseRawIO):
             reset_ev_ids = np.where(reset_ev_mask)[0]
 
             # consistency check for monotone increasing time stamps
-            # explicitely converting to int to allow for negative diff values
+            # explicitly converting to int to allow for negative diff values
             jump_ids = \
                 np.where(np.diff(np.asarray(raw_event_data['timestamp'], dtype=int)) < 0)[0] + 1
             overlap = np.in1d(jump_ids, reset_ev_ids)
@@ -1594,7 +1594,7 @@ class BlackrockRawIO(BaseRawIO):
         """
         Extracts the actual waveform dtype set for each channel.
         """
-        # Blackrock code giving the approiate dtype
+        # Blackrock code giving the appropriate dtype
         conv = {0: 'int8', 1: 'int8', 2: 'int16', 4: 'int32'}
 
         # get all electrode ids from nev ext header
@@ -1639,7 +1639,7 @@ class BlackrockRawIO(BaseRawIO):
 
     def __get_waveform_size_variant_a(self):
         """
-        Returns wavform sizes for all channels for file spec 2.1 and 2.2
+        Returns waveform sizes for all channels for file spec 2.1 and 2.2
         """
         wf_dtypes = self.__get_waveforms_dtype()
         nb_bytes_wf = self.__nev_basic_header['bytes_in_data_packets'] - 8
@@ -1652,7 +1652,7 @@ class BlackrockRawIO(BaseRawIO):
 
     def __get_waveform_size_variant_b(self):
         """
-        Returns wavform sizes for all channels for file spec 2.3
+        Returns waveform sizes for all channels for file spec 2.3
         """
         elids = self.__nev_ext_header[b'NEUEVWAV']['electrode_id']
         spike_widths = self.__nev_ext_header[b'NEUEVWAV']['spike_width']

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -198,7 +198,7 @@ class EDFRawIO(BaseRawIO):
             data.append(buffer)
 
         # downgrade to int16 as this is what is used in the edf file format
-        # use fortran (column major) order to be more efficient after transposal
+        # use fortran (column major) order to be more efficient after transposing
         data = np.asarray(data, dtype=np.int16, order='F')
 
         # use dimensions (time, channel)

--- a/neo/rawio/examplerawio.py
+++ b/neo/rawio/examplerawio.py
@@ -272,7 +272,7 @@ class ExampleRawIO(BaseRawIO):
         # limited with i_start/i_stop (can be None)
         # channel_indexes can be None (=all channel in the stream) or a list or numpy.array
         # This must return a numpy array 2D (even with one channel).
-        # This must return the orignal dtype. No conversion here.
+        # This must return the original dtype. No conversion here.
         # This must as fast as possible.
         # To speed up this call all preparatory calculations should be implemented
         # in _parse_header().
@@ -280,7 +280,7 @@ class ExampleRawIO(BaseRawIO):
         # Here we are lucky:  our signals is always zeros!!
         # it is not always the case :)
         # internally signals are int16
-        # convertion to real units is done with self.header['signal_channels']
+        # conversion to real units is done with self.header['signal_channels']
 
         if i_start is None:
             i_start = 0
@@ -327,7 +327,7 @@ class ExampleRawIO(BaseRawIO):
         spike_timestamps = np.arange(0, 10000, 500) + ts_start
 
         if t_start is not None or t_stop is not None:
-            # restricte spikes to given limits (in seconds)
+            # restrict spikes to given limits (in seconds)
             lim0 = int(t_start * 10000)
             lim1 = int(t_stop * 10000)
             mask = (spike_timestamps >= lim0) & (spike_timestamps <= lim1)
@@ -337,7 +337,7 @@ class ExampleRawIO(BaseRawIO):
 
     def _rescale_spike_timestamp(self, spike_timestamps, dtype):
         # must rescale to second a particular spike_timestamps
-        # with a fixed dtype so the user can choose the precisino he want.
+        # with a fixed dtype so the user can choose the precision he want.
         spike_times = spike_timestamps.astype(dtype)
         spike_times /= 10000.  # because 10kHz
         return spike_times
@@ -354,7 +354,7 @@ class ExampleRawIO(BaseRawIO):
 
         # In our IO waveforms come from all channels
         # they are int16
-        # convertion to real units is done with self.header['spike_channels']
+        # conversion to real units is done with self.header['spike_channels']
         # Here, we have a realistic case: all waveforms are only noise.
         # it is not always the case
         # we 20 spikes with a sweep of 50 (5ms)
@@ -412,7 +412,7 @@ class ExampleRawIO(BaseRawIO):
 
     def _rescale_event_timestamp(self, event_timestamps, dtype, event_channel_index):
         # must rescale to second a particular event_timestamps
-        # with a fixed dtype so the user can choose the precisino he want.
+        # with a fixed dtype so the user can choose the precision he want.
 
         # really easy here because in our case it is already seconds
         event_times = event_timestamps.astype(dtype)

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -4,7 +4,7 @@ Support for intan tech rhd  and rhs files.
 
 This 2 formats are more or less the same but:
   * some variance in headers.
-  * rhs amplifier is more complexe because the optional DC channel
+  * rhs amplifier is more complex because the optional DC channel
 
 RHS supported version 1.0
 RHD supported version  1.0 1.1 1.2 1.3 2.0

--- a/neo/rawio/maxwellrawio.py
+++ b/neo/rawio/maxwellrawio.py
@@ -76,7 +76,7 @@ class MaxwellRawIO(BaseRawIO):
                 if len(rec_names) > 1:
                     if self.rec_name is None:
                         raise ValueError("Detected multiple recordings. Please select a "
-                                         "single recording using the `rec_name` paramter. "
+                                         "single recording using the `rec_name` parameter. "
                                          f"Possible rec_name {rec_names}")
                 else:
                     self.rec_name = rec_names[0]
@@ -228,7 +228,7 @@ This is a big pain for the end user.
 You, as a end user, should ask Maxwell company to change this.
 Please visit this page and install the missing decompression libraries:
 https://share.mxwbio.com/d/4742248b2e674a85be97/
-Then, link the decompression library by setting the `HDF5_PLUGIN_PATH` to your 
+Then, link the decompression library by setting the `HDF5_PLUGIN_PATH` to your
 installation location, e.g. via
 os.environ['HDF5_PLUGIN_PATH'] = '/path/to/cutum/hdf5/plugin/'
 

--- a/neo/rawio/neuralynxrawio/ncssections.py
+++ b/neo/rawio/neuralynxrawio/ncssections.py
@@ -147,7 +147,8 @@ class NcsSectionsFactory:
         Parse sections in memory mapped file when microsPerSampUsed and sampFreqUsed are known,
         filling in an NcsSections object.
 
-        PARAMETERS
+        Parameters
+        ----------
         ncsMemMap:
             memmap of Ncs file
         ncsSections:
@@ -160,7 +161,8 @@ class NcsSectionsFactory:
         blkOnePredTime:
             predicted starting time of second record in block
 
-        RETURN
+        Returns
+        -------
         NcsSections object with block locations marked
         """
         startBlockPredTime = blkOnePredTime
@@ -212,7 +214,8 @@ class NcsSectionsFactory:
         records is the inverse of the sampling frequency stated in the header truncated to
         whole microseconds.
 
-        PARAMETERS
+        Parameters
+        ----------
         ncsMemMap:
             memmap of Ncs file
         actualSampFreq:
@@ -220,7 +223,8 @@ class NcsSectionsFactory:
         reqFreq:
             frequency to require in records
 
-        RETURN:
+        Returns
+        -------
             NcsSections object
         """
         # check frequency in first record
@@ -265,7 +269,8 @@ class NcsSectionsFactory:
         Parse blocks of records from file, allowing a maximum gap in timestamps between records
         in sections. Estimates frequency being used based on timestamps.
 
-        PARAMETERS
+        Parameters
+        ----------
         ncsMemMap:
             memmap of Ncs file
         ncsSects:
@@ -275,7 +280,8 @@ class NcsSectionsFactory:
             maximum difference within a block between predicted time of start of record and
             recorded time
 
-        RETURN:
+        Returns
+        -------
             NcsSections object with sampFreqUsed and microsPerSamp set based on estimate from
             largest block
         """
@@ -354,13 +360,15 @@ class NcsSectionsFactory:
         Determine sections of records in memory mapped Ncs file given a nominal frequency of
         the file, using the default values of frequency tolerance and maximum gap between blocks.
 
-        PARAMETERS
+        Parameters
+        ----------
         ncsMemMap:
             memmap of Ncs file
         nomFreq:
             nominal sampling frequency used, normally from header of file
 
-        RETURN:
+        Returns
+        -------
             NcsSections object
         """
         nb = NcsSections()
@@ -404,13 +412,15 @@ class NcsSectionsFactory:
         Build an NcsSections object for an NcsFile, given as a memmap and NlxHeader,
         handling gap detection appropriately given the file type as specified by the header.
 
-        PARAMETERS
+        Parameters
+        ----------
         ncsMemMap:
             memory map of file
         nlxHdr:
             NlxHeader from corresponding file.
 
-        RETURNS
+        Returns
+        -------
         An NcsSections corresponding to the provided ncsMemMap and nlxHdr
         """
         acqType = nlxHdr.type_of_recording()
@@ -452,12 +462,15 @@ class NcsSectionsFactory:
         Provides a more rapid verification of structure than building a new NcsSections
         and checking equality.
 
-        PARAMETERS
+        Parameters
+        ----------
         ncsMemMap:
             memmap of file to be checked
         ncsSects
             existing block structure to be checked
-        RETURN:
+
+        Returns
+        -------
             true if all timestamps and block record starts and stops agree, otherwise false.
         """
         for blki in range(0, len(ncsSects.sects)):

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -552,7 +552,7 @@ class NeuralynxRawIO(BaseRawIO):
         """
         Retrieve chunk of analog signal, a chunk being a set of contiguous samples.
 
-        PARAMETERS
+        Parameters
         ----------
         block_index:
             index of block in dataset, ignored as only 1 block in this implementation
@@ -565,7 +565,7 @@ class NeuralynxRawIO(BaseRawIO):
         channel_indexes:
             list of channel indices to return data for
 
-        RETURNS
+        Returns
         -------
             array of samples, with each requested channel in a column
         """
@@ -727,12 +727,13 @@ class NeuralynxRawIO(BaseRawIO):
         Ncs files have to have common sampling_rate, number of packets and t_start
         (be part of a single stream)
 
-        PARAMETERS:
-        ------
-        ncs_filenames - list of ncs filenames to scan.
+        Parameters
+        ----------
+        ncs_filenames: list
+            List of ncs filenames to scan.
 
-        RETURNS:
-        ------
+        Returns
+        -------
         memmaps
             [ {} for seg_index in range(self._nb_segment) ][chan_uid]
         seg_time_limits

--- a/neo/rawio/neuroexplorerrawio.py
+++ b/neo/rawio/neuroexplorerrawio.py
@@ -7,11 +7,11 @@ Note:
     If someone have some file in that new format we could also
     integrate it in neo
   * NeuroExplorer now provide there own python class for
-    reading/writting nex and nex5. This could be usefull
+    reading/writing nex and nex5. This could be useful
     for testing this class.
 
 Porting NeuroExplorerIO to NeuroExplorerRawIO have some
-limitation because in neuro explorer signals can differents sampling
+limitation because in neuro explorer signals can have different sampling
 rate and shape. So NeuroExplorerRawIO can read only one channel
 at once.
 
@@ -71,7 +71,7 @@ class NeuroExplorerRawIO(BaseRawIO):
             elif entity_header['type'] == 2:  # interval = Epoch
                 event_channels.append((name, _id, 'epoch'))
 
-            elif entity_header['type'] == 3:  # spiketrain and wavefoms
+            elif entity_header['type'] == 3:  # spiketrain and waveforms
                 wf_units = 'mV'
                 wf_gain = entity_header['ADtoMV']
                 wf_offset = entity_header['MVOffset']
@@ -107,7 +107,7 @@ class NeuroExplorerRawIO(BaseRawIO):
         spike_channels = np.array(spike_channels, dtype=_spike_channel_dtype)
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
-        # each signal channel have a dierent groups that force reading
+        # each signal channel has different groups that force reading
         # them one by one
         sig_channels['stream_id'] = np.arange(sig_channels.size).astype('U')
         signal_streams = np.zeros(sig_channels.size, dtype=_signal_stream_dtype)

--- a/neo/rawio/openephysbinaryrawio.py
+++ b/neo/rawio/openephysbinaryrawio.py
@@ -53,7 +53,7 @@ class OpenEphysBinaryRawIO(BaseRawIO):
         sig_stream_names = sorted(list(all_streams[0][0]['continuous'].keys()))
         event_stream_names = sorted(list(all_streams[0][0]['events'].keys()))
 
-        # first loop to reasign stream by "stream_index" instead of "stream_name"
+        # first loop to reassign stream by "stream_index" instead of "stream_name"
         self._sig_streams = {}
         self._evt_streams = {}
         for block_index in range(nb_block):
@@ -318,10 +318,10 @@ def explore_folder(dirname):
     - block_index is the neo Block index
     - segment_index is the neo Segment index
     - stream_type can be 'continuous'/'events'/'spikes'
-    - stream_information is a dictionionary containing e.g. the sampling rate
+    - stream_information is a dictionary containing e.g. the sampling rate
 
-    Parmeters
-    ---------
+    Parameters
+    ----------
     dirname (str): Root folder of the dataset
 
     Returns

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -59,7 +59,7 @@ class OpenEphysRawIO(BaseRawIO):
         Instead it will raise an error.
 
     Special cases:
-      * Normaly all continuous files have the same first timestamp and length. In situations
+      * Normally all continuous files have the same first timestamp and length. In situations
         where it is not the case all files are clipped to the smallest one so that they are all
         aligned,
         and a warning is emitted.
@@ -127,7 +127,7 @@ class OpenEphysRawIO(BaseRawIO):
                     signal_channels.append((ch_name, chan_id, chan_info['sampleRate'],
                                 'int16', units, chan_info['bitVolts'], 0., processor_id))
 
-            # In some cases, continuous do not have the same lentgh because
+            # In some cases, continuous do not have the same length because
             # one record block is missing when the "OE GUI is freezing"
             # So we need to clip to the smallest files
             if not all(all_sigs_length[0] == e for e in all_sigs_length) or\
@@ -156,7 +156,7 @@ class OpenEphysRawIO(BaseRawIO):
                     all_first_timestamps.append(data_chan[0]['timestamp'])
                     all_last_timestamps.append(data_chan[-1]['timestamp'])
 
-            # check that all signals have the same lentgh and timestamp0 for this segment
+            # check that all signals have the same length and timestamp0 for this segment
             assert all(all_sigs_length[0] == e for e in all_sigs_length),\
                        'Not all signals have the same length'
             assert all(all_first_timestamps[0] == e for e in all_first_timestamps),\
@@ -224,7 +224,7 @@ class OpenEphysRawIO(BaseRawIO):
                     all_sorted_ids += np.unique(data_spike['sorted_id']).tolist()
                 all_sorted_ids = np.unique(all_sorted_ids)
 
-                # supose all channel have the same gain
+                # suppose all channels have the same gain
                 wf_units = 'uV'
                 wf_gain = 1000. / data_spike[0]['gains'][0]
                 wf_offset = - (2**15) * wf_gain
@@ -271,7 +271,7 @@ class OpenEphysRawIO(BaseRawIO):
         self.header['spike_channels'] = spike_channels
         self.header['event_channels'] = event_channels
 
-        # Annotate some objects from coninuous files
+        # Annotate some objects from continuous files
         self._generate_minimal_annotations()
         bl_ann = self.raw_annotations['blocks'][0]
         for seg_index, oe_index in enumerate(oe_indices):
@@ -285,7 +285,7 @@ class OpenEphysRawIO(BaseRawIO):
                 seg_ann['openephys_segment_index'] = oe_index + 1
 
     def _segment_t_start(self, block_index, seg_index):
-        # segment start/stop are difine by  continuous channels
+        # segment start/stop are defined by continuous channels
         return self._sig_timestamp0[seg_index] / self._sig_sampling_rate
 
     def _segment_t_stop(self, block_index, seg_index):
@@ -380,7 +380,7 @@ class OpenEphysRawIO(BaseRawIO):
         subdata = self._events_memmap[seg_index][keep]
         timestamps = subdata['timestamp']
         # question what is the label????
-        # here I put a combinaison
+        # here I put a combination
         labels = np.array(['{}#{}#{}'.format(int(d['event_type']),
                                              int(d['processor_id']),
                                              int(d['chan_id']))
@@ -426,7 +426,7 @@ def make_spikes_dtype(filename):
     See documentation of file format.
     """
 
-    # strangly the header do not have the sample size
+    # strangely the header do not have the sample size
     # So this do not work (too bad):
     # spike_info = read_file_header(filename)
     # N = spike_info['num_channels']
@@ -457,7 +457,7 @@ def make_spikes_dtype(filename):
 
 def explore_folder(dirname):
     """
-    This explores a folder and dispatch coninuous, event and spikes
+    This explores a folder and dispatch continuous, event and spikes
     files by segment (aka recording session).
 
     The number of segments is checked with these rules

--- a/neo/rawio/plexonrawio.py
+++ b/neo/rawio/plexonrawio.py
@@ -99,7 +99,7 @@ class PlexonRawIO(BaseRawIO):
                                 2 ** 32 + bl_header['TimeStamp']
 
         # ... and finalize them in self._data_blocks
-        # for a faster acces depending on type (1, 4, 5)
+        # for a faster access depending on type (1, 4, 5)
         self._data_blocks = {}
         dt_base = [('pos', 'int64'), ('timestamp', 'int64'), ('size', 'int64')]
         dtype_by_bltype = {
@@ -135,7 +135,7 @@ class PlexonRawIO(BaseRawIO):
                     data_block['label'] = bl_header['Unit']
                 elif bl_type == 5:  # Signals
                     if data_block.size > 0:
-                        # cumulative some of sample index for fast acces to chunks
+                        # cumulative some of sample index for fast access to chunks
                         data_block['cumsum'][0] = 0
                         data_block['cumsum'][1:] = np.cumsum(data_block['size'][:-1]) // 2
 
@@ -154,7 +154,7 @@ class PlexonRawIO(BaseRawIO):
             all_sig_length.append(length)
             sampling_rate = float(h['ADFreq'])
             sig_dtype = 'int16'
-            units = ''  # I dont't knwon units
+            units = ''  # I don't know units
             if global_header['Version'] in [100, 101]:
                 gain = 5000. / (2048 * h['Gain'] * 1000.)
             elif global_header['Version'] in [102]:
@@ -174,7 +174,7 @@ class PlexonRawIO(BaseRawIO):
             signal_streams = np.array([], dtype=_signal_stream_dtype)
 
         else:
-            # detect grousp (aka streams)
+            # detect groups (aka streams)
             all_sig_length = all_sig_length = np.array(all_sig_length)
             groups = set(zip(sig_channels['sampling_rate'], all_sig_length))
 
@@ -305,7 +305,7 @@ class PlexonRawIO(BaseRawIO):
                 data = self._memmap[ind0:ind1].view('int16')
                 if bl == bl1 - 1:
                     # right border
-                    # be carfull that bl could be both bl0 and bl1!!
+                    # be careful that bl could be both bl0 and bl1!!
                     border = data.size - (i_stop - data_blocks[bl]['cumsum'])
                     data = data[:-border]
                 if bl == bl0:

--- a/neo/rawio/rawbinarysignalrawio.py
+++ b/neo/rawio/rawbinarysignalrawio.py
@@ -9,7 +9,7 @@ class RawBinarySignalIO
 
 Important release note:
   * Since the version neo 0.6.0 and the neo.rawio API,
-    argmuents of the IO (dtype, nb_channel, sampling_rate) must be
+    arguments of the IO (dtype, nb_channel, sampling_rate) must be
     given at the __init__ and not at read_segment() because there is
     no read_segment() in neo.rawio classes.
 

--- a/neo/rawio/spike2rawio.py
+++ b/neo/rawio/spike2rawio.py
@@ -1,9 +1,9 @@
 """
-Classe for reading data in CED spike2 files (.smr).
+Class for reading data in CED spike2 files (.smr).
 
 This code is based on:
  - sonpy, written by Antonio Gonzalez <Antonio.Gonzalez@cantab.net>
-    Disponible here ::
+    Available here ::
     http://www.neuro.ki.se/broberger/
 
 and sonpy come from :
@@ -111,7 +111,7 @@ class Spike2RawIO(BaseRawIO):
             data_blocks = np.array(data_blocks, dtype=[(
                 'pos', 'int32'), ('size', 'int32'), ('cumsum', 'int32'),
                 ('start_time', 'int32'), ('end_time', 'int32')])
-            data_blocks['pos'] += 20  # 20 is ths header size
+            data_blocks['pos'] += 20  # 20 is the header size
 
             self._all_data_blocks[chan_id] = data_blocks
             self._by_seg_data_blocks[chan_id] = []
@@ -133,7 +133,7 @@ class Spike2RawIO(BaseRawIO):
                     gaps_block_ind, = np.nonzero(inter_block_sizes > interval)
                     all_gaps_block_ind[chan_id] = gaps_block_ind
 
-        # find t_start/t_stop for each seg based on gaps indexe
+        # find t_start/t_stop for each seg based on gaps index
         self._sig_t_starts = {}
         self._sig_t_stops = {}
         if len(all_gaps_block_ind) == 0:
@@ -154,7 +154,7 @@ class Spike2RawIO(BaseRawIO):
         else:
             all_nb_seg = np.array([v.size + 1 for v in all_gaps_block_ind.values()])
             assert np.all(all_nb_seg[0] == all_nb_seg), \
-                'Signal channel have differents pause so diffrents nb_segment'
+                'Signal channel have different pause so different nb_segment'
             nb_segment = int(all_nb_seg[0])
 
             for chan_id, gaps_block_ind in all_gaps_block_ind.items():
@@ -239,7 +239,7 @@ class Spike2RawIO(BaseRawIO):
                     wf_left_sweep = chan_info['n_extra'] // 8
                 wf_sampling_rate = sampling_rate
                 if self.ced_units:
-                    # this is a hudge pain because need
+                    # this is a huge pain because need
                     # to jump over all blocks
                     data_blocks = self._all_data_blocks[chan_id]
                     dt = get_channel_dtype(chan_info)
@@ -391,9 +391,9 @@ class Spike2RawIO(BaseRawIO):
         raw_signals = np.zeros((i_stop - i_start, len(chan_ids)), dtype=dt)
         for c, chan_id in enumerate(chan_ids):
             chan_id = int(chan_id)
-            # NOTE: this actual way is slow because we run throught
+            # NOTE: this actual way is slow because we run through
             # the file for each channel. The loop should be reversed.
-            # But there is no garanty that channels shared the same data block
+            # But there is no guarantee that channels shared the same data block
             # indexes. So this make the job too difficult.
             data_blocks = self._by_seg_data_blocks[chan_id][seg_index]
 
@@ -407,7 +407,7 @@ class Spike2RawIO(BaseRawIO):
                 data = self._memmap[ind0:ind1].view(dt)
                 if bl == bl1 - 1:
                     # right border
-                    # be carfull that bl could be both bl0 and bl1!!
+                    # be careful that bl could be both bl0 and bl1!!
                     border = data.size - (i_stop - data_blocks[bl]['cumsum'])
                     if border > 0:
                         data = data[:-border]

--- a/neo/rawio/spikegadgetsrawio.py
+++ b/neo/rawio/spikegadgetsrawio.py
@@ -89,7 +89,7 @@ class SpikeGadgetsRawIO(BaseRawIO):
             stream_bytes[stream_id] = packet_size
             packet_size += num_bytes
 
-        # timesteamps 4 uint32
+        # timestamps 4 uint32
         self._timestamp_byte = packet_size
         packet_size += 4
 

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -23,7 +23,7 @@ Note:
 
 
 # Not implemented yet in this reader:
-  * contact SpkeGLX developer to see how to deal with absolut t_start when several segment
+  * contact SpkeGLX developer to see how to deal with absolute t_start when several segment
   * contact SpkeGLX developer to understand the last channel SY0 function
   * better handling of annotations at object level by sub group of device (after rawio change)
   * better handling of channel location
@@ -285,7 +285,7 @@ def extract_stream_info(meta_file, meta):
     # Example file name structure:
     # Consider the filenames: `Noise4Sam_g0_t0.nidq.bin` or `Noise4Sam_g0_t0.imec0.lf.bin`
     # The filenames consist of 3 or 4 parts separated by `.`
-    # 1. "Noise4Sam_g0_t0" will be the `name` variable. This choosen by the user
+    # 1. "Noise4Sam_g0_t0" will be the `name` variable. This is chosen by the user
     #    at recording time.
     # 2. "_gt0_" will give the `seg_index` (here 0)
     # 3. "nidq" or "imec0" will give the `device` variable

--- a/neo/rawio/tdtrawio.py
+++ b/neo/rawio/tdtrawio.py
@@ -279,7 +279,7 @@ class TdtRawIO(BaseRawIO):
         spike_channels = []
         keep = info_channel_groups['TankEvType'] == EVTYPE_SNIP
         tsq = np.hstack(self._tsq)
-        # If there is no chance the differet TSQ files will have different units,
+        # If there is no chance the different TSQ files will have different units,
         #  then we can do tsq = self._tsq[0]
         for info in info_channel_groups[keep]:
             for c in range(info['NumChan']):
@@ -576,7 +576,7 @@ data_formats = {
 
 
 def is_tdtblock(blockpath):
-    """Is tha path a  TDT block (=neo.Segment) ?"""
+    """Is the path a TDT block (=neo.Segment) ?"""
     file_ext = list()
     if blockpath.is_dir():
         # for every file, get extension, convert to lowercase and append

--- a/neo/utils/datasets.py
+++ b/neo/utils/datasets.py
@@ -46,8 +46,8 @@ def download_dataset(repo=default_testing_repo, remote_path=None,
         The local folder where to download the data.
         If None, a default project testing folder is used. Default: None
 
-    Returns:
-    --------
+    Returns
+    -------
     local_path:
         The local path of the downloaded file or folder
     """

--- a/neo/utils/misc.py
+++ b/neo/utils/misc.py
@@ -18,8 +18,8 @@ def get_events(container, **properties):
     This function returns a list of Event objects, corresponding to given
     key-value pairs in the attributes or annotations of the Event.
 
-    Parameter:
-    ---------
+    Parameters
+    ----------
     container: Block or Segment
         The Block or Segment object to extract data from.
 
@@ -43,12 +43,12 @@ def get_events(container, **properties):
     If no keyword arguments is passed, all Event Objects will
     be returned in a list.
 
-    Returns:
-    --------
+    Returns
+    -------
     events: list
         A list of Event objects matching the given criteria.
 
-    Example:
+    Examples
     --------
         >>> import neo
         >>> from neo.utils import get_events
@@ -90,8 +90,8 @@ def get_epochs(container, **properties):
     This function returns a list of Epoch objects, corresponding to given
     key-value pairs in the attributes or annotations of the Epoch.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     container: Block or Segment
         The Block or Segment object to extract data from.
 
@@ -115,12 +115,12 @@ def get_epochs(container, **properties):
     If no keyword arguments is passed, all Epoch Objects will
     be returned in a list.
 
-    Returns:
-    --------
+    Returns
+    -------
     epochs: list
         A list of Epoch objects matching the given criteria.
 
-    Example:
+    Examples
     --------
         >>> import neo
         >>> from neo.utils import get_epochs
@@ -193,8 +193,8 @@ def _filter_event_epoch(obj, annotation_key, annotation_value):
     contains attributes or annotations corresponding to requested key-value
     pairs.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     obj : Event
         The Event or Epoch object to modify.
     annotation_key : string, int or float
@@ -206,8 +206,8 @@ def _filter_event_epoch(obj, annotation_key, annotation_value):
         annotation value. The entry of obj is kept if the attribute or
         annotation is equal or contained in annotation_value.
 
-    Returns:
-    --------
+    Returns
+    -------
     obj : Event or Epoch
         The Event or Epoch object with every event or epoch removed that does
         not match the filter criteria (i.e., where none of the entries in
@@ -272,8 +272,8 @@ def add_epoch(
     before the and after the event(s). Additional keywords will be directly
     forwarded to the Epoch intialization.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     segment : Segment
         The segment in which the final Epoch object is added.
     event1 : Event
@@ -291,18 +291,16 @@ def add_epoch(
         event1 times to 25 ms after event2 times
     attach_result: bool
         If True, the resulting Epoch object is added to segment.
+    **kwargs
+        Additional keyword arguments passed to the Epoch object.
 
-    Keyword Arguments:
-    ------------------
-    Passed to the Epoch object.
-
-    Returns:
-    --------
+    Returns
+    -------
     epoch: Epoch
         An Epoch object with the calculated epochs (one per entry in event1).
 
-    See also:
-    ---------
+    See also
+    --------
     Event.to_epoch()
     """
     if event2 is None:
@@ -365,13 +363,13 @@ def match_events(event1, event2):
     Returns filtered two events of identical length, which contain matched
     entries.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     event1, event2: Event
         The two Event objects to match up.
 
-    Returns:
-    --------
+    Returns
+    -------
     event1, event2: Event
         Event objects with identical number of events, containing only those
         events that could be matched against each other. A warning is issued if
@@ -468,9 +466,10 @@ def cut_block_by_epochs(block, properties=None, reset_time=False):
         If False, original time stamps are retained.
         Default is False.
 
-    Returns:
-    --------
-    None
+    Returns
+    -------
+    new_block : Block
+        Updated block.
     """
     if not isinstance(block, neo.Block):
         raise TypeError(
@@ -525,8 +524,8 @@ def cut_segment_by_epoch(seg, epoch, reset_time=False):
         If False, original time stamps are retained.
         Default is False.
 
-    Returns:
-    --------
+    Returns
+    -------
     segments: list of Segments
         Per epoch in the input, a Segment with AnalogSignal and/or
         SpikeTrain Objects will be generated and returned. Each Segment will
@@ -568,8 +567,8 @@ def clean_annotations(dictionary):
     dictionary: dict
         annotation dictionary to be cleaned
 
-    Returns:
-    --------
+    Returns
+    -------
     dict
         A cleaned version of the annotations
     """
@@ -593,8 +592,8 @@ def is_block_rawio_compatible(block, return_problems=False):
     return_problems: bool (False by default)
         Controls whether a list of str that describe problems is also provided as return value
 
-    Returns:
-    --------
+    Returns
+    -------
     is_rawio_compatible: bool
         Compatible or not.
     problems: list of str


### PR DESCRIPTION
As I was working through the code to familiarize myself with the module, I made a bunch of small fixes along the way. 

Included:
- first commit: typo and some wording fixes across most of the module
- second commit: standardizes usage of numpydoc format docstrings in places where it was being used
