### PR TITLE
Fixed Documentation Typos

### DIFF
--- a/doc/source/core.rst
+++ b/doc/source/core.rst
@@ -191,7 +191,7 @@ Relationship:
 
 :download:`Click here for a better quality SVG diagram <./images/simple_generated_diagram.svg>`
 
-.. note:: This figure do not include :class:`ChannelView` and :class:`RegionOfInterest`.
+.. note:: This figure does not include :class:`ChannelView` and :class:`RegionOfInterest`.
 
 For more details, see the :doc:`api_reference`.
 

--- a/doc/source/developers_guide.rst
+++ b/doc/source/developers_guide.rst
@@ -146,7 +146,7 @@ example can be copied and pasted as-is.
 The documentation is written in `reStructuredText`_, using the `Sphinx`_
 documentation system. Any mention of another Neo module, class, attribute,
 method, or function should be properly marked up so automatic
-links can be generated.  The same goes for quantities or numpy.
+links can be generated.  The same goes for quantities or NumPy.
 
 To build the documentation::
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -114,7 +114,7 @@ Read a time slice of Segment
 
 Some objects support the ``time_slice`` argument in ``read_segment()``.
 This is useful to read only a subset of a dataset clipped in time.
-By default  ``time_slice=None`` meaning load everything.
+By default  ``time_slice=None`` will load everything.
 
 This reads everything::
 
@@ -130,7 +130,7 @@ This reads only the first 5 seconds::
 Lazy option and proxy objects
 =============================
 
-In some cases you may not want to load everything in memory because it could be too big.
+In some cases you may not want to load everything in memory (RAM) because it could be too big.
 For this scenario, some IOs implement ``lazy=True/False``.
 Since neo 0.7, a new lazy system has been added for some IO modules (all IO classes that inherit from rawio).
 To know if a class supports lazy mode use ``ClassIO.support_lazy``.
@@ -144,12 +144,12 @@ These proxy objects contain metadata (name, sampling_rate, id, ...) so they can 
 but they do not contain any array-like data.
 All proxy objects contain a ``load()`` method to postpone the real load of array like data.
 
-Further more the  ``load()`` method has a ``time_slice`` argument to load only a slice
+Furthermore the  ``load()`` method has a ``time_slice`` argument to load only a slice
 from the file. In this way the consumption of memory can be finely controlled.
 
 
 Here are two examples that read a dataset, extract sections of the signal based on recorded events,
-and averages the sections.
+and average the sections.
 
 The first example is without lazy mode, so it consumes more memory::
 
@@ -178,7 +178,7 @@ The second example uses lazy mode, so it consumes less memory::
     apply_my_fancy_average(all_sig_chunks)
 
 In addition to ``time_slice``, AnalogSignalProxy supports the ``channel_indexes`` argument.
-This allows loading only a subset of channels. This is useful where the channel count is very high.
+This allows loading only a subset of channels. This is useful when the channel count is very high.
 
  .. TODO: add something about magnitude mode when implemented for all objects.
 
@@ -295,7 +295,7 @@ For more complex logging, please see the documentation for the logging_ module.
 
 .. note:: If you wish to implement more advanced logging as describe in the documentation for the logging_ module or elsewhere on the internet, please do so before calling any :mod:`neo` functions or initializing any :mod:`neo` classes.
           This is because the default handler is created when :mod:`neo` is imported, but it is not attached to the :mod:`neo` logger until a class that uses logging is initialized or a function that uses logging is called.
-          Further, the handler is only attached if there are no handlers already attached to the root logger or the :mod:`neo` logger, so adding your own logger will override the default one.
+          Furthermore, the handler is only attached if there are no handlers already attached to the root logger or the :mod:`neo` logger, so adding your own logger will override the default one.
           Additional functions and/or classes may get logging during bugfix releases, so code relying on particular modules not having logging may break at any time without warning.
 
 .. _`logging`: https://docs.python.org/3/library/logging.html

--- a/doc/source/io_developers_guide.rst
+++ b/doc/source/io_developers_guide.rst
@@ -22,9 +22,9 @@ For read/write classes you can mix the two levels neo.rawio for reading and neo.
 
 Recipe to develop an IO module for a new data format:
     1. Fully understand the object model. See :doc:`core`. If in doubt ask the `mailing list`_.
-    2. Fully understand :mod:`neo.rawio.examplerawio`, It is a fake IO to explain the API. If in doubt ask the list.
+    2. Fully understand :mod:`neo.rawio.examplerawio`. It is a fake IO to explain the API. If in doubt ask the list.
     3. Copy/paste ``examplerawio.py`` and choose clear file and class names for your IO.
-    4. implement all methods that **raise(NotImplementedError)** in :mod:`neo.rawio.baserawio`. Return None when the object is not supported (spike/waveform)
+    4. Implement all methods that **raise(NotImplementedError)** in :mod:`neo.rawio.baserawio`. Return None when the object is not supported (spike/waveform)
     5. Write good docstrings. List dependencies, including minimum version numbers.
     6. Add your class to :mod:`neo.rawio.__init__`. Keep imports inside ``try/except`` for dependency reasons.
     7. Create a class in :file:`neo/io/`
@@ -52,9 +52,9 @@ To use these you need to upload some sample data files at `gin-gnode`_. They wil
 These tests:
 
   * check the compliance with the schema: hierarchy, attribute types, ...
-  * For IO modules able to both write and read data, it compares a generated dataset with the same data after a write/read cycle.
+  * For IO modules confirms it is able to both write and read data; they compare a generated dataset with the same data after a write/read cycle.
 
-The test scripts download all files from `gin-gnode`_ and stores them locally in ``/tmp/files_for_tests/``.
+The test scripts download all files from `gin-gnode`_ and store them locally in ``/tmp/files_for_tests/``.
 Subsequent test runs use the previously downloaded files, rather than trying to download them each time.
 
 Each test must have at least one class that inherits ``BaseTestRawIO`` and that has 3 attributes:
@@ -70,7 +70,7 @@ Here is an example test script taken from the distribution: :file:`test_axonrawi
 Logging
 =======
 
-All IO classes by default have logging using the standard :mod:`logging` module: already set up.
+All IO classes by default have logging using the standard :mod:`logging` module already set up.
 The logger name is the same as the fully qualified class name, e.g. :class:`neo.io.nixio.NixIO`.
 The :attr:`class.logger` attribute holds the logger for easy access.
 

--- a/doc/source/io_developers_guide.rst
+++ b/doc/source/io_developers_guide.rst
@@ -52,7 +52,7 @@ To use these you need to upload some sample data files at `gin-gnode`_. They wil
 These tests:
 
   * check for compliance with the schema: hierarchy, attribute types, ...
-  * For IO modules confirms they able to both write and read data; they compare a generated dataset with the same data after a write/read cycle.
+  * For IO modules confirm they able to both write and read data; they compare a generated dataset with the same data after a write/read cycle.
 
 The test scripts download all files from `gin-gnode`_ and store them locally in ``/tmp/files_for_tests/``.
 Subsequent test runs use the previously downloaded files, rather than trying to download them each time.

--- a/doc/source/io_developers_guide.rst
+++ b/doc/source/io_developers_guide.rst
@@ -51,8 +51,8 @@ Tests
 To use these you need to upload some sample data files at `gin-gnode`_. They will be publicly accessible for testing Neo.
 These tests:
 
-  * check the compliance with the schema: hierarchy, attribute types, ...
-  * For IO modules confirms it is able to both write and read data; they compare a generated dataset with the same data after a write/read cycle.
+  * check for compliance with the schema: hierarchy, attribute types, ...
+  * For IO modules confirms they able to both write and read data; they compare a generated dataset with the same data after a write/read cycle.
 
 The test scripts download all files from `gin-gnode`_ and store them locally in ``/tmp/files_for_tests/``.
 Subsequent test runs use the previously downloaded files, rather than trying to download them each time.

--- a/doc/source/io_developers_guide.rst
+++ b/doc/source/io_developers_guide.rst
@@ -54,7 +54,7 @@ These tests:
   * check for compliance with the schema: hierarchy, attribute types, ...
   * For IO modules confirm they able to both write and read data; they compare a generated dataset with the same data after a write/read cycle.
 
-The test scripts download all files from `gin-gnode`_ and store them locally in ``/tmp/files_for_tests/``.
+The test scripts download all files from `gin-gnode`_ and store them locally in ``<home>/ 'ephy_testing_data'``.
 Subsequent test runs use the previously downloaded files, rather than trying to download them each time.
 
 Each test must have at least one class that inherits ``BaseTestRawIO`` and that has 3 attributes:

--- a/doc/source/rawio.rst
+++ b/doc/source/rawio.rst
@@ -15,7 +15,7 @@ For performance and memory consumption reasons a new layer has been added to Neo
 In brief:
     * **neo.io** is the user-oriented read/write layer. Reading consists of getting a tree
       of Neo objects from a data source (file, url, or directory).
-      When  reading, all Neo objects are correctly scaled to the correct units.
+      When  reading, all Neo objects are scaled to the correct units.
       Writing consists of making a set of Neo objects persistent in a file format.
     * **neo.rawio** is a low-level layer for reading data only. Reading consists of getting
       NumPy buffers (often int16/int64) of signals/spikes/events.
@@ -34,9 +34,9 @@ also available in :mod:`neo.io`.
 
 Possible uses of the :mod:`neo.rawio` API are:
     * fast reading chunks of signals in int16 and do the scaling of units (uV)
-      on a GPU while scaling the zoom. This should improve bandwidth HD to RAM
-      and RAM to GPU memory.
-    * load only some small chunk of data for heavy computations. For instance
+      on a GPU while scaling the zoom. This should improve bandwidth from HD/SSD to RAM
+      and from RAM to GPU memory.
+    * load only a small chunk of data for heavy computations. For instance
       the spike sorting module tridesclous_ does this.
 
 
@@ -114,7 +114,7 @@ Read signal chunks of data and scale them::
 
 
 There are 3 ways to select a subset of channels: by index (0 based), by id or by name.
-By index is unambiguous 0 to n-1 (included), whereas for some IOs channel_names
+By index is unambiguous 0 to n-1 (inclusive), whereas for some IOs channel_names
 (and sometimes channel_ids) have no guarantees to
 be unique. In such cases, using names or ids may raise an error.
 

--- a/doc/source/rawio.rst
+++ b/doc/source/rawio.rst
@@ -15,7 +15,7 @@ For performance and memory consumption reasons a new layer has been added to Neo
 In brief:
     * **neo.io** is the user-oriented read/write layer. Reading consists of getting a tree
       of Neo objects from a data source (file, url, or directory).
-      When  reading, all Neo objects are scaled to the correct units.
+      When reading, all Neo objects are scaled to the correct units.
       Writing consists of making a set of Neo objects persistent in a file format.
     * **neo.rawio** is a low-level layer for reading data only. Reading consists of getting
       NumPy buffers (often int16/int64) of signals/spikes/events.


### PR DESCRIPTION
I just noticed a few typos on the documentation so just made  a few corrections.