### PR TITLE
`np.in1d` to `np.isin` as the former will be deprecated 

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -1163,7 +1163,7 @@ class BlackrockRawIO(BaseRawIO):
                 raw_event_data['timestamp'][mask_handled][1:] < raw_event_data['timestamp'][mask_handled][:-1]
             )[0] + 1
             jump_ids = np.where(mask_handled)[0][jump_ids_handled]  # jump ids in full set of events (incl. unhandled)
-            overlap = np.in1d(jump_ids, reset_ev_ids)
+            overlap = np.isin(jump_ids, reset_ev_ids)
             if not all(overlap):
                 # additional resets occurred without a reset event being stored
                 additional_ids = jump_ids[np.invert(overlap)]
@@ -2002,7 +2002,7 @@ class BlackrockRawIO(BaseRawIO):
         a 2.3 nev file.
         """
         # digital events
-        if not np.all(np.in1d(data['packet_insertion_reason'], [1, 129])):
+        if not np.all(np.isin(data['packet_insertion_reason'], [1, 129])):
             # Blackrock spec gives reason==64 means PERIODIC, but never seen this live
             warnings.warn("Unknown event codes found", RuntimeWarning)
         event_types = {

--- a/neo/rawio/spikegadgetsrawio.py
+++ b/neo/rawio/spikegadgetsrawio.py
@@ -183,10 +183,10 @@ class SpikeGadgetsRawIO(BaseRawIO):
                 self.selected_streams = [self.selected_streams]
             assert isinstance(self.selected_streams, list)
 
-            keep = np.in1d(signal_streams['id'], self.selected_streams)
+            keep = np.isin(signal_streams['id'], self.selected_streams)
             signal_streams = signal_streams[keep]
 
-            keep = np.in1d(signal_channels['stream_id'], self.selected_streams)
+            keep = np.isin(signal_channels['stream_id'], self.selected_streams)
             signal_channels = signal_channels[keep]
 
         # No events channels

--- a/neo/utils/misc.py
+++ b/neo/utils/misc.py
@@ -247,13 +247,13 @@ def _get_valid_ids(obj, annotation_key, annotation_value):
         # wrap annotation value to be list
         if not type(annotation_value) in [list, np.ndarray]:
             annotation_value = [annotation_value]
-        valid_mask = np.in1d(obj.labels, annotation_value)
+        valid_mask = np.isin(obj.labels, annotation_value)
 
     elif annotation_key in obj.array_annotations:
         # wrap annotation value to be list
         if not type(annotation_value) in [list, np.ndarray]:
             annotation_value = [annotation_value]
-        valid_mask = np.in1d(obj.array_annotations[annotation_key], annotation_value)
+        valid_mask = np.isin(obj.array_annotations[annotation_key], annotation_value)
 
     elif hasattr(obj, annotation_key) and getattr(obj, annotation_key) == annotation_value:
         valid_mask = np.ones(obj.shape)


### PR DESCRIPTION
Quoting @zm711 in spikeinterface:

> Just wanted to put this on everyone's radar. Not sure when this will be a hard error. I assume in a few versions (similar to the np.bool/np.float which deprecated in 1.20 and hard errored in 1.24)

> https://numpy.org/devdocs/release/2.0.0-notes.html

This PR takes care of this:


