### PR TITLE
Local import and remove HAVE_PACKAGE logic

### DIFF
--- a/neo/io/igorproio.py
+++ b/neo/io/igorproio.py
@@ -17,13 +17,6 @@ import quantities as pq
 from neo.io.baseio import BaseIO
 from neo.core import Block, Segment, AnalogSignal
 
-try:
-    import igor.binarywave as bw
-    import igor.packed as pxp
-    from igor.record.wave import WaveRecord
-    HAVE_IGOR = True
-except ImportError:
-    HAVE_IGOR = False
 
 
 class IgorIO(BaseIO):
@@ -83,6 +76,9 @@ class IgorIO(BaseIO):
         return block
 
     def read_segment(self, lazy=False):
+        import igor.packed as pxp
+        from igor.record.wave import WaveRecord
+
         assert not lazy, 'This IO does not support lazy mode'
         segment = Segment(file_origin=str(self.filename))
 
@@ -104,11 +100,11 @@ class IgorIO(BaseIO):
         return segment
 
     def read_analogsignal(self, path=None, lazy=False):
+        import igor.binarywave as bw
+        import igor.packed as pxp
+
         assert not lazy, 'This IO does not support lazy mode'
 
-        if not HAVE_IGOR:
-            raise Exception("`igor` package not installed. "
-                             "Try `pip install igor`")
         if self.extension == 'ibw':
             data = bw.load(str(self.filename))
             version = data['version']

--- a/neo/io/klustakwikio.py
+++ b/neo/io/klustakwikio.py
@@ -21,14 +21,6 @@ import shutil
 # note neo.core need only numpy and quantitie
 import numpy as np
 
-try:
-    import matplotlib.mlab as mlab
-except ImportError as err:
-    HAVE_MLAB = False
-    MLAB_ERR = err
-else:
-    HAVE_MLAB = True
-    MLAB_ERR = None
 
 # I need to subclass BaseIO
 from neo.io.baseio import BaseIO
@@ -105,8 +97,6 @@ class KlustaKwikIO(BaseIO):
         sampling_rate : in Hz, necessary because the KlustaKwik files
             stores data in samples.
         """
-        if not HAVE_MLAB:
-            raise MLAB_ERR
         BaseIO.__init__(self)
         # self.filename = os.path.normpath(filename)
         self.filename, self.basename = os.path.split(os.path.abspath(filename))

--- a/neo/io/kwikio.py
+++ b/neo/io/kwikio.py
@@ -15,23 +15,6 @@ import numpy as np
 import quantities as pq
 import os
 
-try:
-    from scipy import stats
-except ImportError as err:
-    HAVE_SCIPY = False
-    SCIPY_ERR = err
-else:
-    HAVE_SCIPY = True
-    SCIPY_ERR = None
-
-try:
-    from klusta import kwik
-except ImportError as err:
-    HAVE_KWIK = False
-    KWIK_ERR = err
-else:
-    HAVE_KWIK = True
-    KWIK_ERR = None
 
 # I need to subclass BaseIO
 from neo.io.baseio import BaseIO
@@ -77,8 +60,8 @@ class KwikIO(BaseIO):
         Arguments:
             filename : the filename
         """
-        if not HAVE_KWIK:
-            raise KWIK_ERR
+        from klusta import kwik
+
         BaseIO.__init__(self)
         self.filename = os.path.abspath(filename)
         model = kwik.KwikModel(self.filename)  # TODO this group is loaded twice

--- a/neo/io/neomatlabio.py
+++ b/neo/io/neomatlabio.py
@@ -18,23 +18,8 @@ import re
 import numpy as np
 import quantities as pq
 
-# check scipy
-try:
-    from packaging.version import Version
-    import scipy.io
-    import scipy.version
-except ImportError as err:
-    HAVE_SCIPY = False
-    SCIPY_ERR = err
-else:
-    if Version(scipy.version.version) < Version('0.12.0'):
-        HAVE_SCIPY = False
-        SCIPY_ERR = ImportError("your scipy version is too old to support "
-                                + "MatlabIO, you need at least 0.12.0. "
-                                + "You have %s" % scipy.version.version)
-    else:
-        HAVE_SCIPY = True
-        SCIPY_ERR = None
+from packaging.version import Version
+
 
 from neo.io.baseio import BaseIO
 from neo.core import (Block, Segment, AnalogSignal, IrregularlySampledSignal,
@@ -212,8 +197,13 @@ class NeoMatlabIO(BaseIO):
         Arguments:
             filename : the filename to read
         """
-        if not HAVE_SCIPY:
-            raise SCIPY_ERR
+        import scipy
+
+        if Version(scipy.version.version) < Version('0.12.0'):
+            raise ImportError("your scipy version is too old to support "
+                                    + "MatlabIO, you need at least 0.12.0. "
+                                    + "You have %s" % scipy.version.version)
+
         BaseIO.__init__(self)
         self.filename = filename
 
@@ -222,6 +212,7 @@ class NeoMatlabIO(BaseIO):
         Arguments:
 
         """
+        import scipy.io
         assert not lazy, 'Do not support lazy'
 
         d = scipy.io.loadmat(self.filename, struct_as_record=False,
@@ -241,7 +232,7 @@ class NeoMatlabIO(BaseIO):
         Arguments:
             bl: the block to b saved
         """
-
+        import scipy.io
         bl_struct = self.create_struct_from_obj(bl)
 
         for seg in bl.segments:

--- a/neo/io/tiffio.py
+++ b/neo/io/tiffio.py
@@ -3,11 +3,6 @@ Neo IO module for optical imaging data stored as a folder of TIFF images.
 """
 
 import os
-try:
-    from PIL import Image
-    have_pil = True
-except ImportError:
-    have_pil = False
 
 import numpy as np
 from neo.core import ImageSequence, Segment, Block
@@ -72,9 +67,7 @@ class TiffIO(BaseIO):
 
     def __init__(self, directory_path=None, units=None, sampling_rate=None,
                  spatial_scale=None, **kwargs):
-
-        if not have_pil:
-            raise Exception("Please install the pillow package to use TiffIO")
+        import PIL
 
         BaseIO.__init__(self, directory_path, **kwargs)
         self.units = units
@@ -82,6 +75,8 @@ class TiffIO(BaseIO):
         self.spatial_scale = spatial_scale
 
     def read_block(self, lazy=False, **kwargs):
+        import PIL
+
         # to sort file
         def natural_sort(l):
             convert = lambda text: int(text) if text.isdigit() else text.lower()
@@ -102,13 +97,13 @@ class TiffIO(BaseIO):
         file_name_list = natural_sort(file_name_list)
         list_data_image = []
         for file_name in file_name_list:
-            data = np.array(Image.open(self.filename + "/" + file_name)).astype(np.float32)
+            data = np.array(PIL.Image.open(self.filename + "/" + file_name)).astype(np.float32)
             list_data_image.append(data)
         list_data_image = np.array(list_data_image)
         if len(list_data_image.shape) == 4:
             list_data_image = []
             for file_name in file_name_list:
-                image = Image.open(self.filename + "/" + file_name).convert('L')
+                image = PIL.Image.open(self.filename + "/" + file_name).convert('L')
                 data = np.array(image).astype(np.float32)
                 list_data_image.append(data)
 

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -75,12 +75,6 @@ import sys
 
 from neo import logging_handler
 
-try:
-    import joblib
-
-    HAVE_JOBLIB = True
-except ImportError:
-    HAVE_JOBLIB = False
 
 possible_raw_modes = ['one-file', 'multi-file', 'one-dir', ]  # 'multi-dir', 'url', 'other'
 
@@ -162,7 +156,7 @@ class BaseRawIO:
 
         self.use_cache = use_cache
         if use_cache:
-            assert HAVE_JOBLIB, 'You need to install joblib for cache'
+            import joblib
             self.setup_cache(cache_path)
         else:
             self._cache = None
@@ -703,6 +697,8 @@ class BaseRawIO:
         return self._rescale_epoch_duration(raw_duration, dtype, event_channel_index)
 
     def setup_cache(self, cache_path, **init_kargs):
+        import joblib
+
         if self.rawmode in ('one-file', 'multi-file'):
             resource_name = self.filename
         elif self.rawmode == 'one-dir':

--- a/neo/rawio/biocamrawio.py
+++ b/neo/rawio/biocamrawio.py
@@ -12,11 +12,6 @@ from .baserawio import (BaseRawIO, _signal_channel_dtype, _signal_stream_dtype,
 
 import numpy as np
 
-try:
-    import h5py
-    HAVE_H5PY = True
-except ImportError:
-    HAVE_H5PY = False
 
 
 class BiocamRawIO(BaseRawIO):
@@ -45,7 +40,6 @@ class BiocamRawIO(BaseRawIO):
         return self.filename
 
     def _parse_header(self):
-        assert HAVE_H5PY, 'h5py is not installed'
         self._header_dict = open_biocam_file_header(self.filename)
         self._num_channels = self._header_dict["num_channels"]
         self._num_frames = self._header_dict["num_frames"]
@@ -121,7 +115,7 @@ class BiocamRawIO(BaseRawIO):
 def open_biocam_file_header(filename):
     """Open a Biocam hdf5 file, read and return the recording info, pick the correct method to access raw data,
     and return this to the caller."""
-    assert HAVE_H5PY, 'h5py is not installed'
+    import h5py
 
     rf = h5py.File(filename, 'r')
     # Read recording variables

--- a/neo/rawio/cedrawio.py
+++ b/neo/rawio/cedrawio.py
@@ -26,11 +26,6 @@ from .baserawio import (BaseRawIO, _signal_channel_dtype, _signal_stream_dtype,
 import numpy as np
 from copy import deepcopy
 
-try:
-    import sonpy
-    HAVE_SONPY = True
-except ImportError:
-    HAVE_SONPY = False
 
 
 class CedRawIO(BaseRawIO):
@@ -53,7 +48,7 @@ class CedRawIO(BaseRawIO):
         return self.filename
 
     def _parse_header(self):
-        assert HAVE_SONPY, 'sonpy must be installed'
+        import sonpy
 
         self.smrx_file = sonpy.lib.SonFile(sName=str(self.filename), bReadOnly=True)
         smrx = self.smrx_file

--- a/neo/rawio/maxwellrawio.py
+++ b/neo/rawio/maxwellrawio.py
@@ -27,12 +27,6 @@ from .baserawio import (BaseRawIO, _signal_channel_dtype, _signal_stream_dtype,
 
 import numpy as np
 
-try:
-    import h5py
-    HAVE_H5 = True
-except ImportError:
-    HAVE_H5 = False
-
 
 class MaxwellRawIO(BaseRawIO):
     """
@@ -50,12 +44,7 @@ class MaxwellRawIO(BaseRawIO):
         return self.filename
 
     def _parse_header(self):
-        try:
-            import MEArec as mr
-            HAVE_MEAREC = True
-        except ImportError:
-            HAVE_MEAREC = False
-        assert HAVE_H5, 'h5py is not installed'
+        import h5py
 
         h5 = h5py.File(self.filename, mode='r')
         self.h5_file = h5

--- a/neo/rawio/mearecrawio.py
+++ b/neo/rawio/mearecrawio.py
@@ -44,12 +44,7 @@ class MEArecRawIO(BaseRawIO):
         return self.filename
 
     def _parse_header(self):
-        try:
-            import MEArec as mr
-            HAVE_MEAREC = True
-        except ImportError:
-            HAVE_MEAREC = False
-        assert HAVE_MEAREC, 'MEArec is not installed'
+        import MEArec as mr
         self._recgen = mr.load_recordings(recordings=self.filename, return_h5_objects=True,
                                           check_suffix=False,
                                           load=['recordings', 'spiketrains', 'channel_positions'],

--- a/neo/rawio/nixrawio.py
+++ b/neo/rawio/nixrawio.py
@@ -43,9 +43,9 @@ class NIXRawIO(BaseRawIO):
         return self.filename
 
     def _parse_header(self):
-        import nixio as nix
+        import nixio
 
-        self.file = nix.File.open(self.filename, nix.FileMode.ReadOnly)
+        self.file = nixio.File.open(self.filename, nixio.FileMode.ReadOnly)
         signal_channels = []
         anasig_ids = {0: []}  # ids of analogsignals by segment
         stream_ids = []

--- a/neo/rawio/nixrawio.py
+++ b/neo/rawio/nixrawio.py
@@ -15,13 +15,6 @@ from .baserawio import (BaseRawIO, _signal_channel_dtype, _signal_stream_dtype,
                         _spike_channel_dtype, _event_channel_dtype)
 from ..io.nixio import check_nix_version
 
-try:
-    import nixio as nix
-
-    HAVE_NIX = True
-except ImportError:
-    HAVE_NIX = False
-    nix = None
 
 
 # When reading metadata properties, the following keys are ignored since they
@@ -50,6 +43,8 @@ class NIXRawIO(BaseRawIO):
         return self.filename
 
     def _parse_header(self):
+        import nixio as nix
+
         self.file = nix.File.open(self.filename, nix.FileMode.ReadOnly)
         signal_channels = []
         anasig_ids = {0: []}  # ids of analogsignals by segment

--- a/neo/test/iotest/test_klustakwikio.py
+++ b/neo/test/iotest/test_klustakwikio.py
@@ -15,10 +15,9 @@ import quantities as pq
 import neo
 from neo.test.iotest.common_io_test import BaseTestIO
 from neo.test.tools import assert_arrays_almost_equal
-from neo.io.klustakwikio import KlustaKwikIO, HAVE_MLAB
+from neo.io.klustakwikio import KlustaKwikIO
 
 
-@unittest.skipUnless(HAVE_MLAB, "requires matplotlib")
 class testFilenameParser(unittest.TestCase):
     """Tests that filenames can be loaded with or without basename.
 
@@ -75,7 +74,6 @@ class testFilenameParser(unittest.TestCase):
                                                       'basename2.clu.1')))
 
 
-@unittest.skipUnless(HAVE_MLAB, "requires matplotlib")
 class testRead(unittest.TestCase):
     """Tests that data can be read from KlustaKwik files"""
 
@@ -140,7 +138,6 @@ class testRead(unittest.TestCase):
                                                                      0.228])))
 
 
-@unittest.skipUnless(HAVE_MLAB, "requires matplotlib")
 class testWrite(unittest.TestCase):
     def setUp(self):
         self.dirname = os.path.join(tempfile.gettempdir(),
@@ -249,7 +246,6 @@ class testWrite(unittest.TestCase):
         delete_test_session()
 
 
-@unittest.skipUnless(HAVE_MLAB, "requires matplotlib")
 class testWriteWithFeatures(unittest.TestCase):
     def setUp(self):
         self.dirname = os.path.join(tempfile.gettempdir(),
@@ -333,7 +329,6 @@ class testWriteWithFeatures(unittest.TestCase):
         delete_test_session(self.dirname)
 
 
-@unittest.skipUnless(HAVE_MLAB, "requires matplotlib")
 class CommonTests(BaseTestIO, unittest.TestCase):
     ioclass = KlustaKwikIO
     entities_to_download = [

--- a/neo/test/iotest/test_kwikio.py
+++ b/neo/test/iotest/test_kwikio.py
@@ -14,7 +14,7 @@ from neo.io import kwikio
 from neo.test.iotest.common_io_test import BaseTestIO
 
 
-@unittest.skipUnless(   HAVE_KWIK, "requires klusta")
+@unittest.skipUnless(HAVE_KWIK, "requires klusta")
 class TestKwikIO(BaseTestIO, unittest.TestCase):
     ioclass = kwikio.KwikIO
     entities_to_download = [

--- a/neo/test/iotest/test_kwikio.py
+++ b/neo/test/iotest/test_kwikio.py
@@ -5,17 +5,16 @@ Tests of neo.io.kwikio
 import unittest
 
 try:
-    import h5py
-
-    HAVE_H5PY = True
+    from klusta import kwik
+    HAVE_KWIK = True
 except ImportError:
-    HAVE_H5PY = False
+    HAVE_KWIK = False
+
 from neo.io import kwikio
 from neo.test.iotest.common_io_test import BaseTestIO
 
 
-@unittest.skipUnless(HAVE_H5PY, "requires h5py")
-@unittest.skipUnless(kwikio.HAVE_KWIK, "requires klusta")
+@unittest.skipUnless(   HAVE_KWIK, "requires klusta")
 class TestKwikIO(BaseTestIO, unittest.TestCase):
     ioclass = kwikio.KwikIO
     entities_to_download = [

--- a/neo/test/iotest/test_neomatlabio.py
+++ b/neo/test/iotest/test_neomatlabio.py
@@ -15,7 +15,7 @@ from neo.io.neomatlabio import NeoMatlabIO
 try:
     import scipy.io
     HAVE_SCIPY = True
-except:
+except ImportError:
     HAVE_SCIPY = False
 
 

--- a/neo/test/iotest/test_neomatlabio.py
+++ b/neo/test/iotest/test_neomatlabio.py
@@ -10,7 +10,13 @@ from neo.core.analogsignal import AnalogSignal
 from neo.core.irregularlysampledsignal import IrregularlySampledSignal
 from neo import Block, Segment, SpikeTrain
 from neo.test.iotest.common_io_test import BaseTestIO
-from neo.io.neomatlabio import NeoMatlabIO, HAVE_SCIPY
+from neo.io.neomatlabio import NeoMatlabIO
+
+try:
+    import scipy.io
+    HAVE_SCIPY = True
+except:
+    HAVE_SCIPY = False
 
 
 @unittest.skipUnless(HAVE_SCIPY, "requires scipy")

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ extras_require = {
     'edf': ['pyedflib'],
     'ced': ['sonpy'],
     'nwb': ['pynwb'],
+    'maxwell': ['h5py'],
+    'biocam': ['h5py'],
 }
 
 with open("neo/version.py") as fp:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = ['packaging',
                     'quantities>=0.12.1']
 extras_require = {
     'igorproio': ['igor'],
-    'kwikio': ['scipy', 'klusta'],
+    'kwikio': ['klusta'],
     'neomatlabio': ['scipy>=1.0.0'],
     'nixio': ['nixio>=1.5.0'],
     'stimfitio': ['stfio'],


### PR DESCRIPTION
This PR remove unnecessary import at module level and import extra dependency only when they are needed when instanciating an IO class.

See #1160

This should:
  * help in complicated environement (by not importing everything)
  * decrease import duration

The drawback:
  * it raise error only when instanciate (run time) and not at load time.
