### PR TITLE
[NixIO] use OS independent datetime formatting

### DIFF
--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -630,7 +630,7 @@ class NixIO(BaseIO):
         metadata["neo_name"] = neoname
         nixblock.definition = block.description
         if block.rec_datetime:
-            nix_rec_dt = int(block.rec_datetime.strftime("%s"))
+            nix_rec_dt = int(block.rec_datetime.timestamp())
             nixblock.force_created_at(nix_rec_dt)
         if block.file_datetime:
             fdt, annotype = dt_to_nix(block.file_datetime)


### PR DESCRIPTION
The datetime formatter `%s` is not available on Windows systems, `int(datetime.timestamp())` yields the same information OS independently.