### PR TITLE
Better `id` for Open Ephys Events

### DIFF
--- a/neo/rawio/openephysbinaryrawio.py
+++ b/neo/rawio/openephysbinaryrawio.py
@@ -162,7 +162,7 @@ class OpenEphysBinaryRawIO(BaseRawIO):
                 evt_channel_type = "epoch"
             else:
                 evt_channel_type = "event"
-            event_channels.append((d['channel_name'], stream_ind, evt_channel_type))
+            event_channels.append((d['channel_name'], d['channel_name'], evt_channel_type))
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
         # create memmap for events


### PR DESCRIPTION
The Open Ephys event channel ids were set to the `stream_index`, which made it not very informative.
This PR sets the event `id` to be the same as the event `name`: e.g. `Message Center`, `PXIe`, `RhythmFPGA`, etc.