### PR TITLE
Download correct ddl for 64 system on windows with Plexon

### DIFF
--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -301,7 +301,7 @@ class Plexon2RawIO(BaseRawIO):
         stream_id = self.header['signal_streams'][stream_index]['id']
         stream_characteristic = list(self.signal_stream_characteristics.values())[stream_index]
         assert stream_id == stream_characteristic.id
-        return stream_characteristic.n_samples
+        return int(stream_characteristic.n_samples)  # Avoids returning a numpy.int64 scalar
 
     def _get_signal_t_start(self, block_index, seg_index, stream_index):
         # This returns the t_start of signals as a float value in seconds

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -86,7 +86,7 @@ class Plexon2RawIO(BaseRawIO):
             pl2_dll_folder.mkdir(exist_ok=True)
             pl2_dll_file_path = pl2_dll_folder / file_name
 
-            if not pl2_dll_file_path.exists():
+            if pl2_dll_file_path.exists():
                 # I think this warning should be removed
                 # Warnings should provide a solution but this is just a reminder to the user of normal behavior
                 # Nothing to do

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -77,9 +77,9 @@ class Plexon2RawIO(BaseRawIO):
         # download default PL2 dll once if not yet available
         if pl2_dll_file_path is None:
             architecture = platform.architecture()[0]
-            if architecture == '64bit':
+            if architecture == '64bit' and platform.system() == 'Windows':
                 file_name = "PL2FileReader64.dll"
-            else:
+            else:  # Apparently wine uses the 32 bit version in linux
                 file_name = "PL2FileReader.dll"
             
             pl2_dll_folder = pathlib.Path.home() / '.plexon_dlls_for_neo'
@@ -88,11 +88,12 @@ class Plexon2RawIO(BaseRawIO):
 
             if pl2_dll_file_path.exists():
                 # I think this warning should be removed
-                # Warnings should provide a solution but this is just a reminder to the user of normal behavior
-                # Nothing to do
+                # Warnings should provide a solution but this is 
+                # just a reminder to the user of normal behavior
                 warnings.warn(f'Using cached plexon dll at {pl2_dll_file_path}')  
             else:
-                dist = urlopen(f'https://raw.githubusercontent.com/Neuralensemble/pypl2/master/bin/{file_name}')
+                url = f'https://raw.githubusercontent.com/Neuralensemble/pypl2/master/bin/{file_name}'
+                dist = urlopen(url=url)
 
                 with open(pl2_dll_file_path, 'wb') as f:
                     print(f'Downloading plexon dll to {pl2_dll_file_path}')

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -23,6 +23,8 @@ Author: Julia Sprenger
 """
 import pathlib
 import warnings
+import platform
+
 from collections import namedtuple
 from urllib.request import urlopen
 from datetime import datetime
@@ -74,14 +76,24 @@ class Plexon2RawIO(BaseRawIO):
 
         # download default PL2 dll once if not yet available
         if pl2_dll_file_path is None:
-            pl2_dll_folder = pathlib.Path .home() / '.plexon_dlls_for_neo'
-            pl2_dll_folder.mkdir(exist_ok=True)
-            pl2_dll_file_path = pl2_dll_folder / 'PL2FileReader.dll'
-
-            if pl2_dll_file_path.exists():
-                warnings.warn(f'Using cached plexon dll at {pl2_dll_file_path}')
+            architecture = platform.architecture()[0]
+            if architecture == '64bit':
+                file_name = "PL2FileReader64.dll"
             else:
-                dist = urlopen('https://raw.githubusercontent.com/Neuralensemble/pypl2/master/bin/PL2FileReader.dll')
+                file_name = "PL2FileReader.dll"
+            
+            pl2_dll_folder = pathlib.Path.home() / '.plexon_dlls_for_neo'
+            pl2_dll_folder.mkdir(exist_ok=True)
+            pl2_dll_file_path = pl2_dll_folder / file_name
+
+            if not pl2_dll_file_path.exists():
+                # I think this warning should be removed
+                # Warnings should provide a solution but this is just a reminder to the user of normal behavior
+                # Nothing to do
+                warnings.warn(f'Using cached plexon dll at {pl2_dll_file_path}')  
+            else:
+                dist = urlopen(f'https://raw.githubusercontent.com/Neuralensemble/pypl2/master/bin/{file_name}')
+
                 with open(pl2_dll_file_path, 'wb') as f:
                     print(f'Downloading plexon dll to {pl2_dll_file_path}')
                     f.write(dist.read())

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -86,12 +86,7 @@ class Plexon2RawIO(BaseRawIO):
             pl2_dll_folder.mkdir(exist_ok=True)
             pl2_dll_file_path = pl2_dll_folder / file_name
 
-            if pl2_dll_file_path.exists():
-                # I think this warning should be removed
-                # Warnings should provide a solution but this is 
-                # just a reminder to the user of normal behavior
-                warnings.warn(f'Using cached plexon dll at {pl2_dll_file_path}')  
-            else:
+            if not pl2_dll_file_path.exists():
                 url = f'https://raw.githubusercontent.com/Neuralensemble/pypl2/master/bin/{file_name}'
                 dist = urlopen(url=url)
 


### PR DESCRIPTION
Currently plexon download is fixed to use the 32 bits architecture. This means that plexon is not working if the windows machine is 64 bits. This PR fixes this by adding code that checks the architecture and selects the appropriate file to download based on that query.

There is a warning that I think should be removed in the code. Let me know what you think.

[EDIT] it seems that wine on linux uses the 32 bit architecture (I wonder why?) so I added code that restricts the 64 dll only for windows which does make sense anyway.