### PR TITLE
Protect against corrupted channels in legacy openephys.

### DIFF
--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -141,11 +141,10 @@ class OpenEphysRawIO(BaseRawIO):
                         np.median(diff) == RECORD_SIZE
                     ), f"This file has a non valid data block size for channel {chan_id}, this case cannot be handled"
 
-                diff = np.diff(data_chan["timestamp"])
                 channel_has_corrupted_timestamps = np.any(diff <= 0)
                 if channel_has_corrupted_timestamps:
                     # protect against corrupted timestamp in channel
-                    raise ValueError(f"{ch_name} has corrputed timestamps, this channels need to be moved away from the folder")
+                    raise ValueError(f"{ch_name} has timestamps with zero values or negative differences between consecutive timestamps, this file ({continuous_filename}) with corrupted timestamps needs to be moved away from the folder.")
 
                 if seg_index == 0:
                     # add in channel list

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -141,6 +141,12 @@ class OpenEphysRawIO(BaseRawIO):
                         np.median(diff) == RECORD_SIZE
                     ), f"This file has a non valid data block size for channel {chan_id}, this case cannot be handled"
 
+                diff = np.diff(data_chan["timestamp"])
+                channel_has_corrupted_timestamps = np.any(diff <= 0)
+                if channel_has_corrupted_timestamps:
+                    # protect against corrupted timestamp in channel
+                    raise ValueError(f"{ch_name} has corrputed timestamps, this channels need to be moved away from the folder")
+
                 if seg_index == 0:
                     # add in channel list
                     if ch_name[:2].upper() == "CH":


### PR DESCRIPTION
@weiglszonja : Here this raise an error when a file is corrupted (bad timestamp)