### PR TITLE
support for just .spikes in folder

### DIFF
--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -492,11 +492,11 @@ def explore_folder(dirname):
             if (seg_index + 1) > info['nb_segment']:
                 info['nb_segment'] += 1
         elif filename.endswith('.spikes'):
-            s = filename.replace('.spikes', '').split('_')
-            if len(s) == 2:
-                seg_index = 0
+            s = re.findall("(_\d+)$", filename.replace('.spikes', ''))
+            if s:
+                seg_index = int(s[0][1:]) - 1
             else:
-                seg_index = int(s[2]) - 1
+                seg_index = 0
             if seg_index not in info['spikes'].keys():
                 info['spikes'][seg_index] = []
             info['spikes'][seg_index].append(filename)

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -166,8 +166,8 @@ class OpenEphysRawIO(BaseRawIO):
 
             self._sig_length[seg_index] = all_sigs_length[0]
             self._sig_timestamp0[seg_index] = all_first_timestamps[0]
-        
-        if len(signal_channels)>0:
+
+        if len(signal_channels) > 0:
             signal_channels = np.array(signal_channels, dtype=_signal_channel_dtype)
             self._sig_sampling_rate = signal_channels['sampling_rate'][0]  # unique for channel
 

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -492,7 +492,7 @@ def explore_folder(dirname):
             if (seg_index + 1) > info['nb_segment']:
                 info['nb_segment'] += 1
         elif filename.endswith('.spikes'):
-            s = re.findall("(_\d+)$", filename.replace('.spikes', ''))
+            s = re.findall(r"(_\d+)$", filename.replace('.spikes', ''))
             if s:
                 seg_index = int(s[0][1:]) - 1
             else:


### PR DESCRIPTION
Hi I was trying to load an openephys _.spikes_ file but it required the .continuous file as well. To fix that, I separated a bit better the data loading, all the code was there. 
And I fixed a typo when the filename is read to check the number of segments.

This will work for my case, but probably a similar fix could be made to load only events files.

Cheers,
Fer 