### PR TITLE
[AsciiIO] Fix handling of handle channel index array annotations

### DIFF
--- a/neo/io/asciisignalio.py
+++ b/neo/io/asciisignalio.py
@@ -39,7 +39,7 @@ class AsciiSignalIO(BaseIO):
             column delimiter in file, e.g. '\t', one space, two spaces, ',', ';'
         timecolumn:
             None or a valid integer that identifies which column contains the time vector
-            (counting from zero, within the list of selected columns, see also `usecols` Argument)
+            (counting from zero, within the list of selected columns, see also `usecols` argument)
         units:
             units of AnalogSignal can be a str or directly a Quantity
         time_units:

--- a/neo/io/asciisignalio.py
+++ b/neo/io/asciisignalio.py
@@ -39,7 +39,7 @@ class AsciiSignalIO(BaseIO):
             column delimiter in file, e.g. '\t', one space, two spaces, ',', ';'
         timecolumn:
             None or a valid integer that identifies which column contains the time vector
-            (counting from zero)
+            (counting from zero, within the list of selected columns, see also `usecols` Argument)
         units:
             units of AnalogSignal can be a str or directly a Quantity
         time_units:
@@ -251,6 +251,8 @@ class AsciiSignalIO(BaseIO):
             t_start = sig[0, self.timecolumn] * self.time_units
 
         if self.signal_group_mode == 'all-in-one':
+            channel_index_annotation = self.usecols or np.arange(sig.shape[1])
+            channel_index_annotation = np.asarray(channel_index_annotation)
             if self.timecolumn is not None:
                 mask = list(range(sig.shape[1]))
                 if self.timecolumn >= 0:
@@ -258,6 +260,7 @@ class AsciiSignalIO(BaseIO):
                 else:  # allow negative column index
                     mask.remove(sig.shape[1] + self.timecolumn)
                 signal = sig[:, mask]
+                channel_index_annotation = channel_index_annotation[mask]
             else:
                 signal = sig
             if sampling_rate is None:
@@ -269,7 +272,7 @@ class AsciiSignalIO(BaseIO):
                 ana_sig = AnalogSignal(signal * self.units, sampling_rate=sampling_rate,
                                        t_start=t_start,
                                        name='multichannel')
-                ana_sig.array_annotate(channel_index=self.usecols or np.arange(signal.shape[1]))
+                ana_sig.array_annotate(channel_index=channel_index_annotation)
                 seg.analogsignals.append(ana_sig)
         else:
             if self.timecolumn is not None and self.timecolumn < 0:

--- a/neo/test/iotest/test_asciisignalio.py
+++ b/neo/test/iotest/test_asciisignalio.py
@@ -61,7 +61,9 @@ class TestAsciiSignalIO(unittest.TestCase):
             for row in sample_data:
                 writer.writerow(row)
 
-        io = AsciiSignalIO(filename, usecols=(0, 1, 3), timecolumn=2,
+        usecols = (0, 1, 3)
+        timecolumn = 2
+        io = AsciiSignalIO(filename, usecols=usecols, timecolumn=timecolumn,
                            # note that timecolumn applies to the remaining columns
                            # after applying usecols
                            time_units="ms", delimiter=',', units="mV", method='csv',
@@ -75,6 +77,11 @@ class TestAsciiSignalIO(unittest.TestCase):
                                   np.array(sample_data)[:, 1],
                                   decimal=5)
         self.assertAlmostEqual(signal.sampling_period, 0.1 * pq.ms)
+
+        expected_channel_index = list(usecols)
+        # remove time column as it is not loaded as signal channel
+        expected_channel_index.pop(timecolumn)
+        assert_array_equal(expected_channel_index, signal.array_annotations['channel_index'])
 
         os.remove(filename)
     # test_csv_expect_failure


### PR DESCRIPTION
This PR clarifies the relation between `timecolumn` and `usecol` and covers the case in which `timecolumn` is included in `usecol`. In this case the time column channel index does not require to be annotated. This leads to incorrect dimensions of the array annotations in the current master branch.