### PR TITLE
Testing: Add skip test for non-existent writable io if nixio is not installed

### DIFF
--- a/neo/test/iotest/test_get_io.py
+++ b/neo/test/iotest/test_get_io.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+import platform
 from neo.io import get_io, list_candidate_ios, NixIO
 import pytest
 try:
@@ -34,7 +35,7 @@ def test_list_candidate_ios_filename_stub():
 
         assert NixIO in ios
 
-@pytest.mark.skipif(not HAVE_NIX, reason='Need nixio in order to return NixIO class')
+@pytest.mark.skipif(not HAVE_NIX or platform.system()=='Windows', reason='Need nixio in order to return NixIO class')
 def test_get_io_non_existant_file_writable_io():
     # use nixio for testing with writable io
     non_existant_file = Path("non_existant_file.nix")
@@ -44,4 +45,4 @@ def test_get_io_non_existant_file_writable_io():
     assert isinstance(io, NixIO)
 
     # cleanup
-    non_existant_file.unlink(missing_ok=True)
+    non_existant_file.unlink(missing_ok=True) # cleanup will fail on Windows so need to skip

--- a/neo/test/iotest/test_get_io.py
+++ b/neo/test/iotest/test_get_io.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from neo.io import get_io, list_candidate_ios, NixIO
+import pytest
+try:
+    import nixio
+    HAVE_NIX = True
+except:
+    HAVE_NIX = False
 
 
 def test_list_candidate_ios_non_existant_file():
@@ -28,7 +34,7 @@ def test_list_candidate_ios_filename_stub():
 
         assert NixIO in ios
 
-
+@pytest.mark.skipif(not HAVE_NIX, reason='Need nixio in order to return NixIO class')
 def test_get_io_non_existant_file_writable_io():
     # use nixio for testing with writable io
     non_existant_file = Path("non_existant_file.nix")


### PR DESCRIPTION
The current error is very hard to understand
```python
file_or_folder = PosixPath('non_existant_file.nix'), args = (), kwargs = {}
ios = [<class 'neo.io.nixio.NixIO'>, <class 'neo.io.nixio_fr.NixIO'>]
io = <class 'neo.io.nixio_fr.NixIO'>

    def get_io(file_or_folder, *args, **kwargs):
        """
        Return a Neo IO instance, guessing the type based on the filename suffix.
        """
        ios = list_candidate_ios(file_or_folder)
        for io in ios:
            try:
                return io(file_or_folder, *args, **kwargs)
            except:
                continue
    
>       raise IOError(f"Could not identify IO for {file_or_folder}")
E       OSError: Could not identify IO for non_existant_file.nix
```

It turns out this error only occurs because nixio is not installed. We should skip this test if nixio is not installed. 

The other option would be to instead give a meaningful warning (ie install nixio to run this test), but not everyone would require nixio, so I think it is a better idea to just skip for those that don't have this.