### PR TITLE
Fixed bug in maxwellrawio.py that shuffled channels 

### DIFF
--- a/neo/rawio/maxwellrawio.py
+++ b/neo/rawio/maxwellrawio.py
@@ -183,9 +183,10 @@ class MaxwellRawIO(BaseRawIO):
             if np.array(channel_indexes).size > 1 and np.any(np.diff(channel_indexes) < 0):
                 # get around h5py constraint that it does not allow datasets
                 # to be indexed out of order
-                sorted_channel_indexes = np.sort(channel_indexes)
-                resorted_indexes = np.array(
-                    [list(sorted_channel_indexes).index(ch) for ch in channel_indexes])
+                order_f = np.argsort(channel_indexes) 
+                sorted_channel_indexes = channel_indexes[order_f] 
+                # use argsort again on order_f to obtain resorted_indexes 
+                resorted_indexes = np.argsort(order_f)
 
         try:
             if resorted_indexes is None:


### PR DESCRIPTION
Fix for issue [https://github.com/SpikeInterface/spikeinterface/issues/1691](url) that shuffled channels when selecting and concatenating channels from MaxWell recordings with different mappings.