### PR TITLE
Add `is_header_parsed` flag

### DIFF
--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -161,6 +161,7 @@ class BaseRawIO:
             self._cache = None
 
         self.header = None
+        self.is_header_parsed = False
 
     def parse_header(self):
         """
@@ -177,6 +178,7 @@ class BaseRawIO:
         """
         self._parse_header()
         self._check_stream_signal_channel_characteristics()
+        self.is_header_parsed = True
 
     def source_name(self):
         """Return fancy name of file source"""


### PR DESCRIPTION
baseraw io has contains the method `parse_header` that extracts all the information from the formats and therefore is usually a computational heavy process:

https://github.com/h-mayorquin/python-neo/blob/e3742da276fe3bb9a1ea327489ebdbf06c026956/neo/rawio/baserawio.py#L166-L181

I propose adding a simple flag called `is_header_parsed` that is set to `True` after the header is parsed (i.e. `parse_header` is called). That way, users can check quickly if the header is alredy parsed without having to check for the contents of the header directly.

That is, we follow the mantra that  "explicit is better than implicit" here from the Zen.

Use case in point:

From spikeinterface, we sometimes require one or two properties from the header before intializing the neo reader:

https://github.com/h-mayorquin/spikeinterface/blob/1b8ae2c0907aee49ca9cb44e19c78d9bbfadf6e2/src/spikeinterface/extractors/neoextractors/plexon.py#L62-L64


However, within the neo base extractor we then re-parse the whole file at initialization:
https://github.com/h-mayorquin/spikeinterface/blob/1b8ae2c0907aee49ca9cb44e19c78d9bbfadf6e2/src/spikeinterface/extractors/neoextractors/neobaseextractor.py#L40-L64

We could avoid this with an explicit flag such as the one proposed into the PR without having to make assumptions about what is on the header attribute.

@alejoe91 @weiglszonja

