### PR TITLE
Skip plexon 2 tests when wine is not present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 .idea
 *.swp
 *.swo
+.vscode
+
 
 # Compiled source #
 ###################

--- a/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
+++ b/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
@@ -9,14 +9,20 @@
 # copyright notice is kept intact.
 
 from sys import platform
-import os
+import subprocess
 import pathlib
 import warnings
 
 if any(platform.startswith(name) for name in ("linux", "darwin", "freebsd")):
+    try:
+        result_wine = subprocess.run(["dpkg", "-l", "wine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+    except subprocess.CalledProcessError:
+        raise ImportError("Wine is not installed. Please install wine to use the PL2FileReader.dll")
+
     from zugbruecke import CtypesSession
 
     ctypes = CtypesSession(log_level=100)
+
 
 elif platform.startswith("win"):
     import ctypes

--- a/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
+++ b/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
@@ -19,13 +19,14 @@ plataform_is_windows = platform.system() == "Windows"
 if plataform_is_windows:
     import ctypes
 else:
-
-    try:
-        is_wine_available = subprocess.run(
-            ["wine", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
-        )
-    except subprocess.CalledProcessError:
-        raise ImportError("Wine is not installed. Please install wine to use the PL2FileReader.dll")
+    pltaform_is_linux = platform.system() == "Linux"
+    if pltaform_is_linux:
+        try:
+            is_wine_available = subprocess.run(
+                ["wine", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+            )
+        except subprocess.CalledProcessError:
+            raise ImportError("Wine is not installed. Please install wine to use the PL2FileReader.dll")
 
     from zugbruecke import CtypesSession
 

--- a/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
+++ b/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
@@ -12,24 +12,24 @@ from sys import platform
 import subprocess
 import pathlib
 import warnings
+import numpy as np
 
-if any(platform.startswith(name) for name in ("linux", "darwin", "freebsd")):
+plataform_is_windows = platform.system() == "Windows"
+
+if plataform_is_windows:
+    import ctypes
+else:
+
     try:
-        result_wine = subprocess.run(["dpkg", "-l", "wine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        is_wine_available = subprocess.run(
+            ["wine", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+        )
     except subprocess.CalledProcessError:
         raise ImportError("Wine is not installed. Please install wine to use the PL2FileReader.dll")
 
     from zugbruecke import CtypesSession
 
     ctypes = CtypesSession(log_level=100)
-
-
-elif platform.startswith("win"):
-    import ctypes
-else:
-    raise SystemError("unsupported platform")
-
-import numpy as np
 
 
 class tm(ctypes.Structure):

--- a/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
+++ b/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
@@ -8,25 +8,22 @@
 # You are free to modify or share this file, provided that the above
 # copyright notice is kept intact.
 
-from sys import platform
+import platform
 import subprocess
 import pathlib
 import warnings
 import numpy as np
 
-plataform_is_windows = platform.system() == "Windows"
+platform_is_windows = platform.system() == "Windows"
 
-if plataform_is_windows:
+if platform_is_windows:
     import ctypes
 else:
-    pltaform_is_linux = platform.system() == "Linux"
-    if pltaform_is_linux:
-        try:
-            is_wine_available = subprocess.run(
-                ["wine", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+    is_wine_available = subprocess.run(
+                ["which", "wine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
             )
-        except subprocess.CalledProcessError:
-            raise ImportError("Wine is not installed. Please install wine to use the PL2FileReader.dll")
+    if is_wine_available.returncode != 0:
+        raise ImportError("Wine is not installed. Please install wine to use the PL2FileReader.dll")
 
     from zugbruecke import CtypesSession
 


### PR DESCRIPTION
This is generating error when the tests are attempeded to run without wine.  I added an informative message. Plus, I also added the vscode files to the gitignore. 