### PR TITLE
AxonRawIO: Change Strings Parsing for additional formats.

### DIFF
--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -20,7 +20,11 @@ presented in pyABF MIT License Copyright (c) 2018 Scott W Harden
 written by Scott Harden. His unofficial documentation for the formats
 is here:
 https://swharden.com/pyabf/abf2-file-format/
-
+strings section:
+[uModifierNameIndex, uCreatorNameIndex, uProtocolPathIndex, lFileComment, lADCCChannelNames, lADCUnitsIndex
+lDACChannelNameIndex, lDACUnitIndex, lDACFilePath, nLeakSubtractADC]
+['', 'Clampex', '', 'C:/path/protocol.pro', 'some comment', 'IN 0', 'mV', 'IN 1', 'mV', 'Cmd 0', 'pA', 
+'Cmd 1', 'pA', 'Cmd 2', 'mV', 'Cmd 3', 'mV']
 
 Information on abf 1 and 2 formats is available here:
 http://www.moleculardevices.com/pages/software/developer_info.html
@@ -472,15 +476,17 @@ def parse_axon_soup(filename):
             # not very robust.
             f.seek(sections["StringsSection"]["uBlockIndex"] * BLOCKSIZE)
             big_string = f.read(sections["StringsSection"]["uBytes"])
-
             # this idea comes from pyABF https://github.com/swharden/pyABF
             # previously we searched for clampex, Clampex etc, but this was
             # brittle. pyABF believes that looking for the \x00\x00 is more
             # robust. We find these values, replace mu->u, then split into
             # a set of strings
             indexed_string = big_string[big_string.rfind(b'\x00\x00'):]
+            # replace mu -> u for easy display
             indexed_string = indexed_string.replace(b'\xb5', b'\x75')
-            indexed_string = indexed_string.split(b'\x00')
+            # we need to remove one of the \x00 to have the indices be
+            # the correct order
+            indexed_string = indexed_string.split(b'\x00')[1:]
             strings = indexed_string
 
             # ADC sections
@@ -495,8 +501,8 @@ def parse_axon_soup(filename):
                         ADCInfo[key] = val[0]
                     else:
                         ADCInfo[key] = np.array(val)
-                ADCInfo["ADCChNames"] = strings[ADCInfo["lADCChannelNameIndex"] - 1]
-                ADCInfo["ADCChUnits"] = strings[ADCInfo["lADCUnitsIndex"] - 1]
+                ADCInfo["ADCChNames"] = strings[ADCInfo["lADCChannelNameIndex"]]
+                ADCInfo["ADCChUnits"] = strings[ADCInfo["lADCUnitsIndex"]]
                 header["listADCInfo"].append(ADCInfo)
 
             # protocol sections
@@ -509,7 +515,7 @@ def parse_axon_soup(filename):
                 else:
                     protocol[key] = np.array(val)
             header["protocol"] = protocol
-            header["sProtocolPath"] = strings[header["uProtocolPathIndex"] - 1]
+            header["sProtocolPath"] = strings[header["uProtocolPathIndex"]]
 
             # tags
             listTag = []
@@ -538,8 +544,8 @@ def parse_axon_soup(filename):
                         DACInfo[key] = val[0]
                     else:
                         DACInfo[key] = np.array(val)
-                DACInfo["DACChNames"] = strings[DACInfo["lDACChannelNameIndex"] - 1]
-                DACInfo["DACChUnits"] = strings[DACInfo["lDACChannelUnitsIndex"] - 1]
+                DACInfo["DACChNames"] = strings[DACInfo["lDACChannelNameIndex"]]
+                DACInfo["DACChUnits"] = strings[DACInfo["lDACChannelUnitsIndex"]]
 
                 header["listDACInfo"].append(DACInfo)
 


### PR DESCRIPTION
Fixes #1434.

Still need to be tested by user in PR #1434, but this uses the string parsing strategy that pyABF came up with. License is an MIT https://github.com/swharden/pyABF/blob/main/LICENSE, and docs for his logic here: https://swharden.com/pyabf/abf2-file-format/.

Basically the issue in #1434, the device is not returned (so no `[b"AXENGN", b"clampex", b"Clampex", b"EDR3", b"CLAMPEX", b"axoscope", b"AxoScope", b"Clampfit"`]. I tested the test file locally and it seemed to run when I changed the parsing as in this PR. 

the strategy in short is to parse based \xx0\xx0 rather than trying to find the device. The string format then actually follows the correct indices as given by ADC info so we don't need to subtract one.

@shankardutt can you test from this PR with your data. I tested it (but not extensively) and it seemed to work.