### PR TITLE
add workflow dispatch to manually trigger io tests on non-ubuntu os

### DIFF
--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -1,14 +1,15 @@
 name: NeoIoTest
 
-workflow_call:
-  inputs:
-    os:
-      required: true
-      type: string
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
 
-concurrency:  # Cancel previous workflows on the same pull request
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  concurrency:  # Cancel previous workflows on the same pull request
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
   build-and-test:

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -7,9 +7,9 @@ on:
         required: true
         type: string
 
-  concurrency:  # Cancel previous workflows on the same pull request
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+concurrency:  # Cancel previous workflows on the same pull request
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test:

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -1,26 +1,10 @@
 name: NeoIoTest
 
-on:
-  pull_request:
-    branches: [master]
-    types: [synchronize, opened, reopened, ready_for_review]
-    inputs:
-      os: 'ubuntu-latest'
-
-  # run checks on any change of master, including merge of PRs
-  push:
-    branches: [master]
-
-  workflow_dispatch:
-    inputs:
-      os:
-        description: 'The operating system to run the tests on'
-        required: True
-        default: 'ubuntu-latest'
-        type: choice
-        options:
-          - macos-latest
-          - windows-latest
+workflow_call:
+  inputs:
+    os:
+      required: true
+      type: string
 
 concurrency:  # Cancel previous workflows on the same pull request
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -4,10 +4,23 @@ on:
   pull_request:
     branches: [master]
     types: [synchronize, opened, reopened, ready_for_review]
+    inputs:
+      os: 'ubuntu-latest'
 
   # run checks on any change of master, including merge of PRs
   push:
     branches: [master]
+
+  workflow_dispatch:
+    inputs:
+      os:
+        description: 'The operating system to run the tests on'
+        required: True
+        default: 'ubuntu-latest'
+        type: choice
+        options:
+          - macos-latest
+          - windows-latest
 
 concurrency:  # Cancel previous workflows on the same pull request
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,13 +28,11 @@ concurrency:  # Cancel previous workflows on the same pull request
 
 jobs:
   build-and-test:
-    name: Test on (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Test on (${{ inputs.os }})
+    runs-on: ${{ inputs.os }}
     strategy:
       fail-fast: true
       matrix:
-        # "macos-latest", "windows-latest"
-        os: ["ubuntu-latest", ]
         python-version: ['3.9', ]
     defaults:
       # by default run in bash mode (required for conda usage)

--- a/.github/workflows/io-test_dispatch.yml
+++ b/.github/workflows/io-test_dispatch.yml
@@ -1,15 +1,16 @@
 name: NeoIoTest-manual-trigger
 
-workflow_dispatch:
-  inputs:
-    os:
-      description: 'The operating system to run the tests on'
-      required: True
-      default: 'ubuntu-latest'
-      type: choice
-      options:
-        - macos-latest
-        - windows-latest
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: 'The operating system to run the tests on'
+        required: True
+        default: 'ubuntu-latest'
+        type: choice
+        options:
+          - macos-latest
+          - windows-latest
 
 jobs:
   call-iotests:

--- a/.github/workflows/io-test_dispatch.yml
+++ b/.github/workflows/io-test_dispatch.yml
@@ -14,6 +14,6 @@ on:
 
 jobs:
   call-iotests:
-    uses: Neuralensemble/python-neo/.github/workflows/io-test.yml
+    uses: ./.github/workflows/io-test.yml
     with:
       os: ${{ inputs.os }}

--- a/.github/workflows/io-test_dispatch.yml
+++ b/.github/workflows/io-test_dispatch.yml
@@ -1,0 +1,18 @@
+name: NeoIoTest-manual-trigger
+
+workflow_dispatch:
+  inputs:
+    os:
+      description: 'The operating system to run the tests on'
+      required: True
+      default: 'ubuntu-latest'
+      type: choice
+      options:
+        - macos-latest
+        - windows-latest
+
+jobs:
+  call-iotests:
+    uses: Neuralensemble/python-neo/.github/workflows/io-test.yml@main
+    with:
+      os: ${{ inputs.os }}

--- a/.github/workflows/io-test_dispatch.yml
+++ b/.github/workflows/io-test_dispatch.yml
@@ -14,6 +14,6 @@ on:
 
 jobs:
   call-iotests:
-    uses: Neuralensemble/python-neo/.github/workflows/io-test.yml@main
+    uses: Neuralensemble/python-neo/.github/workflows/io-test.yml
     with:
       os: ${{ inputs.os }}

--- a/.github/workflows/io-test_trigger.yml
+++ b/.github/workflows/io-test_trigger.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   call-iotests:
-    uses: Neuralensemble/python-neo/.github/workflows/io-test.yml@master
+    uses: ./.github/workflows/io-test.yml
     with:
       os: ubuntu-latest

--- a/.github/workflows/io-test_trigger.yml
+++ b/.github/workflows/io-test_trigger.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   call-iotests:
-    uses: Neuralensemble/python-neo/.github/workflows/io-test.yml@main
+    uses: Neuralensemble/python-neo/.github/workflows/io-test.yml@master
     with:
       os: ubuntu-latest

--- a/.github/workflows/io-test_trigger.yml
+++ b/.github/workflows/io-test_trigger.yml
@@ -1,0 +1,16 @@
+name: NeoIoTest-automatic-trigger
+
+on:
+  pull_request:
+    branches: [master]
+    types: [synchronize, opened, reopened, ready_for_review]
+
+  # run checks on any change of master, including merge of PRs
+  push:
+    branches: [master]
+
+jobs:
+  call-iotests:
+    uses: Neuralensemble/python-neo/.github/workflows/io-test.yml@main
+    with:
+      os: ubuntu-latest


### PR DESCRIPTION
This PR adds the option to manually trigger the IO test suite and select the operation system to run the test on.
The automatic triggering of the IO tests always uses 'ubuntu-latest' as operating system. In the manual trigger it is possible to specify also `macos-latest` and `windows-latest` as operation systems.

Most likely the test suite won't pass for the other operation systems with the current test setup, but this will need a 2nd PR for debugging.