### PR TITLE
Handle Pegasus 2.1.1 Nev files and tests of same.

### DIFF
--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -311,7 +311,7 @@ class NlxHeader(OrderedDict):
 
         elif 'FileType' in self:
 
-            if 'FileVersion' in self and self['FileVersion'] in ['3.3', '3.4']:
+            if 'FileVersion' in self and self['FileVersion'] in ['3.2', '3.3', '3.4']:
                 return self['AcquisitionSystem'].split()[1].upper()
 
             else:

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -27,7 +27,8 @@ class TestNeuralynxRawIO(BaseTestRawIO, unittest.TestCase, ):
         'neuralynx/Cheetah_v5.5.1/original_data',
         'neuralynx/Cheetah_v5.6.3/original_data',
         'neuralynx/Cheetah_v5.7.4/original_data',
-        'neuralynx/Cheetah_v6.3.2/incomplete_blocks']
+        'neuralynx/Cheetah_v6.3.2/incomplete_blocks'
+    ]
 
     def test_scan_ncs_files(self):
 
@@ -187,7 +188,9 @@ class TestNcsRecordingType(TestNeuralynxRawIO, unittest.TestCase):
         ('neuralynx/Cheetah_v5.6.3/original_data/CSC1.ncs', 'DIGITALLYNXSX'),
         ('neuralynx/Cheetah_v5.6.3/original_data/TT1.ntt', 'DIGITALLYNXSX'),
         ('neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs', 'DIGITALLYNXSX'),
-        ('neuralynx/Cheetah_v6.3.2/incomplete_blocks/CSC1_reduced.ncs', 'DIGITALLYNXSX')]
+        ('neuralynx/Cheetah_v6.3.2/incomplete_blocks/CSC1_reduced.ncs', 'DIGITALLYNXSX'),
+        ('neuralynx/Pegasus_v2.1.1/Events_0008.nev','ATLAS') ]
+
 
     def test_recording_types(self):
 


### PR DESCRIPTION
This is an older item that was due and is in preparation for dealing with issue #1370. 
Tests use the Pegasus 2.1.1 data already in the ephy_testing_data repository.