### PR TITLE
Array-annotate Amplitudes and PCs in PhyIO

### DIFF
--- a/neo/io/phyio.py
+++ b/neo/io/phyio.py
@@ -7,6 +7,6 @@ class PhyIO(PhyRawIO, BaseFromRaw):
     description = "Phy IO"
     mode = 'dir'
 
-    def __init__(self, dirname):
-        PhyRawIO.__init__(self, dirname=dirname)
+    def __init__(self, dirname, load_pcs=False):
+        PhyRawIO.__init__(self, dirname=dirname, load_pcs=load_pcs)
         BaseFromRaw.__init__(self, dirname)

--- a/neo/rawio/phyrawio.py
+++ b/neo/rawio/phyrawio.py
@@ -179,7 +179,7 @@ class PhyRawIO(BaseRawIO):
                                 current_pc_features[:, pc_idx, channel_idx]
 
             if self._pc_feature_ind is not None:
-                spiketrain_an['pc_feature_ind'] = self._pc_feature_ind[index]
+                spiketrain_an['pc_feature_ind'] = self._pc_feature_ind[unique_templates]
 
     def _segment_t_start(self, block_index, seg_index):
         assert block_index == 0

--- a/neo/rawio/phyrawio.py
+++ b/neo/rawio/phyrawio.py
@@ -159,6 +159,11 @@ class PhyRawIO(BaseRawIO):
 
             cluster_mask = (self._spike_clusters == clust_id).flatten()
 
+            current_templates = self._spike_templates[cluster_mask].flatten()
+            unique_templates = np.unique(current_templates)
+            spiketrain_an['templates'] = unique_templates
+            spiketrain_an['__array_annotations__']['templates'] = current_templates
+
             if self._amplitudes is not None:
                 spiketrain_an['__array_annotations__']['amplitudes'] = \
                     self._amplitudes[cluster_mask]


### PR DESCRIPTION
PhyIO was written before array_annotations were fully functional, so it had TODOs in the comments to deal with data which should be array_annotated once that's possible.
I added array_annotations for PCs and amplitudes to all spikes, and since the PCs can be quite a lot of data I added a flag that can be toggled to load them.