### PR TITLE
Gain on Sync channel missing from NP2.0 probes (Spikeglx)

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -404,7 +404,7 @@ def extract_stream_info(meta_file, meta):
             # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_20.md#channel-entries-by-type
             # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_20.md#imec
             # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_30.md#imec
-            per_channel_gain[:-1] = 1 / 80.
+            per_channel_gain[:] = 1 / 80.
             gain_factor = float(meta['imAiRangeMax']) / 8192
             channel_gains = gain_factor * per_channel_gain * 1e6
         else:


### PR DESCRIPTION
The gain on NP2.0 is fixed at 80 and applied in `per_channel_gain[:-1] = 1 / 80.` in spikeglxrawio.py.

However, I just tested against a NP2 (1-shank) file using the syn channel and the scaling was not correct for the sync channel (as compared to SpikeGLX (output saved in .csv).

Changing the above line to include the sync channel: `per_channel_gain[:] = 1 / 80.` aligned with SpikeGLX scaling and passes the test on the file I have.