### PR TITLE
Switch Neo specific Code to F strings

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -416,8 +416,9 @@ class AnalogSignal(BaseSignal):
         '''
         Handle pretty-printing the :class:`AnalogSignal`.
         '''
-        pp.text(f"{self.__class__.__name__} with {self.shape[1]} channels of length {self.shape[0]}; "
-                f"units {self.units.dimesionality.string}; datatype {self.dtype} ")
+        pp.text(f"{self.__class__.__name__} with {self.shape[1]} channels of length "
+                f"{self.shape[0]}; units {self.units.dimesionality.string}; datatype "
+                f"{self.dtype}")
         if self._has_repr_pretty_attrs_():
             pp.breakable()
             self._repr_pretty_attrs_(pp, cycle)

--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -416,12 +416,8 @@ class AnalogSignal(BaseSignal):
         '''
         Handle pretty-printing the :class:`AnalogSignal`.
         '''
-        pp.text("{cls} with {channels} channels of length {length}; "
-                "units {units}; datatype {dtype} ".format(cls=self.__class__.__name__,
-                                                          channels=self.shape[1],
-                                                          length=self.shape[0],
-                                                          units=self.units.dimensionality.string,
-                                                          dtype=self.dtype))
+        pp.text(f"{self.__class__.__name__} with {self.shape[1]} channels of length {self.shape[0]}; "
+                f"units {self.units.dimesionality.string}; datatype {self.dtype} ")
         if self._has_repr_pretty_attrs_():
             pp.breakable()
             self._repr_pretty_attrs_(pp, cycle)
@@ -431,8 +427,8 @@ class AnalogSignal(BaseSignal):
             with pp.group(indent=1):
                 pp.text(line)
 
-        _pp("sampling rate: {}".format(self.sampling_rate))
-        _pp("time: {} to {}".format(self.t_start, self.t_stop))
+        _pp(f"sampling rate: {self.sampling_rate}")
+        _pp(f"time: {self.t_start} to {self.t_stop}")
 
     def time_index(self, t):
         """Return the array index (or indices) corresponding to the time (or times) `t`"""
@@ -716,7 +712,7 @@ class AnalogSignal(BaseSignal):
             raise MergeError(f'Signals are not continuous. Can not concatenate signals with gaps. '
                              f'Please provide a padding value.')
         if padding is not False:
-            logger.warning('Signals will be padded using {}.'.format(padding))
+            logger.warning(f'Signals will be padded using {padding}.')
             if padding is True:
                 padding = np.nan * units
             if isinstance(padding, pq.Quantity):

--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -33,8 +33,8 @@ def _check_annotations(value):
     """
     if isinstance(value, np.ndarray):
         if not issubclass(value.dtype.type, ALLOWED_ANNOTATION_TYPES):
-            raise ValueError("Invalid annotation. NumPy arrays with dtype %s"
-                             "are not allowed" % value.dtype.type)
+            raise ValueError(f"Invalid annotation. NumPy arrays with dtype {value.dtype.type}"
+                             f"are not allowed")
     elif isinstance(value, dict):
         for element in value.values():
             _check_annotations(element)
@@ -42,8 +42,8 @@ def _check_annotations(value):
         for element in value:
             _check_annotations(element)
     elif not isinstance(value, ALLOWED_ANNOTATION_TYPES):
-        raise ValueError("Invalid annotation. Annotations of type %s are not"
-                         "allowed" % type(value))
+        raise ValueError(f"Invalid annotation. Annotations of type {type(value)} are not"
+                         f"allowed")
 
 
 def merge_annotation(a, b):
@@ -58,8 +58,7 @@ def merge_annotation(a, b):
         For strings: concatenate with ';'
         Otherwise: fail if the annotations are not equal
     """
-    assert type(a) == type(b), 'type({}) {} != type({}) {}'.format(a, type(a),
-                                                               b, type(b))
+    assert type(a) == type(b), f'type({a})) {type(a)} != type({b}) {type(b)}'
     if isinstance(a, dict):
         return merge_annotations(a, b)
     elif isinstance(a, np.ndarray):  # concatenate b to a
@@ -72,7 +71,7 @@ def merge_annotation(a, b):
         else:
             return a + ";" + b
     else:
-        assert a == b, '{} != {}'.format(a, b)
+        assert a == b, f'{a} != {b}'
         return a
 
 
@@ -100,7 +99,7 @@ def merge_annotations(A, *Bs):
                     # exc.args += ('key %s' % name,)
                     # raise
                     merged[name] = "MERGE CONFLICT"  # temporary hack
-    logger.debug("Merging annotations: A=%s Bs=%s merged=%s", A, Bs, merged)
+    logger.debug(f"Merging annotations: A={A} Bs={Bs} merged={merged}")
     return merged
 
 
@@ -122,8 +121,7 @@ def intersect_annotations(A, B):
 
     for key in set(A.keys()) & set(B.keys()):
         v1, v2 = A[key], B[key]
-        assert type(v1) == type(v2), 'type({}) {} != type({}) {}'.format(v1, type(v1),
-                                                                         v2, type(v2))
+        assert type(v1) == type(v2), f'type({v1}) {type(v1)} != type({v2}) {type(v2)}'
         if isinstance(v1, dict) and v1 == v2:
             result[key] = deepcopy(v1)
         elif isinstance(v1, str) and v1 == v2:
@@ -299,7 +297,7 @@ class BaseNeo:
                 else:
                     pp.breakable()
                 with pp.group(indent=1):
-                    pp.text("{}: ".format(key))
+                    pp.text(f"{key}: ")
                     pp.pretty(value)
 
     def _repr_pretty_(self, pp, cycle):
@@ -366,8 +364,8 @@ class BaseNeo:
         according to the type of "obj"
         """
         if obj.__class__.__name__ not in self._parent_objects:
-            raise TypeError("{} can only have parents of type {}, not {}".format(
-                self.__class__.__name__, self._parent_objects, obj.__class__.__name__))
+            raise TypeError((f"{self.__class__.__name__} can only have parents of "
+                             f"type {self._parwents_objects}, not {obj.__class__.__name__}"))
         loc = self._parent_objects.index(obj.__class__.__name__)
         parent_attr = self._parent_attrs[loc]
         setattr(self, parent_attr, obj)

--- a/neo/core/basesignal.py
+++ b/neo/core/basesignal.py
@@ -259,7 +259,7 @@ class BaseSignal(DataObject):
             if attr_self == attr_other:
                 kwargs[name] = attr_self
             else:
-                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
+                kwargs[name] = f"merge({attr_self}, {attr_other})"
         merged_annotations = merge_annotations(self.annotations, other.annotations)
         kwargs.update(merged_annotations)
 

--- a/neo/core/container.py
+++ b/neo/core/container.py
@@ -563,7 +563,7 @@ class Container(BaseNeo):
         for container in self._child_containers:
             objs = getattr(self, container)
             if objs:
-                vals.append('{} {}'.format(len(objs), container))
+                vals.append(f'{objs} {container}')
         pp.text(', '.join(vals))
 
         if self._has_repr_pretty_attrs_():
@@ -573,7 +573,7 @@ class Container(BaseNeo):
         for container in self._repr_pretty_containers:
             pp.breakable()
             objs = getattr(self, container)
-            pp.text("# {} (N={})".format(container, len(objs)))
+            pp.text(f"# {container} (N={objs})")
             for (i, obj) in enumerate(objs):
                 pp.breakable()
                 pp.text("%s: " % i)

--- a/neo/core/dataobject.py
+++ b/neo/core/dataobject.py
@@ -73,7 +73,7 @@ def _normalize_array_annotations(value, length):
 
         if not own_length == val_length:
             raise ValueError(
-                "Incorrect length of array annotation: {} != {}".format(val_length, own_length))
+                f"Incorrect length of array annotation: {val_length} != {own_length}")
 
         # Local function used to check single elements of a list or an array
         # They must not be lists or arrays and fit the usual annotation data types
@@ -264,10 +264,10 @@ class DataObject(BaseNeo, pq.Quantity):
 
         # Warn if keys were omitted
         if omitted_keys_other or omitted_keys_self:
-            warnings.warn("The following array annotations were omitted, because they were only "
-                          "present in one of the merged objects: {} from the one that was merged "
-                          "into and {} from the one that was merged into the other"
-                          "".format(omitted_keys_self, omitted_keys_other), UserWarning)
+            warnings.warn(f"The following array annotations were omitted, because they were only "
+                          f"present in one of the merged objects: {omitted_keys_self} from the "
+                          f"one that was merged into and {omitted_keys_other} from the one that "
+                          f"was merged into the other", UserWarning)
 
         # Return the merged array_annotations
         return merged_array_annotations

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -263,7 +263,7 @@ class Epoch(DataObject):
             if attr_self == attr_other:
                 kwargs[name] = attr_self
             else:
-                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
+                kwargs[name] = f"merge({attr_self}, {attr_other})"
 
         merged_annotations = merge_annotations(self.annotations, other.annotations)
         kwargs.update(merged_annotations)
@@ -354,8 +354,8 @@ class Epoch(DataObject):
 
     def set_labels(self, labels):
         if self.labels is not None and self.labels.size > 0 and len(labels) != self.size:
-            raise ValueError("Labels array has different length to times ({} != {})"
-                             .format(len(labels), self.size))
+            raise ValueError(f"Labels array has different length to times "
+                             f"({len(labels)} != {self.size})")
         self._labels = np.array(labels)
 
     def get_labels(self):
@@ -365,8 +365,8 @@ class Epoch(DataObject):
 
     def set_durations(self, durations):
         if self.durations is not None and self.durations.size > 0 and len(durations) != self.size:
-            raise ValueError("Durations array has different length to times ({} != {})"
-                             .format(len(durations), self.size))
+            raise ValueError("Durations array has different length to times "
+                             f"({len(durations)} != {self.size})")
         self._durations = durations
 
     def get_durations(self):

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -101,7 +101,7 @@ class Event(DataObject):
         # reference dimensionality
         if (len(dim) != 1 or list(dim.values())[0] != 1 or not isinstance(list(dim.keys())[0],
                                                                           pq.UnitTime)):
-            ValueError("Unit {} has dimensions {}, not [time]".format(units, dim.simplified))
+            ValueError(f"Unit {units} has dimensions {dim.simplified}, not [time].")
 
         obj = pq.Quantity(times, units=dim).view(cls)
         obj._labels = labels
@@ -204,7 +204,7 @@ class Event(DataObject):
             if attr_self == attr_other:
                 kwargs[name] = attr_self
             else:
-                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
+                kwargs[name] = f"merge({attr_self}, {attr_other})"
 
         print('Event: merge annotations')
         merged_annotations = merge_annotations(self.annotations, other.annotations)
@@ -244,8 +244,8 @@ class Event(DataObject):
 
     def set_labels(self, labels):
         if self.labels is not None and self.labels.size > 0 and len(labels) != self.size:
-            raise ValueError("Labels array has different length to times ({} != {})"
-                            .format(len(labels), self.size))
+            raise ValueError(f"Labels array has different length to times "
+                             f"({len(labels)} != {self.size})")
         self._labels = np.array(labels)
 
     def get_labels(self):
@@ -353,13 +353,13 @@ class Event(DataObject):
             times = self.times[::2]
             durations = self.times[1::2] - times
             labels = np.array(
-                ["{}-{}".format(a, b) for a, b in zip(self.labels[::2], self.labels[1::2])])
+                [f"{a}-{b}" for a, b in zip(self.labels[::2], self.labels[1::2])])
         elif durations is None:
             # Mode 1
             times = self.times[:-1]
             durations = np.diff(self.times)
             labels = np.array(
-                ["{}-{}".format(a, b) for a, b in zip(self.labels[:-1], self.labels[1:])])
+                [f"{a}-{b}" for a, b in zip(self.labels[:-1], self.labels[1:])])
         else:
             # Mode 3
             times = self.times

--- a/neo/core/group.py
+++ b/neo/core/group.py
@@ -141,8 +141,8 @@ class Group(Container):
         """Add a new Neo object to the Group"""
         for obj in objects:
             if self.allowed_types and not isinstance(obj, self.allowed_types):
-                raise TypeError("This Group can only contain {}, but not {}"
-                                "".format(self.allowed_types, type(obj)))
+                raise TypeError(f"This Group can only contain {self.allowed_types}, "
+                                f"but not {type(obj)}")
         super().add(*objects)
 
     def walk(self):

--- a/neo/core/imagesequence.py
+++ b/neo/core/imagesequence.py
@@ -188,16 +188,10 @@ class ImageSequence(BaseSignal):
         Handle pretty-printing the :class:`ImageSequence`.
         """
         pp.text(
-            "{cls} {nframe} frames with width {width} px and height {height} px; "
-            "units {units}; datatype {dtype} ".format(
-                cls=self.__class__.__name__,
-                nframe=self.shape[0],
-                height=self.shape[1],
-                width=self.shape[2],
-                units=self.units.dimensionality.string,
-                dtype=self.dtype,
+            f"{self.__class__.__name__} {self.shape[0]} frames with "
+            f"width {self.shape[2]} px and height {self.shape[1]} px; "
+            f"units {self.units.dimensionality.string}; datatype {self.dtype} "
             )
-        )
 
         def _pp(line):
             pp.breakable()
@@ -205,8 +199,8 @@ class ImageSequence(BaseSignal):
                 pp.text(line)
 
         for line in [
-            "sampling rate: {!s}".format(self.sampling_rate),
-            "spatial_scale: {!s}".format(self.spatial_scale),
+            f"sampling rate: {self.sampling_rate}",
+            f"spatial_scale: {self.spatial_scale}"
         ]:
             _pp(line)
 

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -192,8 +192,8 @@ class IrregularlySampledSignal(BaseSignal):
         '''
         Returns a string representing the :class:`IrregularlySampledSignal`.
         '''
-        return '<{}({} at times {})>'.format(
-            self.__class__.__name__, super().__repr__(), self.times)
+        return (f"<{self.__class__.__name__}({super().__repr__()} "
+        f"at times {self.times})>")
 
     def __getitem__(self, i):
         '''
@@ -286,8 +286,7 @@ class IrregularlySampledSignal(BaseSignal):
             return
         # dimensionality should match
         if self.ndim != other.ndim:
-            raise ValueError('Dimensionality does not match: {} vs {}'.format(
-                self.ndim, other.ndim))
+            raise ValueError(f'Dimensionality does not match: {self.ndim} vs {other.ndim}')
         # if if the other array does not have a times property,
         # then it should be okay to add it directly
         if not hasattr(other, 'times'):
@@ -295,7 +294,7 @@ class IrregularlySampledSignal(BaseSignal):
 
         # if there is a times property, the times need to be the same
         if not (self.times == other.times).all():
-            raise ValueError('Times do not match: {} vs {}'.format(self.times, other.times))
+            raise ValueError(f'Times do not match: {self.times} vs {other.times}')
 
     def __rsub__(self, other, *args):
         '''
@@ -307,12 +306,9 @@ class IrregularlySampledSignal(BaseSignal):
         '''
         Handle pretty-printing the :class:`IrregularlySampledSignal`.
         '''
-        pp.text("{cls} with {channels} channels of length {length}; "
-                "units {units}; datatype {dtype} ".format(cls=self.__class__.__name__,
-                                                          channels=self.shape[1],
-                                                          length=self.shape[0],
-                                                          units=self.units.dimensionality.string,
-                                                          dtype=self.dtype))
+        pp.text(f"{self.__class__.__name__} with {self.shape[1]} channels of length "
+                f"{self.shape[0]}; units {self.units.dimensionality.string}; datatype "
+                f"{self.dtype}")
         if self._has_repr_pretty_attrs_():
             pp.breakable()
             self._repr_pretty_attrs_(pp, cycle)
@@ -322,7 +318,7 @@ class IrregularlySampledSignal(BaseSignal):
             with pp.group(indent=1):
                 pp.text(line)
 
-        for line in ["sample times: {}".format(self.times)]:
+        for line in [f"sample times: {self.times}"]:
             _pp(line)
 
     @property
@@ -485,7 +481,7 @@ class IrregularlySampledSignal(BaseSignal):
             if attr_self == attr_other:
                 kwargs[name] = attr_self
             else:
-                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
+                kwargs[name] = f"merge({attr_self}, {attr_other})"
         merged_annotations = merge_annotations(self.annotations, other.annotations)
         kwargs.update(merged_annotations)
 
@@ -564,7 +560,7 @@ class IrregularlySampledSignal(BaseSignal):
             if attr_self == attr_other:
                 kwargs[name] = attr_self
             else:
-                kwargs[name] = "merge({}, {})".format(attr_self, attr_other)
+                kwargs[name] = f"merge({attr_self}, {attr_other})"
         merged_annotations = merge_annotations(self.annotations, other.annotations)
         kwargs.update(merged_annotations)
 

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -41,8 +41,7 @@ def check_has_dimensions_time(*values):
                 list(dim.values())[0] != 1 or not
                 isinstance(list(dim.keys())[0], pq.UnitTime)):
             errmsgs.append(
-                "value {} has dimensions {}, not [time]".format(
-                    value, dim))
+                f"value {value} has dimensions {dim}, not [time]")
     if errmsgs:
         raise ValueError("\n".join(errmsgs))
 
@@ -58,7 +57,7 @@ def _check_time_in_range(value, t_start, t_stop, view=False):
     '''
 
     if t_start > t_stop:
-        raise ValueError("t_stop ({}) is before t_start ({})".format(t_stop, t_start))
+        raise ValueError(f"t_stop ({t_stop}) is before t_start ({s_start})")
 
     if not value.size:
         return
@@ -69,9 +68,9 @@ def _check_time_in_range(value, t_start, t_stop, view=False):
         t_stop = t_stop.view(np.ndarray)
 
     if value.min() < t_start:
-        raise ValueError("The first spike ({}) is before t_start ({})".format(value, t_start))
+        raise ValueError(f"The first spike ({value}) is before t_start ({t_start})")
     if value.max() > t_stop:
-        raise ValueError("The last spike ({}) is after t_stop ({})".format(value, t_stop))
+        raise ValueError(f"The last spike ({value}) is after t_stop ({t_stop})")
 
 
 def _check_waveform_dimensions(spiketrain):
@@ -824,10 +823,10 @@ class SpikeTrain(DataObject):
                               if key not in self.array_annotations]
 
         if omitted_keys_self or omitted_keys_other:
-            warnings.warn("The following array annotations were omitted, because they were only "
-                          "present in one of the merged objects: {} from the one that was merged "
-                          "into and {} from the ones that were merged into it."
-                          "".format(omitted_keys_self, omitted_keys_other), UserWarning)
+            warnings.warn(f"The following array annotations were omitted, because they were only "
+                          f"present in one of the merged objects: {omitted_keys_self} from the "
+                          f"one that was merged into and {omitted_keys_other} from the ones that "
+                          f"were merged into it.", UserWarning)
 
         return merged_array_annotations
 

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -57,7 +57,7 @@ def _check_time_in_range(value, t_start, t_stop, view=False):
     '''
 
     if t_start > t_stop:
-        raise ValueError(f"t_stop ({t_stop}) is before t_start ({s_start})")
+        raise ValueError(f"t_stop ({t_stop}) is before t_start ({t_start})")
 
     if not value.size:
         return

--- a/neo/core/spiketrainlist.py
+++ b/neo/core/spiketrainlist.py
@@ -122,7 +122,7 @@ class SpikeTrainList(ObjectList):
                 return str([])
             else:
                 return (f"SpikeTrainList containing {self._spike_time_array.size} "
-                        f"spikes from {len(self._all_channels_ids)} neurons")
+                        f"spikes from {len(self._all_channel_ids)} neurons")
         else:
             return str(self._items)
 

--- a/neo/core/spiketrainlist.py
+++ b/neo/core/spiketrainlist.py
@@ -121,9 +121,8 @@ class SpikeTrainList(ObjectList):
             if self._spike_time_array is None:
                 return str([])
             else:
-                return "SpikeTrainList containing {} spikes from {} neurons".format(
-                    self._spike_time_array.size,
-                    len(self._all_channel_ids))
+                return (f"SpikeTrainList containing {self._spike_time_array.size} "
+                        f"spikes from {len(self._all_channels_ids)} neurons")
         else:
             return str(self._items)
 

--- a/neo/io/basefromrawio.py
+++ b/neo/io/basefromrawio.py
@@ -145,7 +145,7 @@ class BaseFromRaw(BaseIO):
             spike_channels = self.header['spike_channels']
             st_groups = []
             for c in range(spike_channels.size):
-                group = Group(name='SpikeTrain group {}'.format(c))
+                group = Group(name=f'SpikeTrain group {c}')
                 group.annotate(unit_name=spike_channels[c]['name'])
                 group.annotate(unit_id=spike_channels[c]['id'])
                 bl.groups.append(group)

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -183,7 +183,7 @@ class BaseRawIO:
         return self._source_name()
 
     def __repr__(self):
-        txt = f'{self.__class.__.__name__}: {self.source_name()}\n'
+        txt = f'{self.__class__.__name__}: {self.source_name()}\n'
         if self.header is not None:
             nb_block = self.block_count()
             txt += f'nb_block: {nb_block}\n'

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -183,12 +183,12 @@ class BaseRawIO:
         return self._source_name()
 
     def __repr__(self):
-        txt = '{}: {}\n'.format(self.__class__.__name__, self.source_name())
+        txt = f'{self.__class.__.__name__}: {self.source_name()}\n'
         if self.header is not None:
             nb_block = self.block_count()
-            txt += 'nb_block: {}\n'.format(nb_block)
+            txt += f'nb_block: {nb_block}\n'
             nb_seg = [self.segment_count(i) for i in range(nb_block)]
-            txt += 'nb_segment:  {}\n'.format(nb_seg)
+            txt += f'nb_segment:  {nb_seg}\n'
 
             # signal streams
             v = [s['name'] + f' (chans: {self.signal_channels_count(i)})'
@@ -325,18 +325,18 @@ class BaseRawIO:
         txt = 'Raw annotations\n'
         for block_index in range(self.block_count()):
             bl_a = self.raw_annotations['blocks'][block_index]
-            txt += '*Block {}\n'.format(block_index)
+            txt += f'*Block {block_index}\n'
             for k, v in bl_a.items():
                 if k in ('segments',):
                     continue
-                txt += '  -{}: {}\n'.format(k, v)
+                txt += f'  -{k}: {v}\n'
             for seg_index in range(self.segment_count(block_index)):
                 seg_a = bl_a['segments'][seg_index]
-                txt += '  *Segment {}\n'.format(seg_index)
+                txt += f'  *Segment {seg_index}\n'
                 for k, v in seg_a.items():
                     if k in ('signals', 'spikes', 'events',):
                         continue
-                    txt += '    -{}: {}\n'.format(k, v)
+                    txt += f'    -{k}: {v}\n'
 
                 # annotations by channels for spikes/events/epochs
                 for child in ('signals', 'events', 'spikes', ):
@@ -744,14 +744,14 @@ class BaseRawIO:
         hash = joblib.hash(d, hash_name='md5')
 
         # name is constructed from the resource_name and the hash
-        name = '{}_{}'.format(os.path.basename(resource_name), hash)
+        name = f'{os.path.basename(resource_name)}_{hash}'
         self.cache_filename = os.path.join(dirname, name)
 
         if os.path.exists(self.cache_filename):
-            self.logger.warning('Use existing cache file {}'.format(self.cache_filename))
+            self.logger.warning(f'Use existing cache file {self.cache_filename}'
             self._cache = joblib.load(self.cache_filename)
         else:
-            self.logger.warning('Create cache file {}'.format(self.cache_filename))
+            self.logger.warning(f'Create cache file {self.cache_filename}'
             self._cache = {}
             self.dump_cache()
 

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -748,10 +748,10 @@ class BaseRawIO:
         self.cache_filename = os.path.join(dirname, name)
 
         if os.path.exists(self.cache_filename):
-            self.logger.warning(f'Use existing cache file {self.cache_filename}'
+            self.logger.warning(f'Use existing cache file {self.cache_filename}')
             self._cache = joblib.load(self.cache_filename)
         else:
-            self.logger.warning(f'Create cache file {self.cache_filename}'
+            self.logger.warning(f'Create cache file {self.cache_filename}')
             self._cache = {}
             self.dump_cache()
 


### PR DESCRIPTION
I switched a lot of the `.format` and some of the `%` to f-strings. Neo is 3.8 + right now and f-strings were introduced in 3.6.  They are faster (~ 1.5-2x compared to format) and at least to some, myself included, more readable. 

I didn't touch any of the ios/rawios in this PR.
Take a read and let me know what you think.