### PR TITLE
Add `load_sync_channel` logic to OpenEphysBinaryRawIO

### DIFF
--- a/neo/test/rawiotest/test_openephysbinaryrawio.py
+++ b/neo/test/rawiotest/test_openephysbinaryrawio.py
@@ -13,6 +13,7 @@ class TestOpenEphysBinaryRawIO(BaseTestRawIO, unittest.TestCase):
         'openephysbinary/v0.5.3_two_neuropixels_stream',
         'openephysbinary/v0.4.4.1_with_video_tracking',
         'openephysbinary/v0.5.x_two_nodes',
+        'openephysbinary/v0.6.x_neuropixels_multiexp_multistream',
     ]
 
 


### PR DESCRIPTION
This PR adds the `load_sync_channel` (True by default) to avoit loading the SYNC channel in Open Ephys Neuropixels recordings (similar logic to SpikeGLX).

Based on: https://github.com/NeuralEnsemble/python-neo/pull/1159