### PR TITLE
Fix reading TDT files where Tbk header contains incomplete channel group info

### DIFF
--- a/neo/rawio/tdtrawio.py
+++ b/neo/rawio/tdtrawio.py
@@ -557,8 +557,16 @@ def read_tbk(tbk_filename):
         infos.append(info)
 
     # and put into numpy
+    tbk_field_names = [tbk_field_type[0] for tbk_field_type in tbk_field_types]
     info_channel_groups = np.zeros(len(infos), dtype=tbk_field_types)
     for i, info in enumerate(infos):
+        missing_keys = set(tbk_field_names) - set(info.keys())
+        if missing_keys:
+            warnings.warn(
+                f"Could not find all channel group info in tbk file, the missing keys are {missing_keys}.\n"
+                "The reader will continue with channel groups that could be parsed."
+            )
+            continue
         for k, dt in tbk_field_types:
             v = np.dtype(dt).type(info[k])
             info_channel_groups[i][k] = v

--- a/neo/rawio/tdtrawio.py
+++ b/neo/rawio/tdtrawio.py
@@ -563,8 +563,8 @@ def read_tbk(tbk_filename):
         missing_keys = set(tbk_field_names) - set(info.keys())
         if missing_keys:
             warnings.warn(
-                f"Could not find all channel group info in tbk file, the missing keys are {missing_keys}.\n"
-                "The reader will continue with channel groups that could be parsed."
+                f"The tbk file contains incomplete channel group info for group {list(info.items())}. "
+                "This channel group will be skipped."
             )
             continue
         for k, dt in tbk_field_types:


### PR DESCRIPTION
Fix https://github.com/NeuralEnsemble/python-neo/issues/1401

For some TDT files (from 2014 as pointed out in the issue), the channel groups info that is extracted from the Tbk file doesn't contain all expected field names. I think we should allow reading these files (they are currently not readable as they fail at `read_tbk()`) but should issue a warning.
