### PR TITLE
Fix caching of testing data in CI

### DIFF
--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -37,7 +37,7 @@ jobs:
         # the key depend on the last commit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git
         id: ephy_testing_data_hash
         run: |
-          echo "latest_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> GITHUB_OUTPUT
+          echo "latest_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         # Loading cache of ephys_testing_dataset


### PR DESCRIPTION
Currently the cached ephys data do not contain the latest hash in the caching key as the hash is not correctly forwarded to the github output variable.