### PR TITLE
Testing: Skip network-dependent tests if no network access

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -208,6 +208,28 @@ The first time this is run, all of the Neo test files will be downloaded to your
 so the run time can be an hour or more.
 For subsequent runs, the files are already there, so the tests will run much faster.
 
+Because Neo downloads datasets this can lead to issues in the course of offline development or
+for packaging Neo (e.g. for a Linux distribution). In order to not download datasets and to skip
+tests which require downloaded datasets the environment variable :code:`NEO_TESTS_NO_NETWORK` can
+be set to any truthy value (e.g. :code:`'True'``).
+
+For macOS/Linux this can be done by doing:
+
+.. code-block:: bash
+
+    NEO_TESTS_NO_NETWORK='True' pytest .
+
+For Windows this can be done by doing:
+
+.. code-block:: bat
+
+    set NEO_TESTS_NO_NETWORK=true
+
+    pytest . 
+
+This can also be done with a conda environment variable if developing in a conda env. To configure these
+see the docs at `conda env vars documentation`_.
+
 It is often helpful to run only parts of the test suite. To test only the :mod:`neo.core` module,
 which is much quicker than testing :mod:`neo.io`, run::
 
@@ -466,3 +488,4 @@ Making a release
 .. _`continuous integration server`: https://github.com/NeuralEnsemble/python-neo/actions
 .. _`Read the Docs`: https://neo.readthedocs.io/en/latest/
 .. _`docs configuration page`: https://readthedocs.org/projects/neo/
+.. _`conda env vars documentation`: https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment

--- a/neo/test/iotest/common_io_test.py
+++ b/neo/test/iotest/common_io_test.py
@@ -115,7 +115,7 @@ class BaseTestIO:
         cls.io_readandwrite = list(set(cls.ioclass.readable_objects) & set(cls.ioclass.writeable_objects))
         # these objects can be either written or read
         cls.io_readorwrite = list(set(cls.ioclass.readable_objects) | set(cls.ioclass.writeable_objects))
-        if HAVE_DATALAD:
+        if HAVE_DATALAD and can_use_network():
             for remote_path in cls.entities_to_download:
                 download_dataset(repo=repo_for_test, remote_path=remote_path)
 

--- a/neo/test/rawiotest/common_rawio_test.py
+++ b/neo/test/rawiotest/common_rawio_test.py
@@ -65,7 +65,7 @@ class BaseTestRawIO:
         """
         self.shortname = self.rawioclass.__name__.lower().replace("rawio", "")
 
-        if HAVE_DATALAD:
+        if HAVE_DATALAD and self.use_network:
             for remote_path in self.entities_to_download:
                 download_dataset(repo=repo_for_test, remote_path=remote_path)
         else:

--- a/neo/test/rawiotest/tools.py
+++ b/neo/test/rawiotest/tools.py
@@ -12,16 +12,14 @@ def can_use_network():
     """
     Return True if network access is allowed
     """
+
+    if os.environ.get("NEO_TESTS_NO_NETWORK", False):
+        return False
     try:
         import datalad
-
         HAVE_DATALAD = True
     except:
         HAVE_DATALAD = False
     if not HAVE_DATALAD:
-        return False
-    if os.environ.get("NOSETESTS_NO_NETWORK", False):
-        return False
-    if os.environ.get("TRAVIS") == "true":
         return False
     return True

--- a/neo/test/utils/test_datasets.py
+++ b/neo/test/utils/test_datasets.py
@@ -1,8 +1,10 @@
 import unittest
-
+import pytest
 from neo.utils.datasets import download_dataset, default_testing_repo
+from neo.test.rawiotest.tools import can_use_network
 
 
+@pytest.mark.skipif(not can_use_network(), reason="Must have acess to network to run test")
 class TestDownloadDataset(unittest.TestCase):
     def test_download_dataset(self):
         local_path = download_dataset(repo=default_testing_repo, remote_path="blackrock/blackrock_2_1")


### PR DESCRIPTION
Replaces #1263 (potentially-it's just a different strategy). Fixes #1037.

This keeps the same functional approach as before. I changed the order of the import datalad and the env variable because even if someone has datalad the env var should overrule everything else.

Then we need to skip testing download as well (which we didn't do before). If I do this then I can run and pass through all core tests without doing any of the dataset tests.

I also (and this is just me) made the env variable `NEO_TESTS_NO_NETWORK` because `NONETWORK` is hard for me to parse.

@samuelgarcia and @JuliaSprenger.