### PR TITLE
added RAWDATAFILE to neuralynx type_of_recording

### DIFF
--- a/neo/rawio/neuralynxrawio/ncssections.py
+++ b/neo/rawio/neuralynxrawio/ncssections.py
@@ -438,7 +438,7 @@ class NcsSectionsFactory:
 
         # digital lynx style with fractional frequency and micros per samp determined from
         # block times
-        elif acqType == "DIGITALLYNX" or acqType == "DIGITALLYNXSX" or acqType == 'CHEETAH64':
+        elif acqType == "DIGITALLYNX" or acqType == "DIGITALLYNXSX" or acqType == 'CHEETAH64' or acqType == 'RAWDATAFILE':
             nomFreq = nlxHdr['sampling_rate']
             nb = NcsSectionsFactory._buildForMaxGap(ncsMemMap, nomFreq)
 

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -293,6 +293,10 @@ class NlxHeader(OrderedDict):
             # Cheetah64
             elif self['HardwareSubSystemType'] == 'Cheetah64':
                 return 'CHEETAH64'
+            
+            # RawDataFile
+            elif self['HardwareSubSystemType'] == 'RawDataFile':
+                return 'RAWDATAFILE'           
 
             else:
                 return 'UNKNOWN'


### PR DESCRIPTION
Neo didn't recognize the "RawDataFile" acquisition type in the header string. This is set when ".ncs" files are created by an offline replay of Neuralynx raw data (".nrd") files. 
I also commented on the bug in issue#1202