### PR TITLE
update get_io to return ios for files that do not exist yet

### DIFF
--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -429,7 +429,7 @@ def list_candidate_ios(file_or_folder, ignore_patterns=['*.ini', 'README.txt', '
     """
     file_or_folder = pathlib.Path(file_or_folder)
 
-    if file_or_folder.suffix:
+    if file_or_folder.is_file():
         suffix = file_or_folder.suffix[1:].lower()
         if suffix not in io_by_extension:
             raise ValueError(f'{suffix} is not a supported format of any IO.')
@@ -452,6 +452,12 @@ def list_candidate_ios(file_or_folder, ignore_patterns=['*.ini', 'README.txt', '
     # to select all files sharing the `session1-` prefix
     elif file_or_folder.parent.exists():
         filenames = file_or_folder.parent.glob(file_or_folder.name + '*')
+
+    elif file_or_folder.suffix:
+        suffix = file_or_folder.suffix[1:].lower()
+        if suffix not in io_by_extension:
+            raise ValueError(f'{suffix} is not a supported format of any IO.')
+        return io_by_extension[suffix]
     
     else:
         raise ValueError(f'{file_or_folder} does not contain data files of a supported format')

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -429,7 +429,7 @@ def list_candidate_ios(file_or_folder, ignore_patterns=['*.ini', 'README.txt', '
     """
     file_or_folder = pathlib.Path(file_or_folder)
 
-    if file_or_folder.suffix:
+    if file_or_folder.is_file():
         suffix = file_or_folder.suffix[1:].lower()
         if suffix not in io_by_extension:
             raise ValueError(f'{suffix} is not a supported format of any IO.')
@@ -453,6 +453,12 @@ def list_candidate_ios(file_or_folder, ignore_patterns=['*.ini', 'README.txt', '
     elif file_or_folder.parent.exists():
         filenames = file_or_folder.parent.glob(file_or_folder.name + '*')
 
+    elif file_or_folder.suffix:
+        suffix = file_or_folder.suffix[1:].lower()
+        if suffix not in io_by_extension:
+            raise ValueError(f'{suffix} is not a supported format of any IO.')
+        return io_by_extension[suffix]
+    
     else:
         raise ValueError(f'{file_or_folder} does not contain data files of a supported format')
 

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -429,7 +429,7 @@ def list_candidate_ios(file_or_folder, ignore_patterns=['*.ini', 'README.txt', '
     """
     file_or_folder = pathlib.Path(file_or_folder)
 
-    if file_or_folder.is_file():
+    if file_or_folder.suffix:
         suffix = file_or_folder.suffix[1:].lower()
         if suffix not in io_by_extension:
             raise ValueError(f'{suffix} is not a supported format of any IO.')
@@ -452,12 +452,6 @@ def list_candidate_ios(file_or_folder, ignore_patterns=['*.ini', 'README.txt', '
     # to select all files sharing the `session1-` prefix
     elif file_or_folder.parent.exists():
         filenames = file_or_folder.parent.glob(file_or_folder.name + '*')
-
-    elif file_or_folder.suffix:
-        suffix = file_or_folder.suffix[1:].lower()
-        if suffix not in io_by_extension:
-            raise ValueError(f'{suffix} is not a supported format of any IO.')
-        return io_by_extension[suffix]
     
     else:
         raise ValueError(f'{file_or_folder} does not contain data files of a supported format')

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -452,12 +452,22 @@ def list_candidate_ios(file_or_folder, ignore_patterns=['*.ini', 'README.txt', '
     # to select all files sharing the `session1-` prefix
     elif file_or_folder.parent.exists():
         filenames = list(file_or_folder.parent.glob(file_or_folder.name + '*'))
+        # if filenames empty and suffix is provided then non-existent file
+        # may be written in current dir. So run check for io
         if len(filenames)==0 and file_or_folder.suffix:
             suffix = file_or_folder.suffix[1:].lower()
             if suffix not in io_by_extension:
                 raise ValueError(f'{suffix} is not a supported format of any IO.')
             return io_by_extension[suffix]
 
+    # If non-existent file in non-existent dir is given check if this 
+    # structure could be created with an io writing the file
+    elif file_or_folder.suffix:
+        suffix = file_or_folder.suffix[1:].lower()
+        if suffix not in io_by_extension:
+            raise ValueError(f'{suffix} is not a supported format of any IO.')
+        return io_by_extension[suffix]
+    
     else:
         raise ValueError(f'{file_or_folder} does not contain data files of a supported format')
 

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -451,14 +451,13 @@ def list_candidate_ios(file_or_folder, ignore_patterns=['*.ini', 'README.txt', '
     # if only file prefix was provided, e.g /mydatafolder/session1-
     # to select all files sharing the `session1-` prefix
     elif file_or_folder.parent.exists():
-        filenames = file_or_folder.parent.glob(file_or_folder.name + '*')
+        filenames = list(file_or_folder.parent.glob(file_or_folder.name + '*'))
+        if len(filenames)==0 and file_or_folder.suffix:
+            suffix = file_or_folder.suffix[1:].lower()
+            if suffix not in io_by_extension:
+                raise ValueError(f'{suffix} is not a supported format of any IO.')
+            return io_by_extension[suffix]
 
-    elif file_or_folder.suffix:
-        suffix = file_or_folder.suffix[1:].lower()
-        if suffix not in io_by_extension:
-            raise ValueError(f'{suffix} is not a supported format of any IO.')
-        return io_by_extension[suffix]
-    
     else:
         raise ValueError(f'{file_or_folder} does not contain data files of a supported format')
 

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -429,7 +429,7 @@ def list_candidate_ios(file_or_folder, ignore_patterns=['*.ini', 'README.txt', '
     """
     file_or_folder = pathlib.Path(file_or_folder)
 
-    if file_or_folder.is_file():
+    if file_or_folder.suffix:
         suffix = file_or_folder.suffix[1:].lower()
         if suffix not in io_by_extension:
             raise ValueError(f'{suffix} is not a supported format of any IO.')

--- a/neo/test/iotest/test_get_io.py
+++ b/neo/test/iotest/test_get_io.py
@@ -5,10 +5,14 @@ from neo.io import get_io, list_candidate_ios, NixIO
 
 def test_list_candidate_ios_non_existant_file():
     # use plexon io suffix for testing here
-    non_existant_file = 'non_existant_folder/non_existant_file.plx'
+    non_existant_file = Path('non_existant_folder/non_existant_file.plx')
+    non_existant_file.unlink(missing_ok=True)
     ios = list_candidate_ios(non_existant_file)
 
     assert ios
+
+    # cleanup
+    non_existant_file.unlink(missing_ok=True)
 
 
 def test_list_candidate_ios_filename_stub():
@@ -27,7 +31,11 @@ def test_list_candidate_ios_filename_stub():
 
 def test_get_io_non_existant_file_writable_io():
     # use nixio for testing with writable io
-    non_existant_file = 'non_existant_file.nix'
+    non_existant_file = Path('non_existant_file.nix')
+    non_existant_file.unlink(missing_ok=True)
     io = get_io(non_existant_file)
 
     assert isinstance(io, NixIO)
+
+    # cleanup
+    non_existant_file.unlink(missing_ok=True)

--- a/neo/test/iotest/test_get_io.py
+++ b/neo/test/iotest/test_get_io.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from neo.io import get_io, list_candidate_ios, NixIO
+
+
+def test_list_candidate_ios_non_existant_file():
+    # use plexon io suffix for testing here
+    non_existant_file = 'non_existant_folder/non_existant_file.plx'
+    ios = list_candidate_ios(non_existant_file)
+
+    assert ios
+
+
+def test_list_candidate_ios_filename_stub():
+    # create dummy folder with dummy files
+    with TemporaryDirectory(prefix='filename_stub_test_') as test_folder:
+        test_folder = Path(test_folder)
+        test_filename = (test_folder / 'dummy_file.nix')
+        test_filename.touch()
+        filename_stub = test_filename.with_suffix('')
+
+        # check that io is found even though file suffix was not provided
+        ios = list_candidate_ios(filename_stub)
+
+        assert NixIO in ios
+
+
+def test_get_io_non_existant_file_writable_io():
+    # use nixio for testing with writable io
+    non_existant_file = 'non_existant_file.nix'
+    io = get_io(non_existant_file)
+
+    assert isinstance(io, NixIO)


### PR DESCRIPTION
Fixes #1287 

Rather than check if the file exists it now just checks that a suffix is provided. If a suffix is provided whether the file already exists or is a future file it returns the potential ios that would support that file format. The rest of the logic for checking for potential ios remains the same.