### PR TITLE
Accept array_annotation values of tuple type

### DIFF
--- a/neo/core/dataobject.py
+++ b/neo/core/dataobject.py
@@ -20,7 +20,7 @@ def _normalize_array_annotations(value, length):
 
     Parameters
     ----------
-    value : np.ndarray or list or dict
+    value : np.ndarray or list or tuple or dict
         Value to be checked for consistency.
     length : int
         Required length of the array annotation.
@@ -48,7 +48,7 @@ def _normalize_array_annotations(value, length):
         raise ValueError("Array annotations must not be None")
     # If not array annotation, pass on to regular check and make it a list, that is checked again
     # This covers array annotations with length 1
-    elif not isinstance(value, (list, np.ndarray)) or (
+    elif not isinstance(value, (list, np.ndarray, tuple)) or (
             isinstance(value, pq.Quantity) and value.shape == ()):
         _check_annotations(value)
         value = _normalize_array_annotations(np.array([value]), length)

--- a/neo/test/coretest/test_dataobject.py
+++ b/neo/test/coretest/test_dataobject.py
@@ -79,6 +79,12 @@ class Test_array_annotations(unittest.TestCase):
         self.assertIsInstance(list_ann['anno1'], np.ndarray)
         self.assertIsInstance(list_ann['anno2'], np.ndarray)
 
+        # Tuple are also made to np.ndarrays
+        list_ann = {'anno1': (3, 6), 'anno2': ('ABC', 'DEF')}
+        list_ann = _normalize_array_annotations(list_ann, datobj._get_arr_ann_length())
+        self.assertIsInstance(list_ann['anno1'], np.ndarray)
+        self.assertIsInstance(list_ann['anno2'], np.ndarray)
+
     def test_implicit_dict_check(self):
         # DataObject instance that handles checking
         datobj = DataObject([1, 2])  # Inherits from Quantity, so some data is required


### PR DESCRIPTION
Currently annotations do accept values of type `tuple`, but array annotations don't. This PR adds tuples to the accepted type of data for the creation of array annotations.