### PR TITLE
Prevent the same object being added more than once to a given list

### DIFF
--- a/neo/core/objectlist.py
+++ b/neo/core/objectlist.py
@@ -21,7 +21,7 @@ class ObjectList:
             for item in allowed_contents:
                 assert issubclass(item, BaseNeo)
             self.allowed_contents = tuple(allowed_contents)
-        self.contents = []
+        self._items = []
         self.parent = parent
 
     def _handle_append(self, obj):
@@ -43,75 +43,75 @@ class ObjectList:
                 setattr(obj, relationship_name, self.parent)
 
     def __str__(self):
-        return str(self.contents)
+        return str(self._items)
 
     def __repr__(self):
-        return repr(self.contents)
+        return repr(self._items)
 
     def __add__(self, objects):
         # todo: decision: return a list, or a new DataObjectList?
         if isinstance(objects, ObjectList):
-            return self.contents + objects.contents
+            return self._items + objects._items
         else:
-            return self.contents + objects
+            return self._items + objects
 
     def __radd__(self, objects):
         if isinstance(objects, ObjectList):
-            return objects.contents + self.contents
+            return objects._items + self._items
         else:
-            return objects + self.contents
+            return objects + self._items
 
     def __contains__(self, key):
-        return key in self.contents
+        return key in self._items
 
     def __iadd__(self, objects):
         for obj in objects:
             self._handle_append(obj)
-        self.contents.extend(objects)
+        self._items.extend(objects)
         return self
 
     def __iter__(self):
-        return iter(self.contents)
+        return iter(self._items)
 
     def __getitem__(self, i):
-        return self.contents[i]
+        return self._items[i]
 
     def __len__(self):
-        return len(self.contents)
+        return len(self._items)
 
     def __setitem__(self, key, value):
-        self.contents[key] = value
+        self._items[key] = value
 
     def append(self, obj):
         self._handle_append(obj)
-        self.contents.append(obj)
+        self._items.append(obj)
 
     def extend(self, objects):
         for obj in objects:
             self._handle_append(obj)
-        self.contents.extend(objects)
+        self._items.extend(objects)
 
     def clear(self):
-        self.contents = []
+        self._items = []
 
     def count(self, value):
-        return self.contents.count(value)
+        return self._items.count(value)
 
     def index(self, value, start=0, stop=sys.maxsize):
-        return self.contents.index(value, start, stop)
+        return self._items.index(value, start, stop)
 
     def insert(self, index, obj):
         self._handle_append(obj)
-        self.contents.insert(index, obj)
+        self._items.insert(index, obj)
 
     def pop(self, index=-1):
-        return self.contents.pop(index)
+        return self._items.pop(index)
 
     def remove(self, value):
-        return self.contents.remove(value)
+        return self._items.remove(value)
 
     def reverse(self):
-        raise self.contents.reverse()
+        raise self._items.reverse()
 
     def sort(self, *args, key=None, reverse=False):
-        self.contents.sort(*args, key=key, reverse=reverse)
+        self._items.sort(*args, key=key, reverse=reverse)

--- a/neo/core/objectlist.py
+++ b/neo/core/objectlist.py
@@ -32,6 +32,10 @@ class ObjectList:
             )
         ):
             raise TypeError(f"Object is a {type(obj)}. It should be one of {self.allowed_contents}.")
+
+        if self._contains(obj):
+            raise ValueError("Cannot add the same object twice")
+
         # set the child-parent relationship
         if self.parent:
             relationship_name = self.parent.__class__.__name__.lower()
@@ -41,6 +45,13 @@ class ObjectList:
             if current_parent != self.parent:
                 # use weakref here? - see https://github.com/NeuralEnsemble/python-neo/issues/684
                 setattr(obj, relationship_name, self.parent)
+
+    def _contains(self, obj):
+        if self._items is None:
+            obj_ids = []
+        else:
+            obj_ids = [id(item) for item in self._items]
+        return id(obj) in obj_ids
 
     def __str__(self):
         return str(self._items)


### PR DESCRIPTION
This relates to #1405 - in the scenario in that issue, a ValueError will be raised.

(note: the change of attribute name from `contents` to `_items` is because `_handle_append` is also used by SpikeTrainList, which uses the name `_items`).