### PR TITLE
Allow epoch duration to be a float

### DIFF
--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -6,6 +6,7 @@ This module defines :class:`Epoch`, an array of epochs.
 '''
 
 from copy import deepcopy, copy
+from numbers import Number
 
 import numpy as np
 import quantities as pq
@@ -53,10 +54,12 @@ class Epoch(DataObject):
     *Required attributes/properties*:
         :times: (quantity array 1D, numpy array 1D or list) The start times
            of each time period.
-        :durations: (quantity array 1D, numpy array 1D, list, or quantity scalar)
+        :durations: (quantity array 1D, numpy array 1D, list, quantity scalar or float)
            The length(s) of each time period.
-           If a scalar, the same value is used for all time periods.
+           If a scalar/float, the same value is used for all time periods.
         :labels: (numpy.array 1D dtype='U' or list) Names or labels for the time periods.
+        :units: (quantity units or str) Required if the times is a list or NumPy
+                array, not if it is a :class:`Quantity`
 
     *Recommended attributes/properties*:
         :name: (str) A label for the dataset,
@@ -88,8 +91,10 @@ class Epoch(DataObject):
             raise ValueError("Times array has more than 1 dimension")
         if isinstance(durations, (list, tuple)):
             durations = np.array(durations)
-        if durations is None:
+        elif durations is None:
             durations = np.array([]) * pq.s
+        elif isinstance(durations, Number):
+            durations = durations * np.ones(times.shape)
         elif durations.size != times.size:
             if durations.size == 1:
                 durations = durations * np.ones_like(times.magnitude)


### PR DESCRIPTION
in which case the duration units will be taken from the `units` argument or from the units of the `times` argument.