### PR TITLE
Add joblib dependency

### DIFF
--- a/doc/source/developers_guide.rst
+++ b/doc/source/developers_guide.rst
@@ -41,6 +41,7 @@ Requirements
     * Python_ 3.8 or later
     * numpy_ >= 1.19.5
     * quantities_ >= 0.14.1
+    * joblib >= 1.2.0
     * pytest (for running tests)
     * Sphinx_ (for building documentation)
 

--- a/doc/source/developers_guide.rst
+++ b/doc/source/developers_guide.rst
@@ -41,7 +41,7 @@ Requirements
     * Python_ 3.8 or later
     * numpy_ >= 1.19.5
     * quantities_ >= 0.14.1
-    * joblib >= 1.2.0
+    * joblib >= 1.0.0
     * pytest (for running tests)
     * Sphinx_ (for building documentation)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "packaging",
     "numpy>=1.19.5",
     "quantities>=0.14.1",
+    "joblib>=1.2.0"
 ]
 
 [project.urls]
@@ -82,7 +83,7 @@ all = [
     "coveralls",
     "h5py",
     "igor",
-    "ipython",
+    "ipython",    
     "klusta",
     "matplotlib",
     "nixio>=1.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ all = [
     "coveralls",
     "h5py",
     "igor",
-    "ipython",    
+    "ipython",
     "klusta",
     "matplotlib",
     "nixio>=1.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "packaging",
     "numpy>=1.19.5",
     "quantities>=0.14.1",
-    "joblib>=1.2.0"
+    "joblib>=1.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
joblib is used in `BaseRawIO.__init__` and is a hard dependency if caching is used (#1224). I therefore added it to the project's dependencies.