### PR TITLE
Switch `np.math.ceil` to `math.ceil` as the former is deprecated as of NumPy 1.25

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -646,7 +646,7 @@ class BlackrockRawIO(BaseRawIO):
         if t_start is None:
             ind_start = None
         else:
-            ts = np.math.ceil(t_start * self.__nev_basic_header['timestamp_resolution'])
+            ts = int(np.ceil(t_start * self.__nev_basic_header['timestamp_resolution']))
             ind_start = np.searchsorted(timestamp, ts)
 
         if t_stop is None:

--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -61,6 +61,7 @@ import datetime
 import os
 import re
 import warnings
+import math
 
 import numpy as np
 import quantities as pq
@@ -646,7 +647,7 @@ class BlackrockRawIO(BaseRawIO):
         if t_start is None:
             ind_start = None
         else:
-            ts = int(np.ceil(t_start * self.__nev_basic_header['timestamp_resolution']))
+            ts = math.ceil(t_start * self.__nev_basic_header['timestamp_resolution'])
             ind_start = np.searchsorted(timestamp, ts)
 
         if t_stop is None:


### PR DESCRIPTION
This is just a minor deprecation fix PR that I saw while running the test suite.