### PR TITLE
Use igor2 in place of igor

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -25,7 +25,7 @@ Neo will still install but the IO module that uses them will fail on loading:
    * scipy >= 1.0.0 for NeoMatlabIO
    * h5py >= 2.5 for KwikIO
    * klusta for KwikIO
-   * igor >= 0.2 for IgorIO
+   * igor2 >= 0.5.2 for IgorIO
    * nixio >= 1.5 for NixIO
    * stfio for StimfitIO
    * pillow for TiffIO

--- a/neo/io/igorproio.py
+++ b/neo/io/igorproio.py
@@ -2,7 +2,7 @@
 Class for reading data created by IGOR Pro
 (WaveMetrics, Inc., Portland, OR, USA)
 
-Depends on: igor (https://pypi.python.org/pypi/igor/)
+Depends on: igor2 (https://pypi.python.org/pypi/igor2/)
 
 Supported: Read
 
@@ -25,7 +25,7 @@ class IgorIO(BaseIO):
     or Packed Experiment (.pxp) files written by WaveMetrics’
     IGOR Pro software.
 
-    It requires the `igor` Python package by W. Trevor King.
+    It requires the `igor2` Python package.
 
     Usage:
         >>> from neo import io
@@ -76,8 +76,8 @@ class IgorIO(BaseIO):
         return block
 
     def read_segment(self, lazy=False):
-        import igor.packed as pxp
-        from igor.record.wave import WaveRecord
+        import igor2.packed as pxp
+        from igor2.record.wave import WaveRecord
 
         assert not lazy, 'This IO does not support lazy mode'
         segment = Segment(file_origin=str(self.filename))
@@ -100,8 +100,8 @@ class IgorIO(BaseIO):
         return segment
 
     def read_analogsignal(self, path=None, lazy=False):
-        import igor.binarywave as bw
-        import igor.packed as pxp
+        import igor2.binarywave as bw
+        import igor2.packed as pxp
 
         assert not lazy, 'This IO does not support lazy mode'
 

--- a/neo/test/iotest/test_igorio.py
+++ b/neo/test/iotest/test_igorio.py
@@ -5,7 +5,7 @@ Tests of neo.io.igorproio
 import unittest
 
 try:
-    import igor
+    import igor2
 
     HAVE_IGOR = True
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ test = [
     "scipy>=1.0.0",
     "pyedflib",
     "h5py",
-    "igor",
+    "igor2",
     "klusta",
     "tqdm",
     "nixio",
@@ -66,7 +66,7 @@ docs = [
     "docutils<0.18",
 ]
 
-igorproio = ["igor"]
+igorproio = ["igor2"]
 kwikio = ["klusta"]
 neomatlabio = ["scipy>=1.0.0"]
 nixio = ["nixio>=1.5.0"]
@@ -82,7 +82,7 @@ all = [
     "coverage",
     "coveralls",
     "h5py",
-    "igor",
+    "igor2",
     "ipython",
     "klusta",
     "matplotlib",


### PR DESCRIPTION
Because the latter is no longer maintained, and produces errors with recent versions of NumPy