### PR TITLE
Add Typing to `baseio`, `baserawio`, and `exampleio`

### DIFF
--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -33,7 +33,7 @@ def _check_annotations(value):
     """
     if isinstance(value, np.ndarray):
         if not issubclass(value.dtype.type, ALLOWED_ANNOTATION_TYPES):
-            raise ValueError(f"Invalid annotation. NumPy arrays with dtype {value.dtype.type} "
+            raise ValueError(f"Invalid annotation. NumPy arrays with dtype {value.dtype.type}"
                              f"are not allowed")
     elif isinstance(value, dict):
         for element in value.values():
@@ -42,7 +42,7 @@ def _check_annotations(value):
         for element in value:
             _check_annotations(element)
     elif not isinstance(value, ALLOWED_ANNOTATION_TYPES):
-        raise ValueError(f"Invalid annotation. Annotations of type {type(value)} are not "
+        raise ValueError(f"Invalid annotation. Annotations of type {type(value)} are not"
                          f"allowed")
 
 

--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -33,8 +33,8 @@ def _check_annotations(value):
     """
     if isinstance(value, np.ndarray):
         if not issubclass(value.dtype.type, ALLOWED_ANNOTATION_TYPES):
-            raise ValueError("Invalid annotation. NumPy arrays with dtype %s"
-                             "are not allowed" % value.dtype.type)
+            raise ValueError(f"Invalid annotation. NumPy arrays with dtype {value.dtype.type}"
+                             "are not allowed")
     elif isinstance(value, dict):
         for element in value.values():
             _check_annotations(element)
@@ -42,8 +42,8 @@ def _check_annotations(value):
         for element in value:
             _check_annotations(element)
     elif not isinstance(value, ALLOWED_ANNOTATION_TYPES):
-        raise ValueError("Invalid annotation. Annotations of type %s are not"
-                         "allowed" % type(value))
+        raise ValueError(f"Invalid annotation. Annotations of type {type(value)} are not"
+                         "allowed")
 
 
 def merge_annotation(a, b):

--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -33,8 +33,8 @@ def _check_annotations(value):
     """
     if isinstance(value, np.ndarray):
         if not issubclass(value.dtype.type, ALLOWED_ANNOTATION_TYPES):
-            raise ValueError(f"Invalid annotation. NumPy arrays with dtype {value.dtype.type}"
-                             "are not allowed")
+            raise ValueError(f"Invalid annotation. NumPy arrays with dtype {value.dtype.type} "
+                             f"are not allowed")
     elif isinstance(value, dict):
         for element in value.values():
             _check_annotations(element)
@@ -42,8 +42,8 @@ def _check_annotations(value):
         for element in value:
             _check_annotations(element)
     elif not isinstance(value, ALLOWED_ANNOTATION_TYPES):
-        raise ValueError(f"Invalid annotation. Annotations of type {type(value)} are not"
-                         "allowed")
+        raise ValueError(f"Invalid annotation. Annotations of type {type(value)} are not "
+                         f"allowed")
 
 
 def merge_annotation(a, b):

--- a/neo/io/baseio.py
+++ b/neo/io/baseio.py
@@ -98,7 +98,7 @@ class BaseIO:
 
     mode = 'file'  # or 'fake' or 'dir' or 'database'
 
-    def __init__(self, filename: str | Path =None, **kargs):
+    def __init__(self, filename: str | Path = None, **kargs):
         self.filename = str(filename)
         # create a logger for the IO class
         fullname = self.__class__.__module__ + '.' + self.__class__.__name__
@@ -113,7 +113,7 @@ class BaseIO:
             corelogger.addHandler(logging_handler)
 
     ######## General read/write methods #######################
-    def read(self, lazy:bool=False, **kargs):
+    def read(self, lazy: bool = False, **kargs):
         """
         Return all data from the file as a list of Blocks
         """

--- a/neo/io/baseio.py
+++ b/neo/io/baseio.py
@@ -10,6 +10,8 @@ BaseIO        - abstract class which should be overridden, managing how a
 
 If you want a model for developing a new IO start from exampleIO.
 """
+from __future__ import annotations
+from pathlib import Path
 
 try:
     from collections.abc import Sequence
@@ -96,7 +98,7 @@ class BaseIO:
 
     mode = 'file'  # or 'fake' or 'dir' or 'database'
 
-    def __init__(self, filename=None, **kargs):
+    def __init__(self, filename: str | Path =None, **kargs):
         self.filename = str(filename)
         # create a logger for the IO class
         fullname = self.__class__.__module__ + '.' + self.__class__.__name__
@@ -111,7 +113,7 @@ class BaseIO:
             corelogger.addHandler(logging_handler)
 
     ######## General read/write methods #######################
-    def read(self, lazy=False, **kargs):
+    def read(self, lazy:bool=False, **kargs):
         """
         Return all data from the file as a list of Blocks
         """

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -651,7 +651,7 @@ class BaseRawIO:
         return self._spike_count(block_index, seg_index, spike_channel_index)
 
     def get_spike_timestamps(self,
-                             block_index: int  = 0,
+                             block_index: int = 0,
                              seg_index: int = 0,
                              spike_channel_index: int = 0,
                              t_start: float | None = None,
@@ -725,8 +725,10 @@ class BaseRawIO:
             block_index, seg_index, event_channel_index, t_start, t_stop)
         return timestamp, durations, labels
 
-    def rescale_event_timestamp(self, event_timestamps: np.ndarray, dtype: np.dtype= 'float64',
-                    event_channel_index:int = 0):
+    def rescale_event_timestamp(self,
+                                event_timestamps: np.ndarray,
+                                dtype: np.dtype = 'float64',
+                                event_channel_index: int = 0):
         """
         Rescale event timestamps to seconds.
         """

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -134,7 +134,7 @@ class BaseRawIO:
 
     rawmode = None  # one key from possible_raw_modes
 
-    def __init__(self, use_cache: bool=False, cache_path='same_as_resource', **kargs):
+    def __init__(self, use_cache: bool = False, cache_path = 'same_as_resource', **kargs):
         """
         :TODO: Why multi-file would have a single filename is confusing here - shouldn't
         the name of this argument be filenames_list or filenames_base or similar?
@@ -474,7 +474,7 @@ class BaseRawIO:
         channel_indexes = np.array([chan_ids.index(chan_id) for chan_id in channel_ids])
         return channel_indexes
 
-    def _get_channel_indexes(self, stream_index:int, channel_indexes: list[int]|None, channel_names: list[str]|None, channel_ids: list[str]|None):
+    def _get_channel_indexes(self, stream_index: int, channel_indexes: list[int] | None, channel_names: list[str] | None, channel_ids: list[str] | None):
         """
         Select channel_indexes for a stream based on channel_indexes/channel_names/channel_ids
         depending which is not None.
@@ -485,7 +485,7 @@ class BaseRawIO:
             channel_indexes = self.channel_id_to_index(stream_index, channel_ids)
         return channel_indexes
 
-    def _get_stream_index_from_arg(self, stream_index_arg):
+    def _get_stream_index_from_arg(self, stream_index_arg: int | None):
         if stream_index_arg is None:
             assert self.header['signal_streams'].size == 1
             stream_index = 0
@@ -494,7 +494,7 @@ class BaseRawIO:
             stream_index = stream_index_arg
         return stream_index
 
-    def get_signal_size(self, block_index: int, seg_index: int, stream_index: int|None=None):
+    def get_signal_size(self, block_index: int, seg_index: int, stream_index: int | None = None):
         """
         Retrieve the length of a single section of the channels in a stream.
         :param block_index:
@@ -505,7 +505,7 @@ class BaseRawIO:
         stream_index = self._get_stream_index_from_arg(stream_index)
         return self._get_signal_size(block_index, seg_index, stream_index)
 
-    def get_signal_t_start(self, block_index: int, seg_index: int, stream_index: int|None=None):
+    def get_signal_t_start(self, block_index: int, seg_index: int, stream_index: int | None = None):
         """
         Retrieve the t_start of a single section of the channels in a stream.
         :param block_index:
@@ -516,7 +516,7 @@ class BaseRawIO:
         stream_index = self._get_stream_index_from_arg(stream_index)
         return self._get_signal_t_start(block_index, seg_index, stream_index)
 
-    def get_signal_sampling_rate(self, stream_index: int| None=None):
+    def get_signal_sampling_rate(self, stream_index: int | None = None):
         """
         Retrieve sampling rate for a stream and all channels in that stream.
         :param stream_index:
@@ -529,9 +529,9 @@ class BaseRawIO:
         sr = signal_channels[0]['sampling_rate']
         return float(sr)
 
-    def get_analogsignal_chunk(self, block_index: int =0, seg_index: int =0, i_start: int|None =None, i_stop: int|None =None,
-                               stream_index: int|None =None, channel_indexes: list[int]|None =None, channel_names: list[str]|None =None,
-                               channel_ids: list[str]|None=None, prefer_slice:bool=False):
+    def get_analogsignal_chunk(self, block_index: int = 0, seg_index: int = 0, i_start: int | None = None, i_stop: int | None = None,
+                               stream_index: int | None = None, channel_indexes: list[int] | None = None, channel_names: list[str] | None = None,
+                               channel_ids: list[str] | None = None, prefer_slice: bool = False):
         """
         Return a chunk of raw signal as a Numpy array. columns correspond to samples from a
         section of a single channel of recording. The channels are chosen either by channel_names,
@@ -588,8 +588,8 @@ class BaseRawIO:
 
         return raw_chunk
 
-    def rescale_signal_raw_to_float(self, raw_signal: np.ndarray, dtype: np.dtype='float32', stream_index: int|None=None,
-                                    channel_indexes: list[int]|None=None, channel_names: list[str]|None=None, channel_ids: list[str]|None=None):
+    def rescale_signal_raw_to_float(self, raw_signal: np.ndarray, dtype: np.dtype = 'float32', stream_index: int | None = None,
+                                    channel_indexes: list[int] | None = None, channel_names: list[str] | None = None, channel_ids: list[str] | None = None):
         """
         Rescale a chunk of raw signals which are provided as a Numpy array. These are normally
         returned by a call to get_analogsignal_chunk. The channels are specified either by
@@ -628,11 +628,11 @@ class BaseRawIO:
         return float_signal
 
     # spiketrain and unit zone
-    def spike_count(self, block_index: int=0, seg_index: int=0, spike_channel_index:int =0):
+    def spike_count(self, block_index: int = 0, seg_index: int = 0, spike_channel_index: int = 0):
         return self._spike_count(block_index, seg_index, spike_channel_index)
 
-    def get_spike_timestamps(self, block_index=0, seg_index=0, spike_channel_index=0,
-                             t_start=None, t_stop=None):
+    def get_spike_timestamps(self, block_index:int  = 0, seg_index: int = 0, spike_channel_index: int = 0,
+                             t_start: float | None = None, t_stop: float | None = None):
         """
         The timestamp datatype is as close to the format itself. Sometimes float/int32/int64.
         Sometimes it is the index on the signal but not always.
@@ -644,21 +644,21 @@ class BaseRawIO:
                                                spike_channel_index, t_start, t_stop)
         return timestamp
 
-    def rescale_spike_timestamp(self, spike_timestamps: np.ndarray, dtype: np.dtype='float64'):
+    def rescale_spike_timestamp(self, spike_timestamps: np.ndarray, dtype: np.dtype = 'float64'):
         """
         Rescale spike timestamps to seconds.
         """
         return self._rescale_spike_timestamp(spike_timestamps, dtype)
 
     # spiketrain waveform zone
-    def get_spike_raw_waveforms(self, block_index: int=0, seg_index: int=0, spike_channel_index: int=0,
-                                t_start: float|None =None, t_stop: float|None=None):
+    def get_spike_raw_waveforms(self, block_index: int = 0, seg_index: int = 0, spike_channel_index: int = 0,
+                                t_start: float | None = None, t_stop: float | None = None):
         wf = self._get_spike_raw_waveforms(block_index, seg_index,
                                            spike_channel_index, t_start, t_stop)
         return wf
 
-    def rescale_waveforms_to_float(self, raw_waveforms: np.ndarray, dtype: np.dtype ='float32',
-                                   spike_channel_index: int =0):
+    def rescale_waveforms_to_float(self, raw_waveforms: np.ndarray, dtype: np.dtype = 'float32',
+                                   spike_channel_index: int = 0):
         wf_gain = self.header['spike_channels']['wf_gain'][spike_channel_index]
         wf_offset = self.header['spike_channels']['wf_offset'][spike_channel_index]
 
@@ -672,11 +672,11 @@ class BaseRawIO:
         return float_waveforms
 
     # event and epoch zone
-    def event_count(self, block_index:int =0, seg_index: int =0, event_channel_index: int =0):
+    def event_count(self, block_index: int = 0, seg_index: int = 0, event_channel_index: int = 0):
         return self._event_count(block_index, seg_index, event_channel_index)
 
-    def get_event_timestamps(self, block_index: int =0, seg_index: int =0, event_channel_index: int =0,
-                             t_start: float|None =None, t_stop: float|None=None):
+    def get_event_timestamps(self, block_index: int = 0, seg_index: int = 0, event_channel_index: int = 0,
+                             t_start: float | None = None, t_stop: float | None = None):
         """
         The timestamp datatype is as close to the format itself. Sometimes float/int32/int64.
         Sometimes it is the index on the signal but not always.
@@ -694,21 +694,21 @@ class BaseRawIO:
             block_index, seg_index, event_channel_index, t_start, t_stop)
         return timestamp, durations, labels
 
-    def rescale_event_timestamp(self, event_timestamps: np.ndarray, dtype: np.dtype='float64',
-                    event_channel_index:int =0):
+    def rescale_event_timestamp(self, event_timestamps: np.ndarray, dtype: np.dtype= 'float64',
+                    event_channel_index:int = 0):
         """
         Rescale event timestamps to seconds.
         """
         return self._rescale_event_timestamp(event_timestamps, dtype, event_channel_index)
 
-    def rescale_epoch_duration(self, raw_duration: np.ndarray, dtype: np.dtype ='float64',
-                    event_channel_index:int =0):
+    def rescale_epoch_duration(self, raw_duration: np.ndarray, dtype: np.dtype = 'float64',
+                    event_channel_index: int = 0):
         """
         Rescale epoch raw duration to seconds.
         """
         return self._rescale_epoch_duration(raw_duration, dtype, event_channel_index)
 
-    def setup_cache(self, cache_path: 'home'|'same_as_resource', **init_kargs):
+    def setup_cache(self, cache_path: 'home' | 'same_as_resource', **init_kargs):
         try:
             import joblib
         except ImportError:
@@ -780,7 +780,7 @@ class BaseRawIO:
     def _segment_t_start(self, block_index: int, seg_index: int):
         raise (NotImplementedError)
 
-    def _segment_t_stop(self, block_index:int , seg_index: int):
+    def _segment_t_stop(self, block_index: int , seg_index: int):
         raise (NotImplementedError)
 
     ###
@@ -801,8 +801,8 @@ class BaseRawIO:
         """
         raise (NotImplementedError)
 
-    def _get_analogsignal_chunk(self, block_index: int, seg_index: int, i_start: int|None, i_stop: int|None,
-                                stream_index: int, channel_indexes: list[int]|None):
+    def _get_analogsignal_chunk(self, block_index: int, seg_index: int, i_start: int | None, i_stop: int | None,
+                                stream_index: int, channel_indexes: list[int] | None):
         """
         Return the samples from a set of AnalogSignals indexed
         by stream_index and channel_indexes (local index inner stream).
@@ -820,7 +820,7 @@ class BaseRawIO:
         raise (NotImplementedError)
 
     def _get_spike_timestamps(self, block_index: int, seg_index: int,
-                              spike_channel_index: int, t_start: float|None, t_stop: float|None):
+                              spike_channel_index: int, t_start: float | None, t_stop: float | None):
         raise (NotImplementedError)
 
     def _rescale_spike_timestamp(self, spike_timestamps: np.ndarray, dtype: np.dtype):
@@ -829,7 +829,7 @@ class BaseRawIO:
     ###
     # spike waveforms zone
     def _get_spike_raw_waveforms(self, block_index: int, seg_index: int,
-                                 spike_channel_index: int, t_start: float|None, t_stop: float|None):
+                                 spike_channel_index: int, t_start: float | None, t_stop: float | None):
         raise (NotImplementedError)
 
     ###
@@ -837,7 +837,7 @@ class BaseRawIO:
     def _event_count(self, block_index: int, seg_index: int, event_channel_index: int):
         raise (NotImplementedError)
 
-    def _get_event_timestamps(self, block_index: int, seg_index: int, event_channel_index: int, t_start: float|None, t_stop: float|None):
+    def _get_event_timestamps(self, block_index: int, seg_index: int, event_channel_index: int, t_start: float | None, t_stop: float | None):
         raise (NotImplementedError)
 
     def _rescale_event_timestamp(self, event_timestamps: np.ndarray, dtype: np.dtype):
@@ -847,7 +847,7 @@ class BaseRawIO:
         raise (NotImplementedError)
 
 
-def pprint_vector(vector, lim: int=8):
+def pprint_vector(vector, lim: int = 8):
     vector = np.asarray(vector)
     assert vector.ndim == 1
     if len(vector) > lim:

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -67,6 +67,7 @@ or vector can be stored somewhere (near the file, /tmp, any path) for use across
 constructions of a RawIO for a given set of data.
 
 """
+from __future__ import annotations
 
 import logging
 import numpy as np
@@ -133,7 +134,7 @@ class BaseRawIO:
 
     rawmode = None  # one key from possible_raw_modes
 
-    def __init__(self, use_cache=False, cache_path='same_as_resource', **kargs):
+    def __init__(self, use_cache: bool=False, cache_path='same_as_resource', **kargs):
         """
         :TODO: Why multi-file would have a single filename is confusing here - shouldn't
         the name of this argument be filenames_list or filenames_base or similar?
@@ -369,7 +370,7 @@ class BaseRawIO:
         """return number of blocks"""
         return self.header['nb_block']
 
-    def segment_count(self, block_index):
+    def segment_count(self, block_index: int):
         """return number of segments for a given block"""
         return self.header['nb_segment'][block_index]
 
@@ -379,7 +380,7 @@ class BaseRawIO:
         """
         return len(self.header['signal_streams'])
 
-    def signal_channels_count(self, stream_index):
+    def signal_channels_count(self, stream_index: int):
         """Return the number of signal channels for a given stream.
         This number is the same for all Blocks and Segments.
         """
@@ -400,7 +401,7 @@ class BaseRawIO:
         """
         return len(self.header['event_channels'])
 
-    def segment_t_start(self, block_index, seg_index):
+    def segment_t_start(self, block_index: int, seg_index: int):
         """Global t_start of a Segment in s. Shared by all objects except
         for AnalogSignal.
         """
@@ -445,7 +446,7 @@ class BaseRawIO:
 
         self._several_channel_groups = signal_streams.size > 1
 
-    def channel_name_to_index(self, stream_index, channel_names):
+    def channel_name_to_index(self, stream_index: int, channel_names: list[str]):
         """
         Inside a stream, transform channel_names to channel_indexes.
         Based on self.header['signal_channels']
@@ -459,7 +460,7 @@ class BaseRawIO:
         channel_indexes = np.array([chan_names.index(name) for name in channel_names])
         return channel_indexes
 
-    def channel_id_to_index(self, stream_index, channel_ids):
+    def channel_id_to_index(self, stream_index: int, channel_ids: list[str]):
         """
         Inside a stream, transform channel_ids to channel_indexes.
         Based on self.header['signal_channels']
@@ -473,7 +474,7 @@ class BaseRawIO:
         channel_indexes = np.array([chan_ids.index(chan_id) for chan_id in channel_ids])
         return channel_indexes
 
-    def _get_channel_indexes(self, stream_index, channel_indexes, channel_names, channel_ids):
+    def _get_channel_indexes(self, stream_index:int, channel_indexes: list[int]|None, channel_names: list[str]|None, channel_ids: list[str]|None):
         """
         Select channel_indexes for a stream based on channel_indexes/channel_names/channel_ids
         depending which is not None.
@@ -493,7 +494,7 @@ class BaseRawIO:
             stream_index = stream_index_arg
         return stream_index
 
-    def get_signal_size(self, block_index, seg_index, stream_index=None):
+    def get_signal_size(self, block_index: int, seg_index: int, stream_index: int|None=None):
         """
         Retrieve the length of a single section of the channels in a stream.
         :param block_index:
@@ -504,7 +505,7 @@ class BaseRawIO:
         stream_index = self._get_stream_index_from_arg(stream_index)
         return self._get_signal_size(block_index, seg_index, stream_index)
 
-    def get_signal_t_start(self, block_index, seg_index, stream_index=None):
+    def get_signal_t_start(self, block_index: int, seg_index: int, stream_index: int|None=None):
         """
         Retrieve the t_start of a single section of the channels in a stream.
         :param block_index:
@@ -515,7 +516,7 @@ class BaseRawIO:
         stream_index = self._get_stream_index_from_arg(stream_index)
         return self._get_signal_t_start(block_index, seg_index, stream_index)
 
-    def get_signal_sampling_rate(self, stream_index=None):
+    def get_signal_sampling_rate(self, stream_index: int| None=None):
         """
         Retrieve sampling rate for a stream and all channels in that stream.
         :param stream_index:
@@ -528,9 +529,9 @@ class BaseRawIO:
         sr = signal_channels[0]['sampling_rate']
         return float(sr)
 
-    def get_analogsignal_chunk(self, block_index=0, seg_index=0, i_start=None, i_stop=None,
-                               stream_index=None, channel_indexes=None, channel_names=None,
-                               channel_ids=None, prefer_slice=False):
+    def get_analogsignal_chunk(self, block_index: int =0, seg_index: int =0, i_start: int|None =None, i_stop: int|None =None,
+                               stream_index: int|None =None, channel_indexes: list[int]|None =None, channel_names: list[str]|None =None,
+                               channel_ids: list[str]|None=None, prefer_slice:bool=False):
         """
         Return a chunk of raw signal as a Numpy array. columns correspond to samples from a
         section of a single channel of recording. The channels are chosen either by channel_names,
@@ -587,8 +588,8 @@ class BaseRawIO:
 
         return raw_chunk
 
-    def rescale_signal_raw_to_float(self, raw_signal, dtype='float32', stream_index=None,
-                                    channel_indexes=None, channel_names=None, channel_ids=None):
+    def rescale_signal_raw_to_float(self, raw_signal: np.ndarray, dtype: np.dtype='float32', stream_index: int|None=None,
+                                    channel_indexes: list[int]|None=None, channel_names: list[str]|None=None, channel_ids: list[str]|None=None):
         """
         Rescale a chunk of raw signals which are provided as a Numpy array. These are normally
         returned by a call to get_analogsignal_chunk. The channels are specified either by
@@ -627,7 +628,7 @@ class BaseRawIO:
         return float_signal
 
     # spiketrain and unit zone
-    def spike_count(self, block_index=0, seg_index=0, spike_channel_index=0):
+    def spike_count(self, block_index: int=0, seg_index: int=0, spike_channel_index:int =0):
         return self._spike_count(block_index, seg_index, spike_channel_index)
 
     def get_spike_timestamps(self, block_index=0, seg_index=0, spike_channel_index=0,
@@ -643,21 +644,21 @@ class BaseRawIO:
                                                spike_channel_index, t_start, t_stop)
         return timestamp
 
-    def rescale_spike_timestamp(self, spike_timestamps, dtype='float64'):
+    def rescale_spike_timestamp(self, spike_timestamps: np.ndarray, dtype: np.dtype='float64'):
         """
         Rescale spike timestamps to seconds.
         """
         return self._rescale_spike_timestamp(spike_timestamps, dtype)
 
     # spiketrain waveform zone
-    def get_spike_raw_waveforms(self, block_index=0, seg_index=0, spike_channel_index=0,
-                                t_start=None, t_stop=None):
+    def get_spike_raw_waveforms(self, block_index: int=0, seg_index: int=0, spike_channel_index: int=0,
+                                t_start: float|None =None, t_stop: float|None=None):
         wf = self._get_spike_raw_waveforms(block_index, seg_index,
                                            spike_channel_index, t_start, t_stop)
         return wf
 
-    def rescale_waveforms_to_float(self, raw_waveforms, dtype='float32',
-                                   spike_channel_index=0):
+    def rescale_waveforms_to_float(self, raw_waveforms: np.ndarray, dtype: np.dtype ='float32',
+                                   spike_channel_index: int =0):
         wf_gain = self.header['spike_channels']['wf_gain'][spike_channel_index]
         wf_offset = self.header['spike_channels']['wf_offset'][spike_channel_index]
 
@@ -671,11 +672,11 @@ class BaseRawIO:
         return float_waveforms
 
     # event and epoch zone
-    def event_count(self, block_index=0, seg_index=0, event_channel_index=0):
+    def event_count(self, block_index:int =0, seg_index: int =0, event_channel_index: int =0):
         return self._event_count(block_index, seg_index, event_channel_index)
 
-    def get_event_timestamps(self, block_index=0, seg_index=0, event_channel_index=0,
-                             t_start=None, t_stop=None):
+    def get_event_timestamps(self, block_index: int =0, seg_index: int =0, event_channel_index: int =0,
+                             t_start: float|None =None, t_stop: float|None=None):
         """
         The timestamp datatype is as close to the format itself. Sometimes float/int32/int64.
         Sometimes it is the index on the signal but not always.
@@ -693,21 +694,21 @@ class BaseRawIO:
             block_index, seg_index, event_channel_index, t_start, t_stop)
         return timestamp, durations, labels
 
-    def rescale_event_timestamp(self, event_timestamps, dtype='float64',
-                    event_channel_index=0):
+    def rescale_event_timestamp(self, event_timestamps: np.ndarray, dtype: np.dtype='float64',
+                    event_channel_index:int =0):
         """
         Rescale event timestamps to seconds.
         """
         return self._rescale_event_timestamp(event_timestamps, dtype, event_channel_index)
 
-    def rescale_epoch_duration(self, raw_duration, dtype='float64',
-                    event_channel_index=0):
+    def rescale_epoch_duration(self, raw_duration: np.ndarray, dtype: np.dtype ='float64',
+                    event_channel_index:int =0):
         """
         Rescale epoch raw duration to seconds.
         """
         return self._rescale_epoch_duration(raw_duration, dtype, event_channel_index)
 
-    def setup_cache(self, cache_path, **init_kargs):
+    def setup_cache(self, cache_path: 'home'|'same_as_resource', **init_kargs):
         try:
             import joblib
         except ImportError:
@@ -735,7 +736,7 @@ class BaseRawIO:
             dirname = os.path.dirname(resource_name)
         else:
             assert os.path.exists(cache_path), \
-                'cache_path do not exists use "home" or "same_as_resource" to make this auto'
+                'cache_path does not exists use "home" or "same_as_resource" to make this auto'
 
         # the hash of the resource (dir of file) is done with filename+datetime
         # TODO make something more sophisticated when rawmode='one-dir' that use all
@@ -776,15 +777,15 @@ class BaseRawIO:
     def _source_name(self):
         raise (NotImplementedError)
 
-    def _segment_t_start(self, block_index, seg_index):
+    def _segment_t_start(self, block_index: int, seg_index: int):
         raise (NotImplementedError)
 
-    def _segment_t_stop(self, block_index, seg_index):
+    def _segment_t_stop(self, block_index:int , seg_index: int):
         raise (NotImplementedError)
 
     ###
     # signal and channel zone
-    def _get_signal_size(self, block_index, seg_index, stream_index):
+    def _get_signal_size(self, block_index: int, seg_index: int, stream_index: int):
         """
         Return the size of a set of AnalogSignals indexed by channel_indexes.
 
@@ -792,7 +793,7 @@ class BaseRawIO:
         """
         raise (NotImplementedError)
 
-    def _get_signal_t_start(self, block_index, seg_index, stream_index):
+    def _get_signal_t_start(self, block_index: int, seg_index: int, stream_index: int):
         """
         Return the t_start of a set of AnalogSignals indexed by channel_indexes.
 
@@ -800,8 +801,8 @@ class BaseRawIO:
         """
         raise (NotImplementedError)
 
-    def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop,
-                                stream_index, channel_indexes):
+    def _get_analogsignal_chunk(self, block_index: int, seg_index: int, i_start: int|None, i_stop: int|None,
+                                stream_index: int, channel_indexes: list[int]|None):
         """
         Return the samples from a set of AnalogSignals indexed
         by stream_index and channel_indexes (local index inner stream).
@@ -815,38 +816,38 @@ class BaseRawIO:
 
     ###
     # spiketrain and unit zone
-    def _spike_count(self, block_index, seg_index, spike_channel_index):
+    def _spike_count(self, block_index: int, seg_index: int, spike_channel_index: int):
         raise (NotImplementedError)
 
-    def _get_spike_timestamps(self, block_index, seg_index,
-                              spike_channel_index, t_start, t_stop):
+    def _get_spike_timestamps(self, block_index: int, seg_index: int,
+                              spike_channel_index: int, t_start: float|None, t_stop: float|None):
         raise (NotImplementedError)
 
-    def _rescale_spike_timestamp(self, spike_timestamps, dtype):
+    def _rescale_spike_timestamp(self, spike_timestamps: np.ndarray, dtype: np.dtype):
         raise (NotImplementedError)
 
     ###
     # spike waveforms zone
-    def _get_spike_raw_waveforms(self, block_index, seg_index,
-                                 spike_channel_index, t_start, t_stop):
+    def _get_spike_raw_waveforms(self, block_index: int, seg_index: int,
+                                 spike_channel_index: int, t_start: float|None, t_stop: float|None):
         raise (NotImplementedError)
 
     ###
     # event and epoch zone
-    def _event_count(self, block_index, seg_index, event_channel_index):
+    def _event_count(self, block_index: int, seg_index: int, event_channel_index: int):
         raise (NotImplementedError)
 
-    def _get_event_timestamps(self, block_index, seg_index, event_channel_index, t_start, t_stop):
+    def _get_event_timestamps(self, block_index: int, seg_index: int, event_channel_index: int, t_start: float|None, t_stop: float|None):
         raise (NotImplementedError)
 
-    def _rescale_event_timestamp(self, event_timestamps, dtype):
+    def _rescale_event_timestamp(self, event_timestamps: np.ndarray, dtype: np.dtype):
         raise (NotImplementedError)
 
-    def _rescale_epoch_duration(self, raw_duration, dtype):
+    def _rescale_epoch_duration(self, raw_duration: np.ndarray, dtype: np.dtype):
         raise (NotImplementedError)
 
 
-def pprint_vector(vector, lim=8):
+def pprint_vector(vector, lim: int=8):
     vector = np.asarray(vector)
     assert vector.ndim == 1
     if len(vector) > lim:

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -134,7 +134,7 @@ class BaseRawIO:
 
     rawmode = None  # one key from possible_raw_modes
 
-    def __init__(self, use_cache: bool = False, cache_path = 'same_as_resource', **kargs):
+    def __init__(self, use_cache: bool = False, cache_path: str = 'same_as_resource', **kargs):
         """
         :TODO: Why multi-file would have a single filename is confusing here - shouldn't
         the name of this argument be filenames_list or filenames_base or similar?
@@ -474,7 +474,11 @@ class BaseRawIO:
         channel_indexes = np.array([chan_ids.index(chan_id) for chan_id in channel_ids])
         return channel_indexes
 
-    def _get_channel_indexes(self, stream_index: int, channel_indexes: list[int] | None, channel_names: list[str] | None, channel_ids: list[str] | None):
+    def _get_channel_indexes(self,
+                             stream_index: int,
+                             channel_indexes: list[int] | None,
+                             channel_names: list[str] | None,
+                             channel_ids: list[str] | None):
         """
         Select channel_indexes for a stream based on channel_indexes/channel_names/channel_ids
         depending which is not None.
@@ -505,7 +509,10 @@ class BaseRawIO:
         stream_index = self._get_stream_index_from_arg(stream_index)
         return self._get_signal_size(block_index, seg_index, stream_index)
 
-    def get_signal_t_start(self, block_index: int, seg_index: int, stream_index: int | None = None):
+    def get_signal_t_start(self,
+                           block_index: int,
+                           seg_index: int,
+                           stream_index: int | None = None):
         """
         Retrieve the t_start of a single section of the channels in a stream.
         :param block_index:
@@ -529,9 +536,16 @@ class BaseRawIO:
         sr = signal_channels[0]['sampling_rate']
         return float(sr)
 
-    def get_analogsignal_chunk(self, block_index: int = 0, seg_index: int = 0, i_start: int | None = None, i_stop: int | None = None,
-                               stream_index: int | None = None, channel_indexes: list[int] | None = None, channel_names: list[str] | None = None,
-                               channel_ids: list[str] | None = None, prefer_slice: bool = False):
+    def get_analogsignal_chunk(self,
+                               block_index: int = 0,
+                               seg_index: int = 0,
+                               i_start: int | None = None,
+                               i_stop: int | None = None,
+                               stream_index: int | None = None,
+                               channel_indexes: list[int] | None = None,
+                               channel_names: list[str] | None = None,
+                               channel_ids: list[str] | None = None,
+                               prefer_slice: bool = False):
         """
         Return a chunk of raw signal as a Numpy array. columns correspond to samples from a
         section of a single channel of recording. The channels are chosen either by channel_names,
@@ -588,8 +602,13 @@ class BaseRawIO:
 
         return raw_chunk
 
-    def rescale_signal_raw_to_float(self, raw_signal: np.ndarray, dtype: np.dtype = 'float32', stream_index: int | None = None,
-                                    channel_indexes: list[int] | None = None, channel_names: list[str] | None = None, channel_ids: list[str] | None = None):
+    def rescale_signal_raw_to_float(self,
+                                    raw_signal: np.ndarray,
+                                    dtype: np.dtype = 'float32',
+                                    stream_index: int | None = None,
+                                    channel_indexes: list[int] | None = None,
+                                    channel_names: list[str] | None = None,
+                                    channel_ids: list[str] | None = None):
         """
         Rescale a chunk of raw signals which are provided as a Numpy array. These are normally
         returned by a call to get_analogsignal_chunk. The channels are specified either by
@@ -631,8 +650,12 @@ class BaseRawIO:
     def spike_count(self, block_index: int = 0, seg_index: int = 0, spike_channel_index: int = 0):
         return self._spike_count(block_index, seg_index, spike_channel_index)
 
-    def get_spike_timestamps(self, block_index:int  = 0, seg_index: int = 0, spike_channel_index: int = 0,
-                             t_start: float | None = None, t_stop: float | None = None):
+    def get_spike_timestamps(self,
+                             block_index: int  = 0,
+                             seg_index: int = 0,
+                             spike_channel_index: int = 0,
+                             t_start: float | None = None,
+                             t_stop: float | None = None):
         """
         The timestamp datatype is as close to the format itself. Sometimes float/int32/int64.
         Sometimes it is the index on the signal but not always.
@@ -651,8 +674,12 @@ class BaseRawIO:
         return self._rescale_spike_timestamp(spike_timestamps, dtype)
 
     # spiketrain waveform zone
-    def get_spike_raw_waveforms(self, block_index: int = 0, seg_index: int = 0, spike_channel_index: int = 0,
-                                t_start: float | None = None, t_stop: float | None = None):
+    def get_spike_raw_waveforms(self,
+                                block_index: int = 0,
+                                seg_index: int = 0,
+                                spike_channel_index: int = 0,
+                                t_start: float | None = None,
+                                t_stop: float | None = None):
         wf = self._get_spike_raw_waveforms(block_index, seg_index,
                                            spike_channel_index, t_start, t_stop)
         return wf
@@ -675,8 +702,12 @@ class BaseRawIO:
     def event_count(self, block_index: int = 0, seg_index: int = 0, event_channel_index: int = 0):
         return self._event_count(block_index, seg_index, event_channel_index)
 
-    def get_event_timestamps(self, block_index: int = 0, seg_index: int = 0, event_channel_index: int = 0,
-                             t_start: float | None = None, t_stop: float | None = None):
+    def get_event_timestamps(self,
+                             block_index: int = 0,
+                             seg_index: int = 0,
+                             event_channel_index: int = 0,
+                             t_start: float | None = None,
+                             t_stop: float | None = None):
         """
         The timestamp datatype is as close to the format itself. Sometimes float/int32/int64.
         Sometimes it is the index on the signal but not always.
@@ -780,7 +811,7 @@ class BaseRawIO:
     def _segment_t_start(self, block_index: int, seg_index: int):
         raise (NotImplementedError)
 
-    def _segment_t_stop(self, block_index: int , seg_index: int):
+    def _segment_t_stop(self, block_index: int, seg_index: int):
         raise (NotImplementedError)
 
     ###
@@ -801,8 +832,13 @@ class BaseRawIO:
         """
         raise (NotImplementedError)
 
-    def _get_analogsignal_chunk(self, block_index: int, seg_index: int, i_start: int | None, i_stop: int | None,
-                                stream_index: int, channel_indexes: list[int] | None):
+    def _get_analogsignal_chunk(self,
+                                block_index: int,
+                                seg_index: int,
+                                i_start: int | None,
+                                i_stop: int | None,
+                                stream_index: int,
+                                channel_indexes: list[int] | None):
         """
         Return the samples from a set of AnalogSignals indexed
         by stream_index and channel_indexes (local index inner stream).
@@ -819,8 +855,12 @@ class BaseRawIO:
     def _spike_count(self, block_index: int, seg_index: int, spike_channel_index: int):
         raise (NotImplementedError)
 
-    def _get_spike_timestamps(self, block_index: int, seg_index: int,
-                              spike_channel_index: int, t_start: float | None, t_stop: float | None):
+    def _get_spike_timestamps(self,
+                              block_index: int,
+                              seg_index: int,
+                              spike_channel_index: int,
+                              t_start: float | None,
+                              t_stop: float | None):
         raise (NotImplementedError)
 
     def _rescale_spike_timestamp(self, spike_timestamps: np.ndarray, dtype: np.dtype):
@@ -828,8 +868,12 @@ class BaseRawIO:
 
     ###
     # spike waveforms zone
-    def _get_spike_raw_waveforms(self, block_index: int, seg_index: int,
-                                 spike_channel_index: int, t_start: float | None, t_stop: float | None):
+    def _get_spike_raw_waveforms(self,
+                                 block_index: int,
+                                 seg_index: int,
+                                 spike_channel_index: int,
+                                 t_start: float | None,
+                                 t_stop: float | None):
         raise (NotImplementedError)
 
     ###
@@ -837,7 +881,12 @@ class BaseRawIO:
     def _event_count(self, block_index: int, seg_index: int, event_channel_index: int):
         raise (NotImplementedError)
 
-    def _get_event_timestamps(self, block_index: int, seg_index: int, event_channel_index: int, t_start: float | None, t_stop: float | None):
+    def _get_event_timestamps(self,
+                              block_index: int,
+                              seg_index: int,
+                              event_channel_index: int,
+                              t_start: float | None,
+                              t_stop: float | None):
         raise (NotImplementedError)
 
     def _rescale_event_timestamp(self, event_timestamps: np.ndarray, dtype: np.dtype):

--- a/neo/rawio/examplerawio.py
+++ b/neo/rawio/examplerawio.py
@@ -85,7 +85,7 @@ class ExampleRawIO(BaseRawIO):
     extensions = ['fake']
     rawmode = 'one-file'
 
-    def __init__(self, filename: str|Path =''):
+    def __init__(self, filename: str | Path = ''):
         BaseRawIO.__init__(self)
         # note that this filename is ued in self._source_name
         self.filename = filename
@@ -267,8 +267,13 @@ class ExampleRawIO(BaseRawIO):
         # this is not always the case
         return self._segment_t_start(block_index, seg_index)
 
-    def _get_analogsignal_chunk(self, block_index:int, seg_index:int, i_start: int | None, i_stop: int | None,
-                                stream_index: int, channel_indexes: np.ndarray|list|slice|None):
+    def _get_analogsignal_chunk(self,
+                                block_index: int,
+                                seg_index: int,
+                                i_start: int | None,
+                                i_stop: int | None,
+                                stream_index: int,
+                                channel_indexes: np.ndarray | list | slice | None):
         # this must return a signal chunk in a signal stream
         # limited with i_start/i_stop (can be None)
         # channel_indexes can be None (=all channel in the stream) or a list or numpy.array
@@ -308,14 +313,19 @@ class ExampleRawIO(BaseRawIO):
         raw_signals = np.zeros((i_stop - i_start, nb_chan), dtype='int16')
         return raw_signals
 
-    def _spike_count(self, block_index:int, seg_index:int, spike_channel_index:int):
+    def _spike_count(self, block_index: int, seg_index: int, spike_channel_index: int):
         # Must return the nb of spikes for given (block_index, seg_index, spike_channel_index)
         # we are lucky:  our units have all the same nb of spikes!!
         # it is not always the case
         nb_spikes = 20
         return nb_spikes
 
-    def _get_spike_timestamps(self, block_index: int, seg_index: int, spike_channel_index: int, t_start: float|None, t_stop: float|None):
+    def _get_spike_timestamps(self,
+                              block_index: int,
+                              seg_index: int,
+                              spike_channel_index: int,
+                              t_start: float | None,
+                              t_stop: float | None):
         # In our IO, timestamp are internally coded 'int64' and they
         # represent the index of the signals 10kHz
         # we are lucky: spikes have the same discharge in all segments!!
@@ -343,8 +353,12 @@ class ExampleRawIO(BaseRawIO):
         spike_times /= 10000.  # because 10kHz
         return spike_times
 
-    def _get_spike_raw_waveforms(self, block_index: int, seg_index: int, spike_channel_index: int,
-                                 t_start: float|None, t_stop: float|None):
+    def _get_spike_raw_waveforms(self,
+                                 block_index: int,
+                                 seg_index: int,
+                                 spike_channel_index: int,
+                                 t_start: float | None,
+                                 t_stop: float | None):
         # this must return a 3D numpy array (nb_spike, nb_channel, nb_sample)
         # in the original dtype
         # this must be as fast as possible.
@@ -380,7 +394,12 @@ class ExampleRawIO(BaseRawIO):
             # epoch channel
             return 10
 
-    def _get_event_timestamps(self, block_index: int, seg_index: int, event_channel_index: int, t_start: float|None, t_stop: float|None):
+    def _get_event_timestamps(self,
+                              block_index: int,
+                              seg_index: int,
+                              event_channel_index: int,
+                              t_start: float | None,
+                              t_stop: float | None):
         # the main difference between spike channel and event channel
         # is that for event channels we have 3D numpy array (timestamp, durations, labels) where
         # durations must be None for 'event'

--- a/neo/rawio/examplerawio.py
+++ b/neo/rawio/examplerawio.py
@@ -430,7 +430,10 @@ class ExampleRawIO(BaseRawIO):
 
         return timestamp, durations, labels
 
-    def _rescale_event_timestamp(self, event_timestamps: np.ndarray, dtype: np.dtype, event_channel_index: int):
+    def _rescale_event_timestamp(self,
+                                 event_timestamps: np.ndarray,
+                                 dtype: np.dtype,
+                                 event_channel_index: int):
         # must rescale to seconds for a particular event_timestamps
         # with a fixed dtype so the user can choose the precision they want.
 
@@ -438,7 +441,10 @@ class ExampleRawIO(BaseRawIO):
         event_times = event_timestamps.astype(dtype)
         return event_times
 
-    def _rescale_epoch_duration(self, raw_duration: np.ndarray, dtype: np.dtype, event_channel_index: int):
+    def _rescale_epoch_duration(self,
+                                raw_duration: np.ndarray,
+                                dtype: np.dtype,
+                                event_channel_index: int):
         # really easy here because in our case it is already in seconds
         durations = raw_duration.astype(dtype)
         return durations


### PR DESCRIPTION
Replaces #1229 because that now has merge conflicts.

I know this has been discussed #1123. Sam is against, others are typically for. This is just a draft to think about (& correct or reject), but I think adding type hints to some places exposed to the user would be beneficial. By putting the hints into the base it propagates to all ios to minimize other typing needing to be added, although developers can override the typing in their specific io.

I know that neo has complicated inputs, but I think type hints work best to give a suggested appropriate input (And as a nod to Sam I didn't add type hints for the returns yet). 