### PR TITLE
Change `get_rawio_class` to `get_rawio`

### DIFF
--- a/neo/rawio/__init__.py
+++ b/neo/rawio/__init__.py
@@ -246,8 +246,18 @@ rawiolist = [
     WinWcpRawIO,
 ]
 
-
 def get_rawio_class(filename_or_dirname):
+    """Legacy function for returning class guess from file extension
+    DEPRECATED
+    """
+    
+    import warnings
+    warnings.warn('get_rawio_class is deprecated. In the future please use get_rawio')
+
+    return get_rawio(filename_or_dirname)
+
+
+def get_rawio(filename_or_dirname):
     """
     Return a neo.rawio class guess from file extension.
     """

--- a/neo/test/rawiotest/test_get_rawio.py
+++ b/neo/test/rawiotest/test_get_rawio.py
@@ -1,4 +1,4 @@
-from neo.rawio import get_rawio_class
+from neo.rawio import get_rawio
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -7,7 +7,7 @@ def test_get_rawio_class():
     # use plexon io suffix for testing here
     non_existant_file = Path('non_existant_folder/non_existant_file.plx')
     non_existant_file.unlink(missing_ok=True)
-    ios = get_rawio_class(non_existant_file)
+    ios = get_rawio(non_existant_file)
 
     assert ios
 
@@ -19,7 +19,7 @@ def test_get_rawio_class_nonsupported_rawio():
 
     non_existant_file = Path('non_existant_folder/non_existant_file.fake')
     non_existant_file.unlink(missing_ok=True)
-    ios = get_rawio_class(non_existant_file)
+    ios = get_rawio(non_existant_file)
 
     assert ios is None
 


### PR DESCRIPTION
As discussed in #1317 and in #1322. 

This just harmonizes the `get_io` and `get_rawio` functions while adding an alias to protect previous users.