### PR TITLE
Fix `format` typo in axonrawio assert statement

### DIFF
--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -85,7 +85,7 @@ class AxonRawIO(BaseRawIO):
         elif version >= 2.:
             mode = info['protocol']['nOperationMode']
 
-        assert mode in [1, 2, 3, 5], 'Mode {} is not supported'.formagt(mode)
+        assert mode in [1, 2, 3, 5], 'Mode {} is not supported'.format(mode)
         # event-driven variable-length mode (mode 1)
         # event-driven fixed-length mode (mode 2 or 5)
         # gap free mode (mode 3) can be in several episodes


### PR DESCRIPTION
Found by @ctigaret, but then the PR was closed. So either that one can be merged if reopened or this one could be merged to fix the typo in the rawio.

#1325 