### PR TITLE
openephys legacy format : handle gaps more correctly

### DIFF
--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -117,7 +117,7 @@ class OpenEphysRawIO(BaseRawIO):
                 
                 if channel_has_gaps:
                     # protect against strange timestamp block like in file 'OpenEphys_SampleData_3' CH32
-                    assert np.median(diff) == RECORD_SIZE, f"This file has strange block timestamp for channel {chan_id}"
+                    assert np.median(diff) == RECORD_SIZE, f"This file has non valid data block size for channel {chan_id}, this case cannot be handle"
 
                 if seg_index == 0:
                     # add in channel list

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -62,9 +62,10 @@ class OpenEphysRawIO(BaseRawIO):
     extensions = ['continuous', 'openephys', 'spikes', 'events', 'xml']
     rawmode = 'one-dir'
 
-    def __init__(self, dirname='', ignore_timestamps_errors=None):
+    def __init__(self, dirname='', ignore_timestamps_errors=None, fill_gap_value=0):
         BaseRawIO.__init__(self)
         self.dirname = dirname
+        self.fill_gap_value = int(fill_gap_value)
         if ignore_timestamps_errors is not None:
             self.logger.warning("OpenEphysRawIO ignore_timestamps_errors=True/False is not used anymore")
 
@@ -313,7 +314,7 @@ class OpenEphysRawIO(BaseRawIO):
             channel_indexes = slice(None)
         global_channel_indexes = global_channel_indexes[channel_indexes]
 
-        sigs_chunk = np.zeros((i_stop - i_start, len(global_channel_indexes)), dtype='int16')
+        sigs_chunk = np.ones((i_stop - i_start, len(global_channel_indexes)), dtype='int16') * self.fill_gap_value
 
         if not self._gap_mode:
             # previous behavior block index are linear

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -142,7 +142,7 @@ class OpenEphysRawIO(BaseRawIO):
                                     'clipping to make them aligned.')
 
                 first = max(all_first_timestamps)
-                last = max(all_last_timestamps)
+                last = min(all_last_timestamps)
                 for chan_index in self._sigs_memmap[seg_index]:
                     data_chan = self._sigs_memmap[seg_index][chan_index]
                     keep = (data_chan['timestamp'] >= first) & (data_chan['timestamp'] < last)
@@ -514,7 +514,6 @@ def explore_folder(dirname):
     "100_CH0_2.continuous" ---> seg_index 1
     "100_CH0_N.continuous" ---> seg_index N-1
     """
-    print(dirname, type(dirname))
     filenames = os.listdir(dirname)
     filenames.sort()
 

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -55,7 +55,7 @@ class OpenEphysRawIO(BaseRawIO):
         hypothesis.
       * A recording can contain gaps due to USB stream loss when high CPU load when recording.
         Theses gaps are checked channel per channel which make the parse_header() slow.
-        I gaps are detected then they are filled with zeros but the the reading will be much slower for getting signals.
+        If gaps are detected then they are filled with zeros but the the reading will be much slower for getting signals.
 
     """
     # file formats used by openephys
@@ -129,8 +129,8 @@ class OpenEphysRawIO(BaseRawIO):
                                 'int16', units, chan_info['bitVolts'], 0., processor_id))
                 
             if any(self._sig_has_gap[seg_index].values()):
-                channel_with_gapes = list(self._sig_has_gap[seg_index].keys())
-                self.logger.warning(f"This OpenEphys dataset contains gaps for some channels {channel_with_gapes} in segment {seg_index} the read will be slow")
+                channel_with_gaps = list(self._sig_has_gap[seg_index].keys())
+                self.logger.warning(f"This OpenEphys dataset contains gaps for some channels {channel_with_gaps} in segment {seg_index} the read will be slow")
                 self._gap_mode = True
 
             

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -117,7 +117,7 @@ class OpenEphysRawIO(BaseRawIO):
                 
                 if channel_has_gaps:
                     # protect against strange timestamp block like in file 'OpenEphys_SampleData_3' CH32
-                    assert np.median(diff) == RECORD_SIZE, f"This file has non valid data block size for channel {chan_id}, this case cannot be handle"
+                    assert np.median(diff) == RECORD_SIZE, f"This file has a non valid data block size for channel {chan_id}, this case cannot be handled"
 
                 if seg_index == 0:
                     # add in channel list

--- a/neo/test/rawiotest/rawio_compliance.py
+++ b/neo/test/rawiotest/rawio_compliance.py
@@ -243,6 +243,7 @@ def read_analogsignals(reader):
                     chunks.append(raw_chunk)
                     i_start += chunksize
                 chunk_raw_sigs = np.concatenate(chunks, axis=0)
+
                 np.testing.assert_array_equal(ref_raw_sigs, chunk_raw_sigs)
 
 

--- a/neo/test/rawiotest/test_openephysrawio.py
+++ b/neo/test/rawiotest/test_openephysrawio.py
@@ -10,23 +10,11 @@ class TestOpenEphysRawIO(BaseTestRawIO, unittest.TestCase, ):
         'openephys'
     ]
     entities_to_test = [
-        'openephys/OpenEphys_SampleData_1',
-        # 'OpenEphys_SampleData_2_(multiple_starts)',  # This not implemented this raise error
-        # 'OpenEphys_SampleData_3',
+        # 'openephys/OpenEphys_SampleData_1',
+        # this file has gaps and this is now handle corretly
+        'openephys/OpenEphys_SampleData_2_(multiple_starts)',
+        # 'openephys/OpenEphys_SampleData_3',
     ]
-
-    def test_raise_error_if_discontinuous_files(self):
-        # the case of discontinuous signals is NOT cover by the IO for the moment
-        # It must raise an error
-        reader = OpenEphysRawIO(dirname=self.get_local_path(
-            'openephys/OpenEphys_SampleData_2_(multiple_starts)'))
-        with self.assertRaises(ValueError):
-            reader.parse_header()
-        # if ignore_timestamps_errors=True, no exception is raised
-        reader = OpenEphysRawIO(dirname=self.get_local_path(
-            'openephys/OpenEphys_SampleData_2_(multiple_starts)'),
-                                ignore_timestamps_errors=True)
-        reader.parse_header()
 
 
     def test_raise_error_if_strange_timestamps(self):

--- a/neo/test/rawiotest/test_openephysrawio.py
+++ b/neo/test/rawiotest/test_openephysrawio.py
@@ -10,7 +10,7 @@ class TestOpenEphysRawIO(BaseTestRawIO, unittest.TestCase, ):
         'openephys'
     ]
     entities_to_test = [
-        # 'openephys/OpenEphys_SampleData_1',
+        'openephys/OpenEphys_SampleData_1',
         # this file has gaps and this is now handle corretly
         'openephys/OpenEphys_SampleData_2_(multiple_starts)',
         # 'openephys/OpenEphys_SampleData_3',


### PR DESCRIPTION
@weiglszonja @bendichter @alejoe91 @CodyCBakerPhD 
This PR should fix the gap problem in openephys legacy format.

The old an erroreneous `ignore_timestamps_errors` is deprecated.
Now there is a gap checking when parsing the header. If gaps are detected then internally the reader go in a gap mode reading which is slower because it need np.seachrsorted at every get_analogsignal_chunk().

I propagate this on spikeinterface side here https://github.com/SpikeInterface/spikeinterface/pull/2450


