### PR TITLE
Add test for get_rawio_class

### DIFF
--- a/neo/test/rawiotest/test_get_rawio.py
+++ b/neo/test/rawiotest/test_get_rawio.py
@@ -1,0 +1,27 @@
+from neo.rawio import get_rawio_class
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+def test_get_rawio_class():
+    # use plexon io suffix for testing here
+    non_existant_file = Path('non_existant_folder/non_existant_file.plx')
+    non_existant_file.unlink(missing_ok=True)
+    ios = get_rawio_class(non_existant_file)
+
+    assert ios
+
+    # cleanup
+    non_existant_file.unlink(missing_ok=True)
+
+
+def test_get_rawio_class_nonsupported_rawio():
+
+    non_existant_file = Path('non_existant_folder/non_existant_file.fake')
+    non_existant_file.unlink(missing_ok=True)
+    ios = get_rawio_class(non_existant_file)
+
+    assert ios is None
+
+    # cleanup
+    non_existant_file.unlink(missing_ok=True)


### PR DESCRIPTION
After working on #1297 and @JuliaSprenger adding tests I thought it would be nice to mirror the same type of tests for the `get_rawio_class`. The two tests I've added are:

1) First test is for a supported file format which should return a reader
2) The second is for a non-supported file format which should return None

One question I wanted to bring up is that currently `neo.io` has a function `get_io` whereas `neo.rawio` instead has a `get_rawio_class` instead. It might be more parsimonious to change to `get_rawio` instead, but rather than just make that change I wanted to ask for opinions first. Happy to add here or raise an issue if that is preferred. 