### PR TITLE
Add 2013 and 2014 neuropixels versions.

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -399,7 +399,7 @@ def extract_stream_info(meta_file, meta):
                 per_channel_gain[c] = 1. / float(v)
             gain_factor = float(meta['imAiRangeMax']) / 512
             channel_gains = gain_factor * per_channel_gain * 1e6
-        elif meta['imDatPrb_type'] in ('21', '24') and stream_kind == 'ap':
+        elif meta['imDatPrb_type'] in ('21', '24', '2013', '2014') and stream_kind == 'ap':
             # This work with NP 2.0 case with different metadata versions
             # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_20.md#channel-entries-by-type
             # https://github.com/billkarsh/SpikeGLX/blob/gh-pages/Support/Metadata_20.md#imec


### PR DESCRIPTION
Hi All,

Some newer versions of NP probes (I think 'commercial 2B probes') have the metadata probe type as '2013' or '2014' rather than '21' or '24' as described [here](https://billkarsh.github.io/SpikeGLX/Sgl_help/Metadata_30.html).

It seems the only changes are to the 'Reference IDs':

```
Type-2013,2014 reference ID values are {0=ext, 1=gnd, [2..5]=tip[0..3]}. On-shank reference electrodes are removed from commercial 2B probes.
```

I assume these are not relevant for neo as these reference channels are automatically set to off?
i.e. from [here](https://billkarsh.github.io/SpikeGLX/Sgl_help/UserManual.html)

```
You can mark a site used=0 if you know it is broken or disconnected. For imec probes, we automatically set used=0 for reference sites and those you have turned off (bad channels) in the IM Setup tab.
```

So, simply also accepting '2013' and '2014' probes seems to work, though it feels a little too good to be true 😅 

I have a '2013' file to test against, happy to cut down and add to the testing repo. Currently I do not have a '2014' so this could be removed from this conditional in the case we want to test against it before rolling out.


