### PR TITLE
update test matrix following NEP29 + 1 year

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -29,6 +29,8 @@ jobs:
              numpy-version: '1.19.5'
            - python-version: '3.11'
              numpy-version: '1.20.3'
+           - python-version: '3.11'
+             numpy-version: '1.21.6'
     steps:
         - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v4

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -9,14 +9,12 @@ on:
   push:
     branches: [master]
 
-
-
 jobs:
   multi-os-python-numpy:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false   # temporary for extending matrix, should normally be true
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # "macos-latest",

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -20,15 +20,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # "macos-latest",
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        numpy-version: ['1.18.5', '1.19.5', '1.20.3', '1.21.6', '1.22.4', '1.23.0']
+        python-version: ['3.8', '3.9', '3.10']
+        numpy-version: ['1.19.5', '1.20.3', '1.21.6', '1.22.4', '1.23.5', '1.24.1']
         exclude:
-           - python-version: '3.7'
-             numpy-version: '1.22.4'
-           - python-version: '3.7'
-             numpy-version: '1.23.0'
-           - python-version: '3.10'
-             numpy-version: '1.18.5'
            - python-version: '3.10'
              numpy-version: '1.19.5'
            - python-version: '3.10'

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: false   # temporary for extending matrix, should normally be true
+      fail-fast: true
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # "macos-latest",

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -18,12 +18,16 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # "macos-latest",
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         numpy-version: ['1.19.5', '1.20.3', '1.21.6', '1.22.4', '1.23.5', '1.24.1']
         exclude:
            - python-version: '3.10'
              numpy-version: '1.19.5'
            - python-version: '3.10'
+             numpy-version: '1.20.3'
+           - python-version: '3.11'
+             numpy-version: '1.19.5'
+           - python-version: '3.11'
              numpy-version: '1.20.3'
     steps:
         - name: Set up Python ${{ matrix.python-version }}

--- a/doc/source/developers_guide.rst
+++ b/doc/source/developers_guide.rst
@@ -38,8 +38,8 @@ a GitHub account and then set to watch the repository at `GitHub Repository`_
 Requirements
 ------------
 
-    * Python_ 3.7 or later
-    * numpy_ >= 1.11.0
+    * Python_ 3.8 or later
+    * numpy_ >= 1.19.5
     * quantities_ >= 0.12.1
     * nose_ >= 1.1.2 (for running tests)
     * Sphinx_ (for building documentation)
@@ -193,7 +193,7 @@ open a pull request on GitHub
 Python version
 --------------
 
-Neo should work with Python 3.7 or newer. If you need support for Python 2.7,
+Neo should work with Python 3.8 or newer. If you need support for Python 2.7,
 use Neo v0.8.0 or earlier.
 
 
@@ -201,7 +201,7 @@ Coding standards and style
 --------------------------
 
 All code should conform as much as possible to `PEP 8`_, and should run with
-Python 3.7 or newer.
+Python 3.8 or newer.
 
 You can use the `pep8`_ program to check the code for PEP 8 conformity.
 You can also use `flake8`_, which combines pep8 and pyflakes.

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -11,8 +11,8 @@ Installing from the Python Package Index
 Dependencies
 ------------
 
-    * Python_ >= 3.7
-    * numpy_ >= 1.18.5
+    * Python_ >= 3.8
+    * numpy_ >= 1.19.5
     * quantities_ >= 0.12.1
 
 You can install the latest published version of Neo and its dependencies using::

--- a/neo/test/coretest/test_base.py
+++ b/neo/test/coretest/test_base.py
@@ -940,7 +940,7 @@ class TestBaseNeoNumpyArrayTypes(unittest.TestCase):
 
     def test_numpy_array_string0(self):
         '''test to make sure string0 type numpy arrays are accepted'''
-        value = np.array([1, 2, 3, 4, 5], dtype=np.strp)
+        value = np.array([1, 2, 3, 4, 5], dtype=np.str_)
         self.base.annotate(data=value)
         result = {'data': value}
         self.assertDictEqual(result, self.base.annotations)
@@ -1127,7 +1127,7 @@ class TestBaseNeoNumpyScalarTypes(unittest.TestCase):
 
     def test_numpy_scalar_string0(self):
         '''test to make sure string0 type numpy scalars are rejected'''
-        value = np.array(99, dtype=np.strp)
+        value = np.array(99, dtype=np.str_)
         self.base.annotate(data=value)
         result = {'data': value}
         self.assertDictEqual(result, self.base.annotations)

--- a/neo/test/coretest/test_base.py
+++ b/neo/test/coretest/test_base.py
@@ -781,16 +781,16 @@ class TestBaseNeoNumpyArrayTypes(unittest.TestCase):
         result = {'data': value}
         self.assertDictEqual(result, self.base.annotations)
 
-    def test_numpy_array_int0(self):
-        '''test to make sure int0 type numpy arrays are accepted'''
-        value = np.array([1, 2, 3, 4, 5], dtype=np.int0)
+    def test_numpy_array_intp(self):
+        '''test to make sure intp type numpy arrays are accepted'''
+        value = np.array([1, 2, 3, 4, 5], dtype=np.intp)
         self.base.annotate(data=value)
         result = {'data': value}
         self.assertDictEqual(result, self.base.annotations)
 
-    def test_numpy_array_uint0(self):
-        '''test to make sure uint0 type numpy arrays are accepted'''
-        value = np.array([1, 2, 3, 4, 5], dtype=np.uint0)
+    def test_numpy_array_uintp(self):
+        '''test to make sure uintp type numpy arrays are accepted'''
+        value = np.array([1, 2, 3, 4, 5], dtype=np.uintp)
         self.base.annotate(data=value)
         result = {'data': value}
         self.assertDictEqual(result, self.base.annotations)
@@ -940,7 +940,7 @@ class TestBaseNeoNumpyArrayTypes(unittest.TestCase):
 
     def test_numpy_array_string0(self):
         '''test to make sure string0 type numpy arrays are accepted'''
-        value = np.array([1, 2, 3, 4, 5], dtype=np.str0)
+        value = np.array([1, 2, 3, 4, 5], dtype=np.strp)
         self.base.annotate(data=value)
         result = {'data': value}
         self.assertDictEqual(result, self.base.annotations)
@@ -969,16 +969,16 @@ class TestBaseNeoNumpyScalarTypes(unittest.TestCase):
         result = {'data': value}
         self.assertDictEqual(result, self.base.annotations)
 
-    def test_numpy_scalar_int0(self):
-        '''test to make sure int0 type numpy scalars are accepted'''
-        value = np.array(99, dtype=np.int0)
+    def test_numpy_scalar_intp(self):
+        '''test to make sure intp type numpy scalars are accepted'''
+        value = np.array(99, dtype=np.intp)
         self.base.annotate(data=value)
         result = {'data': value}
         self.assertDictEqual(result, self.base.annotations)
 
-    def test_numpy_scalar_uint0(self):
-        '''test to make sure uint0 type numpy scalars are accepted'''
-        value = np.array(99, dtype=np.uint0)
+    def test_numpy_scalar_uintp(self):
+        '''test to make sure uintp type numpy scalars are accepted'''
+        value = np.array(99, dtype=np.uintp)
         self.base.annotate(data=value)
         result = {'data': value}
         self.assertDictEqual(result, self.base.annotations)
@@ -1127,7 +1127,7 @@ class TestBaseNeoNumpyScalarTypes(unittest.TestCase):
 
     def test_numpy_scalar_string0(self):
         '''test to make sure string0 type numpy scalars are rejected'''
-        value = np.array(99, dtype=np.str0)
+        value = np.array(99, dtype=np.strp)
         self.base.annotate(data=value)
         result = {'data': value}
         self.assertDictEqual(result, self.base.annotations)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 packaging
-numpy>=1.18.5
+numpy>=1.19.5
 quantities>=0.12.1

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Scientific/Engineering']
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 
 long_description = open("README.rst").read()
 install_requires = ['packaging',
-                    'numpy>=1.18.5',
+                    'numpy>=1.19.5',
                     'quantities>=0.12.1']
 extras_require = {
     'igorproio': ['igor'],
@@ -44,7 +44,7 @@ setup(
     long_description=long_description,
     license="BSD-3-Clause",
     url='https://neuralensemble.org/neo',
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
@@ -52,7 +52,6 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
- drop support for Python 3.7
- drop support for numpy 1.18