### PR TITLE
Add a "pip install neo[all]" option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ extras_require = {
     'maxwell': ['h5py'],
     'biocam': ['h5py'],
 }
+extras_require["all"] = sum(extras_require.values(), [])
 
 with open("neo/version.py") as fp:
     d = {}


### PR DESCRIPTION
to install all optional requirements (helpful for setting up development environments)