### PR TITLE
Make joblib an optional dependency

### DIFF
--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -156,7 +156,6 @@ class BaseRawIO:
 
         self.use_cache = use_cache
         if use_cache:
-            import joblib
             self.setup_cache(cache_path)
         else:
             self._cache = None
@@ -697,7 +696,10 @@ class BaseRawIO:
         return self._rescale_epoch_duration(raw_duration, dtype, event_channel_index)
 
     def setup_cache(self, cache_path, **init_kargs):
-        import joblib
+        try:
+            import joblib
+        except ImportError:
+            raise ImportError("Using the RawIO cache needs joblib to be installed")
 
         if self.rawmode in ('one-file', 'multi-file'):
             resource_name = self.filename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ classifiers = [
 dependencies = [
     "packaging",
     "numpy>=1.19.5",
-    "quantities>=0.14.1",
-    "joblib>=1.0.0"
+    "quantities>=0.14.1"
 ]
 
 [project.urls]
@@ -40,6 +39,10 @@ requires = ["setuptools>=62.0"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
+
+iocache = [
+    "joblib>=1.0.0"
+]
 
 test = [
     "pytest",
@@ -60,6 +63,7 @@ test = [
     "sonpy",
     "pynwb",
     "probeinterface",
+    "joblib>=1.0.0"
 ]
 
 docs = [
@@ -96,5 +100,6 @@ all = [
     "scipy>=1.0.0",
     "sonpy",
     "tqdm",
+    "joblib>=1.0.0"
 ]
 # we do not include 'stfio' in 'all' as it is not pip installable


### PR DESCRIPTION
Since we only use a single feature of joblib, and in only one place, where it is optional, I thought it would be better not to install it by default.