### PR TITLE
Remove reference to all_data property in docstring of class Segment

### DIFF
--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -61,9 +61,6 @@ class Segment(Container):
     Note: Any other additional arguments are assumed to be user-specific
     metadata and stored in :attr:`annotations`.
 
-    *Properties available on this object*:
-        :all_data: (list) A list of all child objects in the :class:`Segment`.
-
     *Container of*:
         :class:`Epoch`
         :class:`Event`


### PR DESCRIPTION
This PR removes the reference to the `all_data` property in the docstring of the neo.core.Segment class. 
https://github.com/NeuralEnsemble/python-neo/blob/ac0d9e6fab1094226610603099b635a7bf53d230/neo/core/segment.py#L65
In pull request #143, the `all_data` property was removed from the class, but the description of the property remained in the docstring. This could be confusing for users who come across the docstring and try to use the all_data property, which is no longer available.

This change does not affect the functionality of the code, but it will improve the clarity and accuracy of the documentation, which is why I considered to add this here.

Feel free to close this PR any time, this is just meant to inform you about this finding. :slightly_smiling_face: 