### PR TITLE
ensure analog signal proxy and analog signal behave the same for time slices 

### DIFF
--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -201,7 +201,7 @@ class AnalogSignalProxy(BaseProxy):
                     assert self.t_start <= t_stop <= self.t_stop, 't_stop is outside'
                 else:
                     t_stop = min(t_stop, self.t_stop)
-                i_stop = int((t_stop - self.t_start).magnitude * sr.magnitude)
+                i_stop = int(np.ceil((t_stop - self.t_start).magnitude * sr.magnitude))
         return i_start, i_stop, sig_t_start
 
     def load(self, time_slice=None, strict_slicing=True,

--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -188,7 +188,7 @@ class AnalogSignalProxy(BaseProxy):
                 else:
                     t_start = max(t_start, self.t_start)
                 # the i_start is necessary ceil
-                i_start = int(np.ceil((t_start - self.t_start).magnitude * sr.magnitude))
+                i_start = np.rint((t_start - self.t_start).magnitude * sr.magnitude)).astype(np.int64)
                 # this needed to get the real t_start of the first sample
                 # because do not necessary match what is demanded
                 sig_t_start = self.t_start + i_start / sr
@@ -201,7 +201,7 @@ class AnalogSignalProxy(BaseProxy):
                     assert self.t_start <= t_stop <= self.t_stop, 't_stop is outside'
                 else:
                     t_stop = min(t_stop, self.t_stop)
-                i_stop = int(np.ceil((t_stop - self.t_start).magnitude * sr.magnitude))
+                i_stop = np.rint((t_stop - self.t_start).magnitude * sr.magnitude)).astype(np.int64)
         return i_start, i_stop, sig_t_start
 
     def load(self, time_slice=None, strict_slicing=True,

--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -188,7 +188,7 @@ class AnalogSignalProxy(BaseProxy):
                 else:
                     t_start = max(t_start, self.t_start)
                 # the i_start is necessary ceil
-                i_start = np.rint((t_start - self.t_start).magnitude * sr.magnitude)).astype(np.int64)
+                i_start = np.rint((t_start - self.t_start).magnitude * sr.magnitude).astype(np.int64)
                 # this needed to get the real t_start of the first sample
                 # because do not necessary match what is demanded
                 sig_t_start = self.t_start + i_start / sr
@@ -201,7 +201,7 @@ class AnalogSignalProxy(BaseProxy):
                     assert self.t_start <= t_stop <= self.t_stop, 't_stop is outside'
                 else:
                     t_stop = min(t_stop, self.t_stop)
-                i_stop = np.rint((t_stop - self.t_start).magnitude * sr.magnitude)).astype(np.int64)
+                i_stop = np.rint((t_stop - self.t_start).magnitude * sr.magnitude).astype(np.int64)
         return i_start, i_stop, sig_t_start
 
     def load(self, time_slice=None, strict_slicing=True,

--- a/neo/test/iotest/test_proxyobjects.py
+++ b/neo/test/iotest/test_proxyobjects.py
@@ -54,8 +54,8 @@ class TestAnalogSignalProxy(BaseProxyTest):
         # ceil next sample when slicing
         anasig = proxy_anasig.load(time_slice=(1.99999 * pq.s, 5.000001 * pq.s))
         assert anasig.t_start == 2. * pq.s
-        assert anasig.duration == 3.0001 * pq.s
-        assert anasig.shape == (30001, 8)
+        assert anasig.duration == 3. * pq.s
+        assert anasig.shape == (30000, 8)
 
         # buggy time slice
         with self.assertRaises(AssertionError):

--- a/neo/test/iotest/test_proxyobjects.py
+++ b/neo/test/iotest/test_proxyobjects.py
@@ -54,8 +54,8 @@ class TestAnalogSignalProxy(BaseProxyTest):
         # ceil next sample when slicing
         anasig = proxy_anasig.load(time_slice=(1.99999 * pq.s, 5.000001 * pq.s))
         assert anasig.t_start == 2. * pq.s
-        assert anasig.duration == 3. * pq.s
-        assert anasig.shape == (30000, 8)
+        assert anasig.duration == 3.0001 * pq.s
+        assert anasig.shape == (30001, 8)
 
         # buggy time slice
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
In #1017 there is a discrepancy between 
`lazy=True` vs `lazy=False` because one uses `AnalogSignal` and one uses `AnalogSignalProxy`. This is likely due to the fact that `AnalogSignalProxy` is missing an `np.ceil` when calculating the `i_stop` which is included when calculating `i_start`. `AnalogSignal` accomplishes this with `np.rint` which when including the `astype(int64)` does the same as `int(np.ceil())`

https://github.com/NeuralEnsemble/python-neo/blob/53b202b2a6ae306392063d1dd2438323b4815de3/neo/io/proxyobjects.py#L191-L204

Let me know if you want a test added for this.