### PR TITLE
NeuralynxIO: support List[str] for filename parameter

### DIFF
--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -69,11 +69,11 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
             Default: False
         """
 
-        if filename:
+        if filename is not None:
             warnings.warn('Deprecated and will be removed. Please use `include_filenames` instead')
             include_filenames = [filename]
 
-        if exclude_filename:
+        if exclude_filename is not None:
             warnings.warn('Deprecated and will be removed. Please use `exclude_filenames` instead')
             exclude_filenames = exclude_filename
 

--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -30,7 +30,6 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
     def __init__(
         self,
         dirname="",
-        filename="",
         use_cache=False,
         cache_path="same_as_resource",
         include_filename=None,
@@ -44,9 +43,6 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
         ----------
         dirname : str
             Directory containing data files
-        filename : str
-            Name of a single ncs, nse, nev, or ntt file to include in dataset. Will be ignored,
-            if dirname is provided.
         use_cache : bool, optional
             Cache results of initial file scans for faster loading in subsequent runs.
             Default: False
@@ -63,20 +59,17 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
             shifted to begin at t_start = 0*pq.second.
             Default: False
         """
+
         NeuralynxRawIO.__init__(
-            self,
-            dirname=dirname,
-            filename=filename,
-            use_cache=use_cache,
-            cache_path=cache_path,
-            include_filename=include_filename,
-            exclude_filename=exclude_filename,
+            self, dirname=dirname,
+            include_filenames=include_filename,
+            exclude_filenames=exclude_filename,
             keep_original_times=keep_original_times,
+            use_cache=use_cache,
+            cache_path=cache_path
         )
 
-        if self.rawmode == "one-file":
-            BaseFromRaw.__init__(self, filename)
-        elif self.rawmode == "one-dir":
+        if self.rawmode == "one-dir":
             BaseFromRaw.__init__(self, dirname)
         elif self.rawmode == "multiple-files":
             BaseFromRaw.__init__(self, include_filename=include_filename)

--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -9,6 +9,7 @@ Supported: Read
 Author: Julia Sprenger, Carlos Canova
 """
 
+import warnings
 from neo.io.basefromrawio import BaseFromRaw
 from neo.rawio.neuralynxrawio.neuralynxrawio import NeuralynxRawIO
 
@@ -67,6 +68,14 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
             shifted to begin at t_start = 0*pq.second.
             Default: False
         """
+
+        if filename:
+            warnings.warn('Deprecated and will be removed. Please use `include_filenames` instead')
+            include_filenames = [filename]
+
+        if exclude_filename:
+            warnings.warn('Deprecated and will be removed. Please use `include_filenames` instead')
+            exclude_filenames = exclude_filename
 
         NeuralynxRawIO.__init__(
             self,

--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -49,6 +49,8 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
         cache_path : str, optional
             Folder path to use for cache files.
             Default: 'same_as_resource'
+        exclude_filename: None,
+            Deprecated and will be removed. Please use `exclude_filenames` instead
         include_filenames: str or list
             Filename or list of filenames to be included. This can be absolute path or path relative to dirname.
         exclude_filenames: str or list

--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -33,6 +33,7 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
         filename="",
         use_cache=False,
         cache_path="same_as_resource",
+        include_filename=None,
         exclude_filename=None,
         keep_original_times=False,
     ):
@@ -52,6 +53,8 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
         cache_path : str, optional
             Folder path to use for cache files.
             Default: 'same_as_resource'
+        include_filename: str or list
+            Filename or list of filenames to be included. This can be absolute path or path relative to dirname.
         exclude_filename: str or list
             Filename or list of filenames to be excluded. Expects base filenames without
             directory path.
@@ -66,6 +69,7 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
             filename=filename,
             use_cache=use_cache,
             cache_path=cache_path,
+            include_filename=include_filename,
             exclude_filename=exclude_filename,
             keep_original_times=keep_original_times,
         )
@@ -73,3 +77,6 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
             BaseFromRaw.__init__(self, filename)
         elif self.rawmode == "one-dir":
             BaseFromRaw.__init__(self, dirname)
+        elif self.rawmode == "multiple-files":
+            BaseFromRaw.__init__(self, include_filename=include_filename)
+

--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -74,7 +74,7 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
             include_filenames = [filename]
 
         if exclude_filename:
-            warnings.warn('Deprecated and will be removed. Please use `include_filenames` instead')
+            warnings.warn('Deprecated and will be removed. Please use `exclude_filenames` instead')
             exclude_filenames = exclude_filename
 
         NeuralynxRawIO.__init__(

--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -32,8 +32,8 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
         dirname="",
         use_cache=False,
         cache_path="same_as_resource",
-        include_filename=None,
-        exclude_filename=None,
+        include_filenames=None,
+        exclude_filenames=None,
         keep_original_times=False,
     ):
         """
@@ -49,9 +49,9 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
         cache_path : str, optional
             Folder path to use for cache files.
             Default: 'same_as_resource'
-        include_filename: str or list
+        include_filenames: str or list
             Filename or list of filenames to be included. This can be absolute path or path relative to dirname.
-        exclude_filename: str or list
+        exclude_filenames: str or list
             Filename or list of filenames to be excluded. Expects base filenames without
             directory path.
         keep_original_times : bool
@@ -62,8 +62,8 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
 
         NeuralynxRawIO.__init__(
             self, dirname=dirname,
-            include_filenames=include_filename,
-            exclude_filenames=exclude_filename,
+            include_filenames=include_filenames,
+            exclude_filenames=exclude_filenames,
             keep_original_times=keep_original_times,
             use_cache=use_cache,
             cache_path=cache_path
@@ -72,5 +72,5 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
         if self.rawmode == "one-dir":
             BaseFromRaw.__init__(self, dirname)
         elif self.rawmode == "multiple-files":
-            BaseFromRaw.__init__(self, include_filename=include_filename)
+            BaseFromRaw.__init__(self, include_filenames=include_filenames)
 

--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -45,6 +45,10 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
         ----------
         dirname : str
             Directory containing data files
+        filename : str
+            Deprecated and will be removed. Please use `include_filenames` instead
+            Name of a single ncs, nse, nev, or ntt file to include in dataset. Will be ignored,
+            if dirname is provided.
         use_cache : bool, optional
             Cache results of initial file scans for faster loading in subsequent runs.
             Default: False

--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -29,12 +29,14 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
 
     def __init__(
         self,
-        dirname="",
+        dirname,
         use_cache=False,
         cache_path="same_as_resource",
         include_filenames=None,
         exclude_filenames=None,
         keep_original_times=False,
+        filename=None,
+        exclude_filename=None,
     ):
         """
         Initialise IO instance
@@ -63,7 +65,8 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
         """
 
         NeuralynxRawIO.__init__(
-            self, dirname=dirname,
+            self,
+            dirname=dirname,
             include_filenames=include_filenames,
             exclude_filenames=exclude_filenames,
             keep_original_times=keep_original_times,

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -151,11 +151,11 @@ class NeuralynxRawIO(BaseRawIO):
 
         if filename:
             include_filenames = filename
-            raise DeprecationWarning("`filename` is deprecated and will be removed. Please use `include_filenames` instead")
+            warnings.warn("`filename` is deprecated and will be removed. Please use `include_filenames` instead")
 
         if exclude_filename:
             exclude_filenames = exclude_filename
-            raise DeprecationWarning("`exclude_filename` is deprecated and will be removed. Please use `exclude_filenames` instead")
+            warnings.warn("`exclude_filename` is deprecated and will be removed. Please use `exclude_filenames` instead")
 
         if include_filenames is None:
             include_filenames = []

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -136,13 +136,23 @@ class NeuralynxRawIO(BaseRawIO):
 
     def __init__(
             self,
-            dirname="",
+            dirname,
             include_filenames=None,
             exclude_filenames=None,
             keep_original_times=False,
             strict_gap_mode=True,
+            filename=None,
+            exclude_filename=None,
             **kargs
     ):
+
+        if filename:
+            include_filenames = filename
+            raise DeprecationWarning("`filename` is deprecated and will be removed. Please use `include_filenames` instead")
+
+        if exclude_filename:
+            exclude_filenames = exclude_filename
+            raise DeprecationWarning("`exclude_filename` is deprecated and will be removed. Please use `exclude_filenames` instead")
 
         if include_filenames is None:
             include_filenames = []
@@ -158,9 +168,6 @@ class NeuralynxRawIO(BaseRawIO):
             include_filepath = {os.path.dirname(f) for f in include_filenames}
             if len(include_filepath) > 1:
                 raise ValueError("Files in include_filename must be in a single path!")
-
-        if (include_filenames is None) and (dirname == ""):
-            raise ValueError("One of dirname or include_filenames must be provided.")
 
         if dirname and include_filenames:
             dirname = os.path.join(dirname, os.path.dirname(include_filenames[0]))

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -167,7 +167,7 @@ class NeuralynxRawIO(BaseRawIO):
         self.dirname = dirname
         self.filename = filename
         self.include_files = include_filename
-        self.exclude_filename = exclude_filename
+        self.exclude_filename = [os.path.basename(f) for f in exclude_filename] if exclude_filename else None
         self.keep_original_times = keep_original_times
         self.strict_gap_mode = strict_gap_mode
         BaseRawIO.__init__(self, **kargs)
@@ -227,8 +227,8 @@ class NeuralynxRawIO(BaseRawIO):
         file_basenames = [os.path.basename(f) for f in filenames]
         if self.exclude_filename is not None:
             for excl_file in self.exclude_filename:
-                if os.path.basename(excl_file) in file_basenames:
-                    filenames.remove(os.path.join(self.dirname, os.path.basename(excl_file)))
+                if excl_file in file_basenames:
+                    filenames.remove(os.path.join(self.dirname, excl_file))
 
         stream_props = {}  # {(sampling_rate, n_samples, t_start): {stream_id: [filenames]}
 

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -152,7 +152,7 @@ class NeuralynxRawIO(BaseRawIO):
         if exclude_filenames is None:
             exclude_filenames = set()
         elif not isinstance(exclude_filenames, (list, set, np.ndarray)):
-            exclude_filenames = set([exclude_filenames])
+            exclude_filenames = {exclude_filenames}
 
         if include_filenames:
             include_filepath = {os.path.dirname(f) for f in include_filenames}

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -231,7 +231,6 @@ class NeuralynxRawIO(BaseRawIO):
         stream_props = {}  # {(sampling_rate, n_samples, t_start): {stream_id: [filenames]}
 
         for filename in full_filenames:
-            filename = os.path.join(self.dirname, filename)
             _, ext = os.path.splitext(filename)
             ext = ext[1:]  # remove dot
             ext = ext.lower()  # make lower case for comparisons

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -176,13 +176,8 @@ class NeuralynxRawIO(BaseRawIO):
         if self.rawmode == "one-file":
             return self.filename
         elif self.rawmode == "multiple-files":
-            dirname = {os.path.dirname(x) for x in self.include_files}
-            if len(dirname) > 1:
-                warnings.warn(
-                    message=f"multiple directories detected! A random one will be returned.",
-                    category=RuntimeWarning,
-                )
-            return list(dirname)[0]
+            dirname = [os.path.dirname(x) for x in self.include_files]
+            return dirname[0]
         else:
             return self.dirname
 

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -151,9 +151,9 @@ class NeuralynxRawIO(BaseRawIO):
         if dirname != "" and (include_filename is not None):
             include_filename = [os.path.join(dirname, f) for f in include_filename]
 
-        if not isinstance(include_filename, (list, set, np.ndarray)):
+        if (not isinstance(include_filename, (list, set, np.ndarray))) and (include_filename is not None):
             include_filename = [include_filename]
-        if not isinstance(exclude_filename, (list, set, np.ndarray)):
+        if (not isinstance(exclude_filename, (list, set, np.ndarray))) and (exclude_filename is not None):
             exclude_filename = [exclude_filename]
 
         if dirname != "":

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -129,7 +129,7 @@ class NeuralynxRawIO(BaseRawIO):
         ("channel_id", "uint32"),
         ("sample_rate", "uint32"),
         ("nb_valid", "uint32"),
-        ("samples", "int16", (NcsSection._RECORD_SIZE)),
+        ("samples", "int16", NcsSection._RECORD_SIZE),
     ]
 
     def __init__(
@@ -224,10 +224,11 @@ class NeuralynxRawIO(BaseRawIO):
                 )
 
         # remove files that were explicitly excluded
+        file_basenames = [os.path.basename(f) for f in filenames]
         if self.exclude_filename is not None:
             for excl_file in self.exclude_filename:
-                if excl_file in filenames:
-                    filenames.remove(excl_file)
+                if os.path.basename(excl_file) in file_basenames:
+                    filenames.remove(os.path.join(self.dirname, os.path.basename(excl_file)))
 
         stream_props = {}  # {(sampling_rate, n_samples, t_start): {stream_id: [filenames]}
 

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -81,7 +81,8 @@ class NeuralynxRawIO(BaseRawIO):
         if dirname is provided. But one of either dirname or filename is required.
     include_filename: str | list | None, default: None
         Name of a single ncs, nse, nev or ntt file or list of such files. Will only include
-        file names in the list. If this is full path, the direname will be sent to self.dirname.
+        file names in the list. This can be plain filenames or fullpath or path relative to
+        dirname.
         All files should be in a single path.
     exclude_filename: str | list | None, default: None
         Name of a single ncs, nse, nev or ntt file or list of such files. Expects plain

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -164,9 +164,9 @@ class NeuralynxRawIO(BaseRawIO):
             include_filenames = []
 
         if exclude_filenames is None:
-            exclude_filenames = set()
+            exclude_filenames = []
         elif not isinstance(exclude_filenames, (list, set, np.ndarray)):
-            exclude_filenames = {exclude_filenames}
+            exclude_filenames = [exclude_filenames]
 
         if include_filenames:
             self.rawmode = 'multiple-files'

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -57,6 +57,7 @@ import numpy as np
 import os
 import pathlib
 import copy
+import warnings
 from collections import namedtuple, OrderedDict
 
 from neo.rawio.neuralynxrawio.ncssections import NcsSection, NcsSectionsFactory
@@ -155,6 +156,14 @@ class NeuralynxRawIO(BaseRawIO):
     def _source_name(self):
         if self.rawmode == "one-file":
             return self.filename
+        elif self.rawmode == "multiple-files":
+            dirname = {os.path.dirname(x) for x in self.filename}
+            if len(dirname) > 1:
+                warnings.warn(
+                    message=f"multiple directories detected! Only the first will be returned.",
+                    category=RuntimeWarning,
+                )
+            return os.path.dirname(self.filename[0])
         else:
             return self.dirname
 

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -152,7 +152,7 @@ class NeuralynxRawIO(BaseRawIO):
         if exclude_filenames is None:
             exclude_filenames = set()
         elif not isinstance(exclude_filenames, (list, set, np.ndarray)):
-            exclude_filenames = set(exclude_filenames)
+            exclude_filenames = set([exclude_filenames])
 
         if include_filenames:
             include_filepath = {os.path.dirname(f) for f in include_filenames}
@@ -167,7 +167,7 @@ class NeuralynxRawIO(BaseRawIO):
             include_filenames = [os.path.basename(f) for f in include_filenames]
 
         if exclude_filenames:
-            exclude_filenames = {os.path.basename(f) for f in exclude_filenames}
+            exclude_filenames = {os.path.join(dirname, os.path.basename(f)) for f in exclude_filenames}
 
         if include_filenames:
             self.rawmode = 'multiple-files'

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -176,13 +176,13 @@ class NeuralynxRawIO(BaseRawIO):
         if self.rawmode == "one-file":
             return self.filename
         elif self.rawmode == "multiple-files":
-            dirname = {os.path.dirname(x) for x in self.filename}
+            dirname = {os.path.dirname(x) for x in self.include_files}
             if len(dirname) > 1:
                 warnings.warn(
-                    message=f"multiple directories detected! Only the first will be returned.",
+                    message=f"multiple directories detected! A random one will be returned.",
                     category=RuntimeWarning,
                 )
-            return os.path.dirname(self.filename[0])
+            return list(dirname)[0]
         else:
             return self.dirname
 

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -213,13 +213,14 @@ class NeuralynxRawIO(BaseRawIO):
         event_annotations = []
 
         if self.rawmode == "one-dir":
-            filenames = [os.path.join(self.dirname, f) for f in os.listdir(self.dirname)]
+            filenames = os.listdir(self.dirname)
         else:
-            filenames = [os.path.join(self.dirname, f) for f in self.include_filenames]
+            filenames = self.include_filenames
 
         filenames = [f for f in filenames if f not in self.exclude_filenames]
+        full_filenames = [os.path.join(self.dirname, f) for f in filenames]
 
-        for filename in filenames:
+        for filename in full_filenames:
             if not os.path.isfile(filename):
                 raise ValueError(
                     f"Provided Filename is not a file: "
@@ -229,7 +230,7 @@ class NeuralynxRawIO(BaseRawIO):
 
         stream_props = {}  # {(sampling_rate, n_samples, t_start): {stream_id: [filenames]}
 
-        for filename in filenames:
+        for filename in full_filenames:
             filename = os.path.join(self.dirname, filename)
             _, ext = os.path.splitext(filename)
             ext = ext[1:]  # remove dot

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -162,10 +162,12 @@ class NeuralynxRawIO(BaseRawIO):
 
         if include_filenames is None:
             include_filenames = []
+        elif isinstance(include_filenames, str):
+            include_filenames = [include_filenames]
 
         if exclude_filenames is None:
             exclude_filenames = []
-        elif not isinstance(exclude_filenames, (list, set, np.ndarray)):
+        elif isinstance(exclude_filenames, str):
             exclude_filenames = [exclude_filenames]
 
         if include_filenames:

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -136,7 +136,7 @@ class NeuralynxRawIO(BaseRawIO):
 
     def __init__(
             self,
-            dirname,
+            dirname="",
             include_filenames=None,
             exclude_filenames=None,
             keep_original_times=False,
@@ -145,6 +145,9 @@ class NeuralynxRawIO(BaseRawIO):
             exclude_filename=None,
             **kargs
     ):
+
+        if not dirname:
+            raise ValueError("`dirname` cannot be empty.")
 
         if filename:
             include_filenames = filename

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -150,7 +150,6 @@ class NeuralynxRawIO(BaseRawIO):
 
         if dirname != "" and (include_filename is not None):
             include_filename = [os.path.join(dirname, f) for f in include_filename]
-            dirname = ""
 
         if not isinstance(include_filename, (list, set, np.ndarray)):
             include_filename = [include_filename]
@@ -158,11 +157,12 @@ class NeuralynxRawIO(BaseRawIO):
             exclude_filename = [exclude_filename]
 
         if dirname != "":
-            self.rawmode = "one-dir"
+            if include_filename is not None:
+                self.rawmode = 'multiple-files'
+            else:
+                self.rawmode = "one-dir"
         elif filename != "":
             self.rawmode = "one-file"
-        else:
-            self.rawmode = "multiple-files"
 
         self.dirname = dirname
         self.filename = filename

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -209,7 +209,7 @@ class NeuralynxRawIO(BaseRawIO):
         event_annotations = []
 
         if self.rawmode == "one-dir":
-            filenames = sorted(os.listdir(self.dirname))
+            filenames = sorted([f for f in os.listdir(self.dirname) if os.path.isfile(f) and not f.startswith('.')])
         elif self.rawmode == "one-file":
             filenames = [self.filename]
         else:

--- a/neo/test/iotest/test_neuralynxio.py
+++ b/neo/test/iotest/test_neuralynxio.py
@@ -180,20 +180,20 @@ class TestCheetah_v574(CommonNeuralynxIOTest, unittest.TestCase):
         block = nio.read_block(signal_group_mode="group-by-same-units")
         self.assertEqual(len(block.groups), 1)
 
-    def test_read_single_file(self):
+    def test_include_filenames(self):
         filename = self.get_local_path("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs")
-        nio = NeuralynxIO(filename=filename, use_cache=False)
+        nio = NeuralynxIO(include_filenames=filename, use_cache=False)
         block = nio.read_block()
         self.assertTrue(len(block.segments[0].analogsignals) > 0)
         self.assertTrue((len(block.segments[0].spiketrains)) == 0)
         self.assertTrue((len(block.segments[0].events)) == 0)
         self.assertTrue((len(block.segments[0].epochs)) == 0)
 
-    def test_exclude_filename(self):
+    def test_exclude_filenames(self):
         dname = self.get_local_path("neuralynx/Cheetah_v5.7.4/original_data/")
 
         # exclude a single file
-        nio = NeuralynxIO(dirname=dname, exclude_filename="CSC1.ncs", use_cache=False)
+        nio = NeuralynxIO(dirname=dname, exclude_filenames="CSC1.ncs", use_cache=False)
         block = nio.read_block()
         self.assertTrue(len(block.segments[0].analogsignals) > 0)
         self.assertTrue((len(block.segments[0].spiketrains)) >= 0)

--- a/neo/test/iotest/test_neuralynxio.py
+++ b/neo/test/iotest/test_neuralynxio.py
@@ -202,7 +202,7 @@ class TestCheetah_v574(CommonNeuralynxIOTest, unittest.TestCase):
 
         # exclude all ncs files from session
         exclude_files = [f"CSC{i}.ncs" for i in range(6)]
-        nio = NeuralynxIO(dirname=dname, exclude_filename=exclude_files, use_cache=False)
+        nio = NeuralynxIO(dirname=dname, exclude_filenames=exclude_files, use_cache=False)
         block = nio.read_block()
         self.assertTrue(len(block.segments[0].analogsignals) == 0)
         self.assertTrue((len(block.segments[0].spiketrains)) >= 0)

--- a/neo/test/iotest/test_neuralynxio.py
+++ b/neo/test/iotest/test_neuralynxio.py
@@ -182,7 +182,8 @@ class TestCheetah_v574(CommonNeuralynxIOTest, unittest.TestCase):
 
     def test_include_filenames(self):
         filename = self.get_local_path("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs")
-        nio = NeuralynxIO(include_filenames=filename, use_cache=False)
+        dirname, filename = os.path.split(filename)
+        nio = NeuralynxIO(dirname=dirname, include_filenames=filename, use_cache=False)
         block = nio.read_block()
         self.assertTrue(len(block.segments[0].analogsignals) > 0)
         self.assertTrue((len(block.segments[0].spiketrains)) == 0)

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -105,14 +105,14 @@ class TestNeuralynxRawIO(
         # check that there are only 3 memmaps
         self.assertEqual(len(rawio._sigs_memmaps[seg_idx]), 3)
 
-    def test_single_file_mode(self):
+    def test_include_filenames(self):
         """
-        Tests reading of single files.
+        Tests include_filenames with only one file
         """
 
         # test single analog signal channel
         fname = self.get_local_path("neuralynx/Cheetah_v5.6.3/original_data/CSC1.ncs")
-        rawio = NeuralynxRawIO(filename=fname)
+        rawio = NeuralynxRawIO(include_filenames=fname)
         rawio.parse_header()
 
         self.assertEqual(rawio._nb_segment, 2)
@@ -127,7 +127,7 @@ class TestNeuralynxRawIO(
 
         # test one single electrode channel
         fname = self.get_local_path("neuralynx/Cheetah_v5.5.1/original_data/STet3a.nse")
-        rawio = NeuralynxRawIO(filename=fname)
+        rawio = NeuralynxRawIO(include_filenames=fname)
         rawio.parse_header()
 
         self.assertEqual(rawio._nb_segment, 1)

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -1,5 +1,6 @@
 import unittest
 
+import os
 import numpy as np
 
 from neo.rawio.neuralynxrawio.neuralynxrawio import NeuralynxRawIO
@@ -112,7 +113,8 @@ class TestNeuralynxRawIO(
 
         # test single analog signal channel
         fname = self.get_local_path("neuralynx/Cheetah_v5.6.3/original_data/CSC1.ncs")
-        rawio = NeuralynxRawIO(include_filenames=fname)
+        dirname, filename = os.path.split(fname)
+        rawio = NeuralynxRawIO(dirname=dirname, include_filenames=filename)
         rawio.parse_header()
 
         self.assertEqual(rawio._nb_segment, 2)

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -378,6 +378,7 @@ if __name__ == "__main__":
     # test = TestNeuralynxRawIO()
     # test.test_scan_ncs_files()
     # test.test_exclude_filenames()
+    # test.test_include_filenames()
 
     # test = TestNcsSectionsFactory()
     # test.test_ncsblocks_partial()

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -378,9 +378,9 @@ class TestNcsSections(TestNeuralynxRawIO, unittest.TestCase):
 if __name__ == "__main__":
     unittest.main()
 
-    test = TestNeuralynxRawIO()
+    # test = TestNeuralynxRawIO()
     # test.test_scan_ncs_files()
-    test.test_exclude_filenames()
+    # test.test_exclude_filenames()
     # test.test_include_filenames()
 
     # test = TestNcsSectionsFactory()

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -380,8 +380,8 @@ if __name__ == "__main__":
 
     test = TestNeuralynxRawIO()
     # test.test_scan_ncs_files()
-    # test.test_exclude_filenames()
-    test.test_include_filenames()
+    test.test_exclude_filenames()
+    # test.test_include_filenames()
 
     # test = TestNcsSectionsFactory()
     # test.test_ncsblocks_partial()

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -129,7 +129,8 @@ class TestNeuralynxRawIO(
 
         # test one single electrode channel
         fname = self.get_local_path("neuralynx/Cheetah_v5.5.1/original_data/STet3a.nse")
-        rawio = NeuralynxRawIO(include_filenames=fname)
+        dirname, filename = os.path.split(fname)
+        rawio = NeuralynxRawIO(dirname=dirname, include_filenames=filename)
         rawio.parse_header()
 
         self.assertEqual(rawio._nb_segment, 1)
@@ -377,10 +378,10 @@ class TestNcsSections(TestNeuralynxRawIO, unittest.TestCase):
 if __name__ == "__main__":
     unittest.main()
 
-    # test = TestNeuralynxRawIO()
+    test = TestNeuralynxRawIO()
     # test.test_scan_ncs_files()
     # test.test_exclude_filenames()
-    # test.test_include_filenames()
+    test.test_include_filenames()
 
     # test = TestNcsSectionsFactory()
     # test.test_ncsblocks_partial()

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -143,7 +143,7 @@ class TestNeuralynxRawIO(
     def test_exclude_filenames(self):
         # exclude single ncs file from session
         dname = self.get_local_path("neuralynx/Cheetah_v5.6.3/original_data/")
-        rawio = NeuralynxRawIO(dirname=dname, exclude_filename="CSC2.ncs")
+        rawio = NeuralynxRawIO(dirname=dname, exclude_filenames="CSC2.ncs")
         rawio.parse_header()
 
         self.assertEqual(rawio._nb_segment, 2)
@@ -157,7 +157,7 @@ class TestNeuralynxRawIO(
         self.assertEqual(len(rawio.header["event_channels"]), 2)
 
         # exclude multiple files from session
-        rawio = NeuralynxRawIO(dirname=dname, exclude_filename=["Events.nev", "CSC2.ncs"])
+        rawio = NeuralynxRawIO(dirname=dname, exclude_filenames=["Events.nev", "CSC2.ncs"])
         rawio.parse_header()
 
         self.assertEqual(rawio._nb_segment, 2)


### PR DESCRIPTION
Add a feature to allow multiple files as filename. 

Now user can create a list of filenames and assign it to the argument `filename` of `neo.io.NeuralynxIO(filename=session_data)` to read the specific files. 

If there are multiple files for a single channel, they should be consistent for all channels.