### PR TITLE
[NWB] enable closing of dangling file io

### DIFF
--- a/neo/io/nwbio.py
+++ b/neo/io/nwbio.py
@@ -227,10 +227,10 @@ class NWBIO(BaseIO):
         import pynwb
 
         assert self.nwb_file_mode in ('r',)
-        io = pynwb.NWBHDF5IO(self.filename, mode=self.nwb_file_mode,
+        self._io_nwb = pynwb.NWBHDF5IO(self.filename, mode=self.nwb_file_mode,
                              load_namespaces=True)  # Open a file with NWBHDF5IO
         try:
-            self._file = io.read()
+            self._file = self._io_nwb.read()
         except ValueError:
             print("Error: Unable to read this version of NWB file.")
             print("Please convert to a later NWB format.")
@@ -644,6 +644,10 @@ class NWBIO(BaseIO):
                               segment=segment.name,
                               block=segment.block.name)
         return self._nwbfile.epochs
+
+    def close(self):
+        if self._io_nwb:
+            self._io_nwb.close()
 
 
 class AnalogSignalProxy(BaseAnalogSignalProxy):


### PR DESCRIPTION
Hi @legouee!
I had discovered that you are closing all io instances except for one in the NWBIO and that you have an instance variable `_nwb_io` that looks like it's intended for referencing the opened io. Here I added the functionality to close the io that has been used for reading. Can you have a look and see if this is what you intended originally?
