### PR TITLE
[NixIO] Relax criteria for float comparison

### DIFF
--- a/neo/test/iotest/test_nixio.py
+++ b/neo/test/iotest/test_nixio.py
@@ -138,7 +138,7 @@ class NixIOTest(unittest.TestCase):
                 neosp = neosig.sampling_period
                 nixsp = create_quantity(timedim.sampling_interval,
                                         timedim.unit)
-                self.assertEqual(neosp, nixsp)
+                self.assertAlmostEqual(neosp, nixsp)
                 tsunit = timedim.unit
                 if "t_start.units" in da.metadata.props:
                     tsunit = da.metadata["t_start.units"]


### PR DESCRIPTION
The float comparison seems to fail only on GH actions. This solves #1277.

@samuelgarcia Can you have a look and merge this together with #1274 to not have failing CI tests in master any more?