### PR TITLE
Gain calculation for Neuropixel 2.0 might be wrong

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -409,7 +409,8 @@ def extract_stream_info(meta_file, meta):
             # We allow also LF streams for NP2.0 because CatGT can produce them
             # See: https://github.com/SpikeInterface/spikeinterface/issues/1949
             per_channel_gain[:-1] = 1 / 80.
-            gain_factor = float(meta['imAiRangeMax']) / 8192
+            max_int = int(meta['imMaxInt']) if 'imMaxInt' in meta else 8192
+            gain_factor = float(meta['imAiRangeMax']) / max_int
             channel_gains = gain_factor * per_channel_gain * 1e6
         else:
             raise NotImplementedError('This meta file version of spikeglx'

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -408,7 +408,10 @@ def extract_stream_info(meta_file, meta):
             # https://github.com/billkarsh/SpikeGLX/blob/15ec8898e17829f9f08c226bf04f46281f106e5f/Markdown/Metadata_30.md#imec
             # We allow also LF streams for NP2.0 because CatGT can produce them
             # See: https://github.com/SpikeInterface/spikeinterface/issues/1949
-            per_channel_gain[:-1] = 1 / 80.
+            if 'imChan0apGain' in meta:
+                per_channel_gain[:-1] = 1 / float(meta['imChan0apGain'])
+            else:
+                per_channel_gain[:-1] = 1 / 80.
             max_int = int(meta['imMaxInt']) if 'imMaxInt' in meta else 8192
             gain_factor = float(meta['imAiRangeMax']) / max_int
             channel_gains = gain_factor * per_channel_gain * 1e6


### PR DESCRIPTION
For commercial 2.0 probes, the manual says the ADC is 12 bits, which would make the highest positive value to be 2048, not 8192, as is hardcoded in the code. In the metadata of my recordings, `imMaxInt=2048`. 

Jennifer Colonnel's code [here](https://github.com/jenniferColonell/SpikeGLX_Datafile_Tools/blob/4b6c28658b715808e4941e43d5fa0c57198b09da/Python/DemoReadSGLXData/readSGLX.py#L78C29-L78C29) uses the imMaxInt to calculate the gain factor. 
