### PR TITLE
Fix issue #1432: loading Neuropixel data from SpikeGadgets session.

### DIFF
--- a/neo/rawio/spikegadgetsrawio.py
+++ b/neo/rawio/spikegadgetsrawio.py
@@ -107,9 +107,10 @@ class SpikeGadgetsRawIO(BaseRawIO):
         stream_bytes = {}
         for device in hconf:
             stream_id = device.attrib["name"]
-            num_bytes = int(device.attrib["numBytes"])
-            stream_bytes[stream_id] = packet_size
-            packet_size += num_bytes
+            if 'numBytes' in device.attrib.keys():
+               num_bytes = int(device.attrib["numBytes"])
+               stream_bytes[stream_id] = packet_size
+               packet_size += num_bytes
 
         # timestamps 4 uint32
         self._timestamp_byte = packet_size
@@ -139,7 +140,7 @@ class SpikeGadgetsRawIO(BaseRawIO):
                     # TODO LATER: deal with "headstageSensor" which have interleaved
                     continue
 
-                if channel.attrib["dataType"] == "analog":
+                if ('dataType' in channel.attrib.keys()) and (channel.attrib["dataType"] == "analog"):
 
                     if stream_id not in stream_ids:
                         stream_ids.append(stream_id)

--- a/neo/test/rawiotest/test_spikegadgetsrawio.py
+++ b/neo/test/rawiotest/test_spikegadgetsrawio.py
@@ -10,7 +10,7 @@ class TestSpikeGadgetsRawIO(
 ):
     rawioclass = SpikeGadgetsRawIO
     entities_to_download = ["spikegadgets"]
-    entities_to_test = ["spikegadgets/20210225_em8_minirec2_ac.rec", "spikegadgets/W122_06_09_2019_1_fromSD.rec"]
+    entities_to_test = ["spikegadgets/20210225_em8_minirec2_ac.rec", "spikegadgets/W122_06_09_2019_1_fromSD.rec", "spikegadgets/SpikeGadgets_test_data_2xNpix1.0_20240318_173658.rec"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updates spikegadgetsrawio.py:_parse_header() to check devices for proper dictionary keys before attempting to access them.