### PR TITLE
Add workflow actions for automated release to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi-test.yml
+++ b/.github/workflows/publish-to-pypi-test.yml
@@ -1,0 +1,43 @@
+name: Release to Test PyPI
+
+on:
+  push:
+    tags:
+       - '*'
+jobs:
+  release:
+    environment: TEST_PYPI_API_TOKEN
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install Tools
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine build
+        pip install .
+    - name: Test version/tag correspondence
+      id: version-check
+      run: |
+        neo_version=$(python -c "import neo; print(neo.__version__)")
+        if [[ ${{ github.event.release.tag_name }} == $neo_version ]]; then
+            echo "VERSION_TAG_MATCH=true" >> $GITHUB_OUTPUT
+            echo "Version matches tag, proceeding with release to Test PyPI"
+        else
+            echo "VERSION_TAG_MATCH=false" >> $GITHUB_OUTPUT
+            echo "Version does not match tag! Fix this before proceeding."
+            exit 1
+        fi
+    - name: Package and Upload
+      env:
+        STACKMANAGER_VERSION: ${{ github.event.release.tag_name }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      if: ${{ steps.version-check.outputs.VERSION_TAG_MATCH == 'true' }}
+      run: |
+        python -m build --sdist --wheel
+        twine upload --repository testpypi dist/*

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -25,4 +25,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         python -m build --sdist --wheel
-        twine upload --repository testpypi dist/*
+        twine upload dist/*

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,28 @@
+name: Release to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    environment: PYPI_API_TOKEN
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install Tools
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine build
+    - name: Package and Upload
+      env:
+        STACKMANAGER_VERSION: ${{ github.event.release.tag_name }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python -m build --sdist --wheel
+        twine upload --repository testpypi dist/*


### PR DESCRIPTION
As discussed, this PR adds two actions for releasing NEO:

1. `Release to Test PyPI`: this action is run at every tag and it:
    - checks that `neo.__version__` corresponds to the `tag`
    - uploads to Test PyPI (added an environment secret `TEST_PYPI_API_TOKEN`) 

2. `Release to real PyPI`: this action needs to be triggered manually (after the test pypi action succeeded), to upload to PyPI


@apdavison can you add me as maintainer of the `neo` package on Test PyPI?