### PR TITLE
Read gain scaling from .rec header.

### DIFF
--- a/neo/rawio/spikegadgetsrawio.py
+++ b/neo/rawio/spikegadgetsrawio.py
@@ -55,10 +55,10 @@ class SpikeGadgetsRawIO(BaseRawIO):
 
         Notes
         -----
-        This file format has multiple version. New versions include the gain for scaling.
-        The current implementation does not contain this feature because we don't have
-        files to test this. So now the gain is "hardcoded" to 1, and so units are
-        not handled correctly.
+        This file format has multiple versions:
+            - Newer versions include the gain for scaling to microvolts [uV].
+            - If the scaling is not found in the header, it will be "hardcoded" to 1,
+              in which case the units are not handled correctly.
 
         Examples
         --------
@@ -173,12 +173,17 @@ class SpikeGadgetsRawIO(BaseRawIO):
 
             chan_ind = 0
             for trode in sconf:
+                if "spikeScalingToUv" in trode.attrib:
+                    gain = float(trode.attrib["spikeScalingToUv"])
+                    units = "uV"
+                else:
+                    gain = 1  # revert to hardcoded gain
+                    units = ""
+
                 for schan in trode:
                     name = "trode" + trode.attrib["id"] + "chan" + schan.attrib["hwChan"]
                     chan_id = schan.attrib["hwChan"]
-                    # TODO LATER : handle gain correctly according the file version
-                    units = ""
-                    gain = 1.0
+
                     offset = 0.0
                     signal_channels.append(
                         (name, chan_id, self._sampling_rate, "int16", units, gain, offset, stream_id)

--- a/neo/rawio/spikegadgetsrawio.py
+++ b/neo/rawio/spikegadgetsrawio.py
@@ -57,7 +57,7 @@ class SpikeGadgetsRawIO(BaseRawIO):
         -----
         This file format has multiple versions:
             - Newer versions include the gain for scaling to microvolts [uV].
-            - If the scaling is not found in the header, it will be "hardcoded" to 1,
+            - If the scaling is not found in the header, the gain will be "hardcoded" to 1,
               in which case the units are not handled correctly.
 
         Examples

--- a/neo/rawio/spikegadgetsrawio.py
+++ b/neo/rawio/spikegadgetsrawio.py
@@ -59,6 +59,9 @@ class SpikeGadgetsRawIO(BaseRawIO):
             - Newer versions include the gain for scaling to microvolts [uV].
             - If the scaling is not found in the header, the gain will be "hardcoded" to 1,
               in which case the units are not handled correctly.
+        This will not affect functions that do not rely on the data having physical units,
+            e.g., _get_analogsignal_chunk, but functions such as rescale_signal_raw_to_float
+            will be inaccurate.
 
         Examples
         --------
@@ -172,6 +175,10 @@ class SpikeGadgetsRawIO(BaseRawIO):
             self._mask_channels_bytes[stream_id] = []
 
             chan_ind = 0
+            self.is_scaleable = "spikeScalingToUv" in sconf[0].attrib
+            if not self.is_scaleable:
+                self.logger.warning("Unable to read channel gain scaling (to uV) from .rec header. Data has no physical units!")
+
             for trode in sconf:
                 if "spikeScalingToUv" in trode.attrib:
                     gain = float(trode.attrib["spikeScalingToUv"])


### PR DESCRIPTION
Updates spikegadgetsrawio.py:_parse_header() to read the channel (ntrode) gain scaling from the header file elements.