### PR TITLE
OpenEphys: Allow for new `stream` naming convention

### DIFF
--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -297,7 +297,7 @@ class OpenEphysRawIO(BaseRawIO):
                 if oe_index == 0:
                     event_filename = Path(self.dirname) / (event_file_name_0 + ".events")
                 else:
-                    event_filename = Path(self.dirname) / (event_file_name_0 + f"_{oe_index}.events")
+                    event_filename = Path(self.dirname) / (event_file_name_0 + f"_{oe_index + 1}.events")
 
                 event_info = read_file_header(event_filename)
                 # event files can exist, but just not have data

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -295,9 +295,9 @@ class OpenEphysRawIO(BaseRawIO):
             event_file_name_0 = event_files[0].stem  # this should always be the file without a '_n' appended
             for seg_index, oe_index in enumerate(oe_indices):
                 if oe_index == 0:
-                    event_filename = Path(self.dirname) / event_file_name_0 / ".events"
+                    event_filename = Path(self.dirname) / event_file_name_0 + ".events"
                 else:
-                    event_filename = Path(self.dirname) / event_file_name_0 / f"_{oe_index}" / ".events"
+                    event_filename = Path(self.dirname) / event_file_name_0 + f"_{oe_index}" + ".events"
 
                 event_info = read_file_header(event_filename)
                 # event files can exist, but just not have data

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -115,6 +115,7 @@ class OpenEphysRawIO(BaseRawIO):
                 chan_info = read_file_header(continuous_filename)
 
                 s = continuous_filename.stem.split("_")
+                # Formats are ['processor_id', 'ch_name'] or  ['processor_id', 'name', 'ch_name']
                 if len(s) == 2:
                     processor_id, ch_name = s[0], s[1]
                     chan_str = re.split(r"(\d+)", s[1])[0]
@@ -602,7 +603,7 @@ def explore_folder(dirname):
             # For continuous files we check if the last value is an int indicating that a new segment should be
             # generated and if it is not an int then this must be same segment
             try:
-                seg_index = int(s[-1])
+                seg_index = int(s[-1]) - 1
             except ValueError:
                 seg_index = 0
             if seg_index not in info["continuous"].keys():

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -295,9 +295,9 @@ class OpenEphysRawIO(BaseRawIO):
             event_file_name_0 = event_files[0].stem  # this should always be the file without a '_n' appended
             for seg_index, oe_index in enumerate(oe_indices):
                 if oe_index == 0:
-                    event_filename = Path(self.dirname) / event_file_name_0 + ".events"
+                    event_filename = Path(self.dirname) / (event_file_name_0 + ".events")
                 else:
-                    event_filename = Path(self.dirname) / event_file_name_0 + f"_{oe_index}" + ".events"
+                    event_filename = Path(self.dirname) / (event_file_name_0 + f"_{oe_index}.events")
 
                 event_info = read_file_header(event_filename)
                 # event files can exist, but just not have data

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -117,7 +117,7 @@ class OpenEphysRawIO(BaseRawIO):
                 s = continuous_filename.stem.split("_")
                 if len(s) == 2:
                     processor_id, ch_name = s[0], s[1]
-                    chan_str = re.split(r"(\d+)", s[2])[0]
+                    chan_str = re.split(r"(\d+)", s[1])[0]
                 else:
                     processor_id, ch_name = s[0], s[2]
                     chan_str = re.split(r"(\d+)", s[2])[0]

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -289,20 +289,15 @@ class OpenEphysRawIO(BaseRawIO):
                 if event_file.name != "messages.events"
             ]
         )
-        event_files.sort()
-        # only run if we have actual potential event files 
+        event_files.sort()  # sort should put the xx.events first followed by xx_x.events
+        # only run if we have actual potential event files
         if len(event_files) > 0:
+            event_file_name_0 = event_files[0].stem  # this should always be the file without a '_n' appended
             for seg_index, oe_index in enumerate(oe_indices):
                 if oe_index == 0:
-                    if (event_files[0].parent / "all_channels.events").exists():
-                        event_filename = Path(self.dirname) / "all_channels.events"
-                    else:
-                        event_filename = event_files[seg_index]
+                    event_filename = Path(self.dirname) / event_file_name_0 / ".events"
                 else:
-                    if (event_files[0].parent / f"all_channels_{oe_index + 1}.events").exists():
-                        event_filename = Path(self.dirname) / f"all_channels_{oe_index + 1}.events"
-                    else:
-                        event_filename = event_files[seg_index]
+                    event_filename = Path(self.dirname) / event_file_name_0 / f"_{oe_index}" / ".events"
 
                 event_info = read_file_header(event_filename)
                 # event files can exist, but just not have data

--- a/neo/test/rawiotest/test_openephysrawio.py
+++ b/neo/test/rawiotest/test_openephysrawio.py
@@ -15,6 +15,9 @@ class TestOpenEphysRawIO(
         # this file has gaps and this is now handle corretly
         "openephys/OpenEphys_SampleData_2_(multiple_starts)",
         # 'openephys/OpenEphys_SampleData_3',
+        # two nodes with the new naming convention for openephys
+        "openephys/openephys_rhythmdata_test_nodes/Record Node 120",
+        "openephys/openephys_rhythmdata_test_nodes/Record Node 121",
     ]
 
     def test_raise_error_if_strange_timestamps(self):


### PR DESCRIPTION
Fixes #1320 
Replaces #1423 

It seems that newer versions of openephys have filenames of `xx_RhythmData_CHx` instead of `xx_CHx`. This PR switches to using pathlib for openephys + accounts for this new naming convention + more robustly deals with missing `.events` files since in fact there can also be empty `.events` files. 

We can test with these files for the new naming format.

[openephys_rhythmdata_test_nodes.zip](https://github.com/NeuralEnsemble/python-neo/files/14839537/openephys_rhythmdata_test_nodes.zip)


Also adding for changes to [OE docs](https://open-ephys.github.io/gui-docs/User-Manual/Recording-data/Open-Ephys-format.html) for those who wan to read about these changes.