### PR TITLE
Fixed a few typos in ExampleRawIO

### DIFF
--- a/neo/rawio/examplerawio.py
+++ b/neo/rawio/examplerawio.py
@@ -58,7 +58,7 @@ class ExampleRawIO(BaseRawIO):
     This fake IO:
         * has 2 blocks
         * blocks have 2 and 3 segments
-        * has  2 signals streams  of 8 channel each (sample_rate = 10000) so 16 channels in total
+        * has  2 signals streams  of 8 channels each (sample_rate = 10000) so 16 channels in total
         * has 3 spike_channels
         * has 2 event channels: one has *type=event*, the other has
           *type=epoch*
@@ -100,9 +100,9 @@ class ExampleRawIO(BaseRawIO):
         # information required for fast access
         # at any place in the file
         # In short `_parse_header()` can be slow but
-        # `_get_analogsignal_chunk()` need to be as fast as possible
+        # `_get_analogsignal_chunk()` needs to be as fast as possible
 
-        # create fake signals stream information
+        # create fake signal streams information
         signal_streams = []
         for c in range(2):
             name = f'stream {c}'
@@ -110,7 +110,7 @@ class ExampleRawIO(BaseRawIO):
             signal_streams.append((name, stream_id))
         signal_streams = np.array(signal_streams, dtype=_signal_stream_dtype)
 
-        # create fake signals channels information
+        # create fake signal channels information
         # This is mandatory!!!!
         # gain/offset/units are really important because
         # the scaling to real value will be done with that
@@ -121,7 +121,7 @@ class ExampleRawIO(BaseRawIO):
             # our channel id is c+1 just for fun
             # Note that chan_id should be related to
             # original channel id in the file format
-            # so that the end user should not be lost when reading datasets
+            # so that the end user should not be confused when reading datasets
             chan_id = c + 1
             sr = 10000.  # Hz
             dtype = 'int16'
@@ -129,7 +129,7 @@ class ExampleRawIO(BaseRawIO):
             gain = 1000. / 2 ** 16
             offset = 0.
             # stream_id indicates how to group channels
-            # channels inside a "stream" share same characteristics
+            # channels inside a "stream" share the same characteristics
             #  (sampling rate/dtype/t_start/units/...)
             stream_id = str(c // 8)
             signal_channels.append((ch_name, chan_id, sr, dtype, units, gain, offset, stream_id))
@@ -142,7 +142,7 @@ class ExampleRawIO(BaseRawIO):
         # will be generated per Segment.
         signal_channels[-2:]['units'] = 'pA'
 
-        # create fake units channels
+        # create fake unit channels
         # This is mandatory!!!!
         # Note that if there is no waveform at all in the file
         # then wf_units/wf_gain/wf_offset/wf_left_sweep/wf_sampling_rate
@@ -163,13 +163,13 @@ class ExampleRawIO(BaseRawIO):
 
         # creating event/epoch channel
         # This is mandatory!!!!
-        # In RawIO epoch and event they are dealt the same way.
+        # In RawIO epoch and event are dealt with in the same way.
         event_channels = []
         event_channels.append(('Some events', 'ev_0', 'event'))
         event_channels.append(('Some epochs', 'ep_1', 'epoch'))
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)
 
-        # fille into header dict
+        # fill information into the header dict
         # This is mandatory!!!!!
         self.header = {}
         self.header['nb_block'] = 2
@@ -187,7 +187,7 @@ class ExampleRawIO(BaseRawIO):
         # `_generate_minimal_annotations()` must be called to generate the nested
         # dict of annotations/array_annotations
         self._generate_minimal_annotations()
-        # this pprint lines really help for understand the nested (and complicated sometimes) dict
+        # this pprint lines really help with understanding the nested (and sometimes complicated) dict
         # from pprint import pprint
         # pprint(self.raw_annotations)
 
@@ -229,14 +229,14 @@ class ExampleRawIO(BaseRawIO):
                         event_an['nickname'] = 'MrEpoch 1'
 
     def _segment_t_start(self, block_index, seg_index):
-        # this must return an float scale in second
-        # this t_start will be shared by all object in the segment
+        # this must return a float scaled in seconds
+        # this t_start will be shared by all objects in the segment
         # except AnalogSignal
         all_starts = [[0., 15.], [0., 20., 60.]]
         return all_starts[block_index][seg_index]
 
     def _segment_t_stop(self, block_index, seg_index):
-        # this must return an float scale in second
+        # this must return a float scaled in seconds
         all_stops = [[10., 25.], [10., 30., 70.]]
         return all_stops[block_index][seg_index]
 
@@ -245,20 +245,20 @@ class ExampleRawIO(BaseRawIO):
         # across all segments (10.0 seconds)
         # This is not the case for real data, instead you should return the signal
         # size depending on the block_index and segment_index
-        # this must return an int = the number of sample
+        # this must return an int = the number of samples
 
         # Note that channel_indexes can be ignored for most cases
-        # except for several sampling rate.
+        # except for the case of several sampling rates.
         return 100000
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
-        # This give the t_start of signals.
-        # Very often this equal to _segment_t_start but not
+        # This give the t_start of a signal.
+        # Very often this is equal to _segment_t_start but not
         # always.
-        # this must return an float scale in second
+        # this must return a float scaled in seconds
 
         # Note that channel_indexes can be ignored for most cases
-        # except for several sampling rate.
+        # except for the case of several sampling rates.
 
         # Here this is the same.
         # this is not always the case
@@ -271,11 +271,11 @@ class ExampleRawIO(BaseRawIO):
         # channel_indexes can be None (=all channel in the stream) or a list or numpy.array
         # This must return a numpy array 2D (even with one channel).
         # This must return the original dtype. No conversion here.
-        # This must as fast as possible.
+        # This must be as fast as possible.
         # To speed up this call all preparatory calculations should be implemented
         # in _parse_header().
 
-        # Here we are lucky:  our signals is always zeros!!
+        # Here we are lucky:  our signals are always zeros!!
         # it is not always the case :)
         # internally signals are int16
         # conversion to real units is done with self.header['signal_channels']
@@ -286,7 +286,7 @@ class ExampleRawIO(BaseRawIO):
             i_stop = 100000
 
         if i_start < 0 or i_stop > 100000:
-            # some check
+            # some checks
             raise IndexError("I don't like your jokes")
 
         if channel_indexes is None:
@@ -334,8 +334,8 @@ class ExampleRawIO(BaseRawIO):
         return spike_timestamps
 
     def _rescale_spike_timestamp(self, spike_timestamps, dtype):
-        # must rescale to second a particular spike_timestamps
-        # with a fixed dtype so the user can choose the precision he want.
+        # must rescale to seconds, a particular spike_timestamps
+        # with a fixed dtype so the user can choose the precision they want.
         spike_times = spike_timestamps.astype(dtype)
         spike_times /= 10000.  # because 10kHz
         return spike_times
@@ -355,7 +355,7 @@ class ExampleRawIO(BaseRawIO):
         # conversion to real units is done with self.header['spike_channels']
         # Here, we have a realistic case: all waveforms are only noise.
         # it is not always the case
-        # we 20 spikes with a sweep of 50 (5ms)
+        # we get 20 spikes with a sweep of 50 (5ms)
 
         # trick to get how many spike in the slice
         ts = self._get_spike_timestamps(block_index, seg_index,
@@ -379,11 +379,11 @@ class ExampleRawIO(BaseRawIO):
 
     def _get_event_timestamps(self, block_index, seg_index, event_channel_index, t_start, t_stop):
         # the main difference between spike channel and event channel
-        # is that for here we have 3 numpy array timestamp, durations, labels
+        # is that for event channels we have 3D numpy array (timestamp, durations, labels) where
         # durations must be None for 'event'
         # label must a dtype ='U'
 
-        # in our IO event are directly coded in seconds
+        # in our IO events are directly coded in seconds
         seg_t_start = self._segment_t_start(block_index, seg_index)
         if event_channel_index == 0:
             timestamp = np.arange(0, 6, dtype='float64') + seg_t_start
@@ -409,14 +409,14 @@ class ExampleRawIO(BaseRawIO):
         return timestamp, durations, labels
 
     def _rescale_event_timestamp(self, event_timestamps, dtype, event_channel_index):
-        # must rescale to second a particular event_timestamps
-        # with a fixed dtype so the user can choose the precision he want.
+        # must rescale to seconds for a particular event_timestamps
+        # with a fixed dtype so the user can choose the precision they want.
 
-        # really easy here because in our case it is already seconds
+        # really easy here because in our case it is already in seconds
         event_times = event_timestamps.astype(dtype)
         return event_times
 
     def _rescale_epoch_duration(self, raw_duration, dtype, event_channel_index):
-        # really easy here because in our case it is already seconds
+        # really easy here because in our case it is already in seconds
         durations = raw_duration.astype(dtype)
         return durations


### PR DESCRIPTION
Was checking out the new documentation--theme looks great by the way and saw a few typos.  This just fixes those.