### PR TITLE
Add a flag for intanrawio indicating whether intan hardware has already applied a notch filter to raw data

### DIFF
--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -333,6 +333,11 @@ def read_rhs(filename):
         if len(channels_by_type[sig_type]) > 0:
             name = {5: 'DIGITAL-IN', 6: 'DIGITAL-OUT'}[sig_type]
             data_dtype += [(name, 'uint16', BLOCK_SIZE)]
+           
+    if bool(global_info['notch_filter_mode']) and global_info['major_version'] >= 3:
+        global_info['notch_filter_applied'] = True
+    else:
+        global_info['notch_filter_applied'] = False
 
     return global_info, ordered_channels, data_dtype, header_size, BLOCK_SIZE
 
@@ -360,6 +365,7 @@ rhd_global_header_part1 = [
     ('desired_upper_bandwidth', 'float32'),
 
     ('notch_filter_mode', 'int16'),
+    
 
     ('desired_impedance_test_frequency', 'float32'),
     ('actual_impedance_test_frequency', 'float32'),
@@ -544,5 +550,10 @@ def read_rhd(filename):
         if len(channels_by_type[sig_type]) > 0:
             name = {4: 'DIGITAL-IN', 5: 'DIGITAL-OUT'}[sig_type]
             data_dtype += [(name, 'uint16', BLOCK_SIZE)]
-
+    
+    if bool(global_info['notch_filter_mode']) and version >= V('3.0'):
+        global_info['notch_filter_applied'] = True
+    else:
+        global_info['notch_filter_applied'] = False
+    
     return global_info, ordered_channels, data_dtype, header_size, BLOCK_SIZE

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -1,13 +1,13 @@
 """
 
-Support for intan tech rhd  and rhs files.
+Support for intan tech rhd and rhs files.
 
-This 2 formats are more or less the same but:
+These 2 formats are more or less the same but:
   * some variance in headers.
   * rhs amplifier is more complex because the optional DC channel
 
 RHS supported version 1.0
-RHD supported version  1.0 1.1 1.2 1.3 2.0
+RHD supported version  1.0 1.1 1.2 1.3 2.0 3.0, 3.1
 
 See:
   * http://intantech.com/files/Intan_RHD2000_data_file_formats.pdf

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -351,7 +351,6 @@ rhd_global_header_base = [
     ('minor_version', 'int16'),
 ]
 
-
 rhd_global_header_part1 = [
     ('sampling_rate', 'float32'),
 
@@ -366,7 +365,6 @@ rhd_global_header_part1 = [
 
     ('notch_filter_mode', 'int16'),
     
-
     ('desired_impedance_test_frequency', 'float32'),
     ('actual_impedance_test_frequency', 'float32'),
 


### PR DESCRIPTION
This is my first stab at incorporating a flag so that users can see whether or not their data has already had a notch filter applied. I couldn't think of a way to get it incorporated during the flow of the rest of the script, so I added the check right before the return to generate the flag.

@samuelgarcia 