### PR TITLE
SpikeglxRawIO: raise error if no `.meta`-`.bin` combos of files detected

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -299,7 +299,7 @@ def scan_files(dirname):
                 info_list.append(info)
 
     if len(info_list) == 0:
-        raise FileNotFoundError(f'No appropriate combination of .meta and .bin files were detected in {print(dirname)}')
+        raise FileNotFoundError(f"No appropriate combination of .meta and .bin files were detected in {dirname}")
 
     # the segment index will depend on both 'gate_num' and 'trigger_num'
     # so we order by 'gate_num' then 'trigger_num'

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -298,6 +298,9 @@ def scan_files(dirname):
                 info["bin_file"] = str(bin_filename)
                 info_list.append(info)
 
+    if len(info_list) == 0:
+        raise FileNotFoundError(f'No appropriate combination of .meta and .bin files were detected in {print(dirname)}')
+
     # the segment index will depend on both 'gate_num' and 'trigger_num'
     # so we order by 'gate_num' then 'trigger_num'
     # None is before any int


### PR DESCRIPTION
Fixes #1144.

In this case if there are no combo of .meta and .bin we raise a FileNotFoundError so that the user can double check their directory folder names. Happy to hear better ideas for this error though.