### PR TITLE
Check that keys of nested dictionaries in annotations are `str`

### DIFF
--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -45,7 +45,8 @@ def _check_annotations(value):
         if not issubclass(value.dtype.type, ALLOWED_ANNOTATION_TYPES):
             raise ValueError(f"Invalid annotation. NumPy arrays with dtype {value.dtype.type}" f"are not allowed")
     elif isinstance(value, dict):
-        for element in value.values():
+        for key, element in value.items():
+            _check_annotations(key)
             _check_annotations(element)
     elif isinstance(value, (list, tuple)):
         for element in value:

--- a/neo/core/baseneo.py
+++ b/neo/core/baseneo.py
@@ -46,7 +46,8 @@ def _check_annotations(value):
             raise ValueError(f"Invalid annotation. NumPy arrays with dtype {value.dtype.type}" f"are not allowed")
     elif isinstance(value, dict):
         for key, element in value.items():
-            _check_annotations(key)
+            if not isinstance(key, str):
+                raise TypeError(f"Annotations keys must be strings not of type {type(key)}")
             _check_annotations(element)
     elif isinstance(value, (list, tuple)):
         for element in value:


### PR DESCRIPTION
Fixes #1195.

Just adding a check for the key. Example from issue:
```
my_meta={(lambda a: None): 5}
```
Because the keys aren't checked this doesn't fail until writing. We should check to make sure the key is one of the [allowable annotations](https://github.com/NeuralEnsemble/python-neo/blob/c96ec936049a125d6bedfa26b67514f927bb1ab3/neo/core/baseneo.py#L14-L29).

We still have problems with writing some of the allowable annotations (see [this issue](1198)), but adding this check at least moves in the right direction. 
