### PR TITLE
Fix `test_asciisignalio` to work on Windows

### DIFF
--- a/neo/test/iotest/test_asciisignalio.py
+++ b/neo/test/iotest/test_asciisignalio.py
@@ -55,7 +55,7 @@ class TestAsciiSignalIO(unittest.TestCase):
             (-64.6, -64.2, -77.0, 0.7),
             (-64.3, -64.0, -99.9, 0.8)
         ]
-        with open(filename, 'w') as csvfile:
+        with open(filename,'w', newline='') as csvfile:
             writer = csv.writer(csvfile, delimiter=',',
                                 quotechar='|', quoting=csv.QUOTE_MINIMAL)
             for row in sample_data:


### PR DESCRIPTION
Since Windows use a different newline in order for the csv to work the `newline` argument must be specified. Adding this doesn't affect Linux testing, but it makes my life better when running local tests on Windows.