### PR TITLE
memmap refactoring

### DIFF
--- a/neo/rawio/utils.py
+++ b/neo/rawio/utils.py
@@ -1,0 +1,34 @@
+import mmap
+import numpy as np
+
+def get_memmap_shape(filename, dtype, num_channels=None, offset=0):
+    dtype = np.dtype(dtype)
+    with open(filename, mode='rb') as f:
+        f.seek(0, 2)
+        flen = f.tell()
+        bytes = flen - offset
+        if bytes % dtype.itemsize != 0:
+            raise ValueError("Size of available data is not a multiple of the data-type size.")
+        size = bytes // dtype.itemsize
+        if num_channels is None:
+            shape = (size,)
+        else:
+            shape = (size // num_channels, num_channels)
+        return shape
+
+def create_memmap_buffer(fid, shape, dtype, offset=0):
+    """
+    A function that mimic the np.memmap but:
+      * use an already opened file as input without checking the file size.
+      * it handles also only the ready only case
+    This should be faster.
+    """
+    dtype = np.dtype(dtype)
+    size = np.prod(shape, dtype='int64')
+    bytes = dtype.itemsize * size
+    start = offset - offset % mmap.ALLOCATIONGRANULARITY
+    bytes -= start
+    array_offset = offset - start
+    mmap_buffer = mmap.mmap(fid.fileno(), bytes, access=mmap.ACCESS_READ, offset=start)
+    arr = np.ndarray.__new__(np.ndarray, shape, dtype=dtype, buffer=mmap_buffer, offset=array_offset, order='c')
+    return arr


### PR DESCRIPTION
This is a proposal to change the actual memap behavior in rawio layer.

spikeinterface use neo.rawio a lot with extenssive IO demand with parralel read/computing.
Many users experience big memmory saturation even on big machine when the file are enormous.
This quite a bit OS dependant, mainly windows but even some linux have this problem).
Somehow, the memmap do not release page after the use of one buffer and so the memory increase forever.

The actual strategy we now have in almost all IO when it is binary base :
 1. In  parse_header, open one or several numpy.memmap object and set then as attribute or nested dict
 2. In get_analogsignal_chunk : lazly fetch buffer via numpy slicing using this memmap arrays
After consumming the traces chunk the memory should be relased and so the memmory usage should low but in fact in some case it increase until saturating.

@h-mayorquin and @samuelgarcia made some benchmark to find a better strategy.
Here some code examples:
https://gist.github.com/h-mayorquin/8b8d1899c724690ce7c18fb49f56af82

The best strategy we find to try to fix is:
  1. In the parse header, open the file with mode='rb'
  2. In get_analogsignal_chunk : create a new memmap object using the opened file

For the 2. we mimic the numpy.memmap but a but simplify to be faster.
The speed of reading is almost the same and the memory problem seems to be fixed.



@maxjuv @TomBugnon @vncntprvst @juliencarponcy: we need more tests!
I started to change spikeglx and openephysrawbinary.
Could you try to combine this branch and also this [PR on spikeinterface](https://github.com/SpikeInterface/spikeinterface/pull/1602)
And then:
  * read a recording with read_spikeglx() or read_openephys()
  * make a simple preprocessing
  * rec.save(folder=folder, n_jobs=64, chunk_duration='1s', progress_bar=True)
And monitor the memory usage.
Do you still have an infinite memory increase or not ?





