### PR TITLE
Remove pickle python 2 library

### DIFF
--- a/neo/io/pickleio.py
+++ b/neo/io/pickleio.py
@@ -10,10 +10,8 @@ Supported: Read/Write
 Authors: Andrew Davison
 """
 
-try:
-    import cPickle as pickle  # Python 2
-except ImportError:
-    import pickle  # Python 3
+
+import pickle  # Python 3
 
 from neo.io.baseio import BaseIO
 from neo.core import (Block, Segment,

--- a/neo/io/pickleio.py
+++ b/neo/io/pickleio.py
@@ -11,7 +11,7 @@ Authors: Andrew Davison
 """
 
 
-import pickle  # Python 3
+import pickle
 
 from neo.io.baseio import BaseIO
 from neo.core import (Block, Segment,


### PR DESCRIPTION
I encountered this today while debuggin some issue.

Python 2 is long gone:
https://devguide.python.org/versions/