### PR TITLE
Increase line limit for pep8 speaks

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,5 +1,5 @@
 pycodestyle:
-    max-line-length: 99  # Default is 79 in PEP8
+    max-line-length: 120  # Default is 79 in PEP8
     ignore:
       - W503 # Change in PEP8, this warning is replaced by W504
       - E127


### PR DESCRIPTION
Since there is no consensus on adding linting yet could we at least switch pep8speaks to something more reasonable. For me I prefer anything > 110, but I know @alejoe91 likes 120, so that is what I switched this to. Would you at least be okay with that @samuelgarcia ?