### PR TITLE
Preparing release of version 0.11.1

### DIFF
--- a/doc/source/releases/0.11.1.rst
+++ b/doc/source/releases/0.11.1.rst
@@ -1,0 +1,47 @@
+========================
+Neo 0.11.1 release notes
+========================
+
+21st October 2022
+
+.. currentmodule:: neo.io
+
+Bug fixes and improvements in IO modules
+----------------------------------------
+
+Bug fixes and/or improvements have been made to
+:class:`OpenEphysBinaryIO`, :class:`BlackrockIO`, :class:`NWBIO`, :class:`PhyIO`, :class:`NeuralynxIO`
+
+
+Supported format versions
+-------------------------
+
+:class:`BlackrockIO` now supports file version 3.0
+
+
+Other changes
+-------------
+
+New installation mode
+
+- Neo can now be installed including all optional dependencies via *pip install neo[all]*
+
+Faster import
+
+- Dependency imports have been optimized for faster import of Neo
+
+Epoch durations
+
+- Epoch durations of epochs can now be of type float
+
+See all `pull requests`_ included in this release and the `list of closed issues`_.
+
+Acknowledgements
+----------------
+
+Thanks to Andrew Davison, Julia Sprenger, Chadwick Boulay, Alessio Buccino, Elodie Legouée, Samuel Garcia for their contributions to this release.
+
+.. generated with git shortlog --since=2022-09-01 -sne then checking Github for PRs merged since the last release but with commits before then
+
+.. _`list of closed issues`: https://github.com/NeuralEnsemble/python-neo/issues?q=is%3Aissue+milestone%3A0.11.1+is%3Aclosed
+.. _`pull requests`: https://github.com/NeuralEnsemble/python-neo/pulls?q=is%3Apr+is%3Aclosed+merged%3A%3E2022-09-01+milestone%3A0.11.1

--- a/doc/source/whatisnew.rst
+++ b/doc/source/whatisnew.rst
@@ -6,6 +6,7 @@ Release notes
 .. toctree::
    :maxdepth: 1
 
+   releases/0.11.1.rst
    releases/0.11.0.rst
    releases/0.10.2.rst
    releases/0.10.1.rst

--- a/neo/version.py
+++ b/neo/version.py
@@ -1,1 +1,1 @@
-version = '0.12.0.dev0'
+version = '0.11.1'


### PR DESCRIPTION
This PR updates the release notes and version number for 0.11.1
Anticipated release date is the 21st October.

@samuelgarcia @apdavison Do you have something to add? It would be ideal if we could find a solution for #1184  before the release.