### PR TITLE
Improve CI speed

### DIFF
--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -1,0 +1,111 @@
+name: Create caches for gin ecephys data and virtual env
+
+on:
+  workflow_dispatch: # Workflow can be triggered manually via GH actions webinterface
+  push:  # When something is pushed into master this checks if caches need to re-created
+    branches:
+      - master
+  schedule:
+    - cron: "0 12 * * *"  # Daily at noon UTC
+
+jobs:
+
+  create-conda-env-cache-if-missing:
+    name: Caching conda env
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: true
+    matrix:
+      python-version: [ '3.9',]
+    defaults:
+      # by default run in bash mode (required for conda usage)
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get current year-month
+        id: date
+        run: |
+          echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
+
+      - name: Get current dependencies hash
+        id: dependencies
+        run: |
+          echo "hash=${{hashFiles('**/pyproject.toml', '**/environment_testing.yml')}}" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        # the cache for python package is reset:
+        #   * every month
+        #   * when package dependencies change
+        id: cache-conda-env
+        with:
+          path: /usr/share/miniconda/envs/neo-test-env
+          key: ${{ runner.os }}-conda-env-${{ steps.dependencies.outputs.hash }}-${{ steps.date.outputs.date }}
+
+      - name: Cache found?
+        run: echo "Cache-hit == ${{steps.cache-conda-env.outputs.cache-hit == 'true'}}"
+
+      # activate environment if not restored from cache
+      - uses: conda-incubator/setup-miniconda@v2
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        with:
+          activate-environment: neo-test-env
+          python-version: ${{ matrix.python-version }}
+
+      - name: Create the conda environment to be cached
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        # create conda env, configure git and install pip, neo and test dependencies from master
+        # for PRs that change dependencies, this environment will be updated in the test workflow
+        run: |
+          conda env update neo-test-env --file environment_testing.yml
+          git config --global user.email "neo_ci@fake_mail.com"
+          git config --global user.name "neo CI"
+          python -m pip install -U pip  # Official recommended way
+          pip install --upgrade -e .
+          pip install .[test]
+
+  create-data-cache-if-missing:
+    name: Caching data env
+    runs-on: "ubuntu-latest"
+    steps:
+
+      - name: Get current hash (SHA) of the ephy_testing_data repo
+        id: ephy_testing_data
+        run: |
+          echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        # Loading cache of ephys_testing_dataset
+        id: cache-datasets
+        with:
+          path: ~/ephy_testing_data
+          key: ${{ runner.os }}-datasets-${{ steps.ephy_testing_data.outputs.dataset_hash }}
+
+      - name: Cache found?
+        run: echo "Cache-hit == ${{steps.cache-datasets.outputs.cache-hit == 'true'}}"
+
+      - name: Installing datalad and git-annex
+        if: steps.cache-datasets.outputs.cache-hit != 'true'
+        run: |
+          git config --global user.email "neo_ci@fake_mail.com"
+          git config --global user.name "neo CI"
+          python -m pip install -U pip  # Official recommended way
+          pip install datalad-installer
+          datalad-installer --sudo ok git-annex --method datalad/packages
+          pip install datalad
+          git config --global filter.annex.process "git-annex filter-process"  # recommended for efficiency
+
+      - name: Download dataset
+        if: steps.cache-datasets.outputs.cache-hit != 'true'
+        # Download repository and also fetch data
+        run: |
+          datalad install --recursive --get-data https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+
+      - name: Show size of the cache to assert data is downloaded
+        run: |
+          cd ~
+          pwd
+          du -hs ephy_testing_data
+          cd ephy_testing_data
+          pwd

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -58,6 +58,7 @@ jobs:
                 echo "CORE_CHANGED=true" >> $GITHUB_OUTPUT
               fi
             done
+          shell: bash  # Necessary for pipeline to work on windows
 
         - name: Core changed?
           run: echo "Core changed == ${{steps.modules-changed.outputs.CORE_CHANGED == 'true'}}"

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -40,7 +40,26 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v3
 
+        - name: Get changed files
+          id: changed-files
+          uses: tj-actions/changed-files@v35
+
+        - name: Module changes
+          id: modules-changed
+          # check if core (or toml) has been changed.
+          run: |
+            for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+              if [[ $file == *"/core/"* || $file == *"/pyproject.toml" ]]; then
+                echo "Core changed"
+                echo "CORE_CHANGED=true" >> $GITHUB_OUTPUT
+              fi
+            done
+
+      - name: Core changed?
+        run: echo "Core changed == ${{steps.modules-changed.outputs.CORE_CHANGED == 'true'}}"
+
         - name: Install numpy ${{ matrix.numpy-version }}
+          if: ${{ steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
           run: |
             python -m pip install --upgrade pip
             pip install numpy==${{ matrix.numpy-version }}
@@ -48,10 +67,12 @@ jobs:
             pip install .
 
         - name: List pip packages
+          if: ${{ steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
           run: |
             pip -V
             pip list
 
         - name: Run tests
+          if: ${{ steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
           run: |
             pytest --cov=neo neo/test/coretest

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -4,10 +4,16 @@ on:
   pull_request:
     branches: [master]
     types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - 'neo/core/**'
+      - 'pyproject.toml'
 
   # run checks on any change of master, including merge of PRs
   push:
     branches: [master]
+    paths:
+      - 'neo/core/**'
+      - 'pyproject.toml'
 
 concurrency: # Cancel previous workflows on the same pull request
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -44,27 +50,7 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v3
 
-        - name: Get changed files
-          id: changed-files
-          uses: tj-actions/changed-files@v35
-
-        - name: Module changes
-          id: modules-changed
-          # check if core (or toml) has been changed.
-          run: |
-            for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-              if [[ $file == *"/core/"* || $file == *"/pyproject.toml" ]]; then
-                echo "Core changed"
-                echo "CORE_CHANGED=true" >> $GITHUB_OUTPUT
-              fi
-            done
-          shell: bash  # Necessary for pipeline to work on windows
-
-        - name: Core changed?
-          run: echo "Core changed == ${{steps.modules-changed.outputs.CORE_CHANGED == 'true'}}"
-
         - name: Install numpy ${{ matrix.numpy-version }}
-          if: ${{ steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
           run: |
             python -m pip install --upgrade pip
             pip install numpy==${{ matrix.numpy-version }}
@@ -72,12 +58,10 @@ jobs:
             pip install .
 
         - name: List pip packages
-          if: ${{ steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
           run: |
             pip -V
             pip list
 
         - name: Run tests
-          if: ${{ steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
           run: |
             pytest --cov=neo neo/test/coretest

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -55,8 +55,8 @@ jobs:
               fi
             done
 
-      - name: Core changed?
-        run: echo "Core changed == ${{steps.modules-changed.outputs.CORE_CHANGED == 'true'}}"
+        - name: Core changed?
+          run: echo "Core changed == ${{steps.modules-changed.outputs.CORE_CHANGED == 'true'}}"
 
         - name: Install numpy ${{ matrix.numpy-version }}
           if: ${{ steps.modules-changed.outputs.CORE_CHANGED == 'true' }}

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -9,6 +9,10 @@ on:
   push:
     branches: [master]
 
+concurrency: # Cancel previous workflows on the same pull request
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   multi-os-python-numpy:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -11,9 +11,6 @@ on:
   # run checks on any change of master, including merge of PRs
   push:
     branches: [master]
-    paths:
-      - 'neo/core/**'
-      - 'pyproject.toml'
 
 concurrency: # Cancel previous workflows on the same pull request
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         # Loading cache of ephys_testing_dataset
         id: cache-datasets
         with:
@@ -59,7 +59,7 @@ jobs:
         run: |
           echo "hash=${{hashFiles('**/pyproject.toml', '**/environment_testing.yml')}}" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         # the cache for python package is reset:
         #   * every month
         #   * when package dependencies change

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           path: ~/ephy_testing_data
           key: ${{ runner.os }}-datasets-${{ steps.ephy_testing_data.outputs.dataset_hash }}
-          restore-key: ${{ runner.os }}-datasets-
+          restore-keys: ${{ runner.os }}-datasets-
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: [master]
 
+concurrency:  # Cancel previous workflows on the same pull request
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test:

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -35,34 +35,48 @@ jobs:
 
       - name: Get ephy_testing_data current head hash
         # the key depend on the last commit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git
-        id: ephy_testing_data_hash
+        id: ephy_testing_data
         run: |
-          echo "latest_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
+          echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         # Loading cache of ephys_testing_dataset
         id: cache-datasets
         with:
           path: ~/ephy_testing_data
-          key: ${{ runner.os }}-datasets-${{ steps.ephy_testing_data_hash.outputs.latest_hash }}
+          key: ${{ runner.os }}-datasets-${{ steps.ephy_testing_data.outputs.dataset_hash }}
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: neo-test-env
           python-version: ${{ matrix.python-version }}
-          clean-patched-environment-file: false
+
+      - name: Get current year-month
+        id: date
+        run: |
+          echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
+
+      - name: Get current dependencies hash
+        id: dependencies
+        run: |
+          echo "hash=${{hashFiles('**/pyproject.toml', '**/environment_testing.yml')}}" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         # the cache for python package is reset:
         #   * every month
-        #   * when requirements/requirements_testing change
+        #   * when package dependencies change
         id: cache-conda-env
         with:
           path: /usr/share/miniconda/envs/neo-test-env
-          key: ${{ runner.os }}-conda-env-${{ hashFiles('**/pyproject.toml') }}-${{ steps.date.outputs.date }}
+          key: ${{ runner.os }}-conda-env-${{ steps.dependencies.outputs.hash }}-${{ steps.date.outputs.date }}
+          # restore-keys match any key that starts with the restore-key
+          restore-keys: |
+            ${{ runner.os }}-conda-env-${{ steps.dependencies.outputs.hash }}-
+            ${{ runner.os }}-conda-env-
 
       - name: Install testing dependencies
-        # testing environment is only installed if no cache was found
+        # testing environment is only created from yml if no cache was found
+        # restore-key hits should result in `cache-hit` == 'false'
         if: steps.cache-conda-env.outputs.cache-hit != 'true'
         run: |
           conda env update neo-test-env --file environment_testing.yml
@@ -72,10 +86,19 @@ jobs:
           git config --global user.email "neo_ci@fake_mail.com"
           git config --global user.name "neo CI"
 
-      - name: Install neo
+      - name: Install neo including dependencies
+        # installation with dependencies is only required if no cache was found
+        # restore-key hits should result in `cache-hit` == 'false'
+        if: steps.cache-conda-env.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade -e .
           pip install .[test]
+
+      - name: Install neo without dependencies
+        # only installing neo version to test as dependencies should be in cached conda env already
+        if: steps.cache-conda-env.outputs.cache-hit == 'true'
+        run: |
+          pip install --no-dependencies -e .
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           path: ~/ephy_testing_data
           key: ${{ runner.os }}-datasets-${{ steps.ephy_testing_data.outputs.dataset_hash }}
+          restore-key: ${{ runner.os }}-datasets-
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -51,11 +51,6 @@ jobs:
           activate-environment: neo-test-env
           python-version: ${{ matrix.python-version }}
 
-      - name: Get current year-month
-        id: date
-        run: |
-          echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
-
       - name: Get current dependencies hash
         id: dependencies
         run: |


### PR DESCRIPTION
This PR introduces a dedicated cron job for cache creation to be used in IO tests, based on the CI tests in [spikeinterface](https://github.com/SpikeInterface/spikeinterface/blob/master/.github/workflows/caches_cron_job.yml).

It also reduces the number of tests run by executing Neo core tests only if core files or dependencies changed.

@samuelgarcia @h-mayorquin What do you think of this setup?
