### PR TITLE
Fix DeprecationWarning during Testing due to invalid escape character

### DIFF
--- a/neo/rawio/alphaomegarawio.py
+++ b/neo/rawio/alphaomegarawio.py
@@ -4,9 +4,9 @@ This module implements file reader for AlphaOmega MPX file format version 4.
 This module expect default channel names from the AlphaOmega record system (RAW
 ###, SPK ###, LFP ###, AI ###,…).
 
-This module reads all \*.mpx files in a directory (not recursively) by default.
-If you provide a list of \*.lsx files only the \*.mpx files referenced by those
-\*.lsx files will be loaded.
+This module reads all *.mpx files in a directory (not recursively) by default.
+If you provide a list of *.lsx files only the *.mpx files referenced by those
+*.lsx files will be loaded.
 
 The specifications are mostly extracted from the "AlphaRS User Manual V1.0.1.pdf"
 manual provided with the AlphaRS hardware. The specifications are described in


### PR DESCRIPTION
When running pytest I keep getting this:

``` python
\neo\rawio\alphaomegarawio.py:1: DeprecationWarning: invalid escape sequence \*
```

So this is a pull request just to fix the docstring. It is the only DeprecationWarning I'm getting currently so should be an easy fix.