### PR TITLE
IntanRawIO: Update support of `rhs` files

### DIFF
--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -112,7 +112,7 @@ class IntanRawIO(BaseRawIO):
                 header_size,
                 self._block_size,
                 channel_number_dict,
-            ) = read_rhs(self.filename)
+            ) = read_rhs(self.filename, self.file_format)
 
 
         # 3 possibilities for rhd files, one combines the header and the data in the same file with suffix `rhd` while

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -481,8 +481,8 @@ def read_rhs(filename, file_format: str):
         channels_by_type = {k: [] for k in [0, 3, 4, 5, 6]}
         if not file_format == "header-attached":
             # data_dtype for rhs is complicated. There is not 1, 2 (supply and aux),
-            # but there are dc-amp (10) and stim (11). we make timestamps (7)
-            data_dtype = {k: [] for k in [0, 3, 4, 5, 6, 7, 10, 11]}
+            # but there are dc-amp (10) and stim (11). we make timestamps (15)
+            data_dtype = {k: [] for k in [0, 3, 4, 5, 6, 10, 11, 15]}
         for g in range(global_info["nb_signal_group"]):
             group_info = read_variable_header(f, rhs_signal_group_header)
 
@@ -568,7 +568,7 @@ def read_rhs(filename, file_format: str):
             if file_format == "header-attached":
                 data_dtype += [(name + "_STIM", "uint16", BLOCK_SIZE)]
             else:
-                data_dtype[11] == "uint16"
+                data_dtype[11] = "uint16"
     else:
         warnings.warn("Stim not implemented for `one-file-per-channel` due to lack of test files")
 
@@ -952,7 +952,7 @@ one_file_per_signal_filenames_rhs = [
     "supply.dat",
     "analogin.dat",
     "analogout.dat",
-     "digitalin.dat",
+    "digitalin.dat",
     "digitalout.dat",
 ]
 

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -97,7 +97,7 @@ class IntanRawIO(BaseRawIO):
 
         if self.filename.endswith(".rhs"):
             if filename.name == "info.rhs":
-                if any((filename.parent / file).exists for file in one_file_per_signal_filenames):
+                if any((filename.parent / file).exists() for file in one_file_per_signal_filenames):
                     self.file_format = "one-file-per-signal"
                     raw_file_paths_dict = create_one_file_per_signal_dict(dirname=filename.parent, rhs=True)
                 else:

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -217,7 +217,7 @@ class IntanRawIO(BaseRawIO):
         stream_ids_sorted = sorted([int(stream_id) for stream_id in stream_ids])
         signal_streams["id"] = [str(stream_id) for stream_id in stream_ids_sorted]
 
-        for stream_index, stream_id in enumerate(stream_ids):
+        for stream_index, stream_id in enumerate(stream_ids_sorted):
             if self.filename.endswith(".rhd"):
                 signal_streams["name"][stream_index] = stream_type_to_name_rhd.get(int(stream_id), "")
             else:

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -538,7 +538,7 @@ def read_rhs(filename, file_format: str):
             if file_format == "header-attached":
                 data_dtype += [(name + "_DC", "uint16", BLOCK_SIZE)]
             else:
-                data_dtype[10] = "unit16"
+                data_dtype[10] = "uint16"
     # I can't seem to get stim files to generate for one-file-per-channel
     # so let's skip for now and can be given on request
 
@@ -560,7 +560,7 @@ def read_rhs(filename, file_format: str):
             if file_format == "header-attached":
                 data_dtype += [(name + "_STIM", "uint16", BLOCK_SIZE)]
             else:
-                data_dtype[11] == "unit16"
+                data_dtype[11] == "uint16"
     else:
         warnings.warn("Stim not implemented for `one-file-per-channel` due to lack of test files")
 
@@ -583,7 +583,7 @@ def read_rhs(filename, file_format: str):
             if file_format == "header-attached":
                 data_dtype += [(name, "uint16", BLOCK_SIZE)]
             else:
-                data_dtype[sig_type] = "unit16"
+                data_dtype[sig_type] = "uint16"
 
     # 5: Digital input channel.
     # 6: Digital output channel.

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -176,7 +176,7 @@ class IntanRawIO(BaseRawIO):
         if self.file_format == "header-attached":
             timestamp = self._raw_data["timestamp"].flatten()
 
-        # timestamps are always 6 for rhd and 7 for rhs
+        # timestamps are always last stream for headerless binary files
         elif self.file_format == "one-file-per-signal":
             time_stream_index = max(self._raw_data.keys())
             timestamp = self._raw_data[time_stream_index]
@@ -951,7 +951,8 @@ one_file_per_signal_filenames_rhs = [
     "auxiliary.dat",
     "supply.dat",
     "analogin.dat",
-    "analogout.dat" "digitalin.dat",
+    "analogout.dat",
+     "digitalin.dat",
     "digitalout.dat",
 ]
 

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -212,7 +212,11 @@ class IntanRawIO(BaseRawIO):
 
         stream_ids = np.unique(signal_channels["stream_id"])
         signal_streams = np.zeros(stream_ids.size, dtype=_signal_stream_dtype)
-        signal_streams["id"] = stream_ids
+
+        # we need to sort the data because the string of 10 is mis-sorted.
+        stream_ids_sorted = sorted([int(stream_id) for stream_id in stream_ids])
+        signal_streams["id"] = [str(stream_id) for stream_id in stream_ids_sorted]
+
         for stream_index, stream_id in enumerate(stream_ids):
             if self.filename.endswith(".rhd"):
                 signal_streams["name"][stream_index] = stream_type_to_name_rhd.get(int(stream_id), "")

--- a/neo/test/iotest/test_intanio.py
+++ b/neo/test/iotest/test_intanio.py
@@ -19,6 +19,8 @@ class TestIntanIO(
         "intan/intan_rhd_test_1.rhd",
         "intan/intan_fpc_test_231117_052630/info.rhd",
         "intan/intan_fps_test_231117_052500/info.rhd",
+        "intan/intan_fpc_rhs_test_240329_091536/info.rhs",
+        "intan/intan_fps_rhs_test_240329_091637/info.rhs",
     ]
 
 

--- a/neo/test/iotest/test_intanio.py
+++ b/neo/test/iotest/test_intanio.py
@@ -20,7 +20,7 @@ class TestIntanIO(
         "intan/intan_fpc_test_231117_052630/info.rhd",
         "intan/intan_fps_test_231117_052500/info.rhd",
         "intan/intan_fpc_rhs_test_240329_091637/info.rhs",
-        "intan/intan_fps_rhs_test_240329_091636/info.rhs",
+        "intan/intan_fps_rhs_test_240329_091536/info.rhs",
     ]
 
 

--- a/neo/test/iotest/test_intanio.py
+++ b/neo/test/iotest/test_intanio.py
@@ -19,8 +19,8 @@ class TestIntanIO(
         "intan/intan_rhd_test_1.rhd",
         "intan/intan_fpc_test_231117_052630/info.rhd",
         "intan/intan_fps_test_231117_052500/info.rhd",
-        "intan/intan_fpc_rhs_test_240329_091536/info.rhs",
-        "intan/intan_fps_rhs_test_240329_091637/info.rhs",
+        "intan/intan_fpc_rhs_test_240329_091537/info.rhs",
+        "intan/intan_fps_rhs_test_240329_091636/info.rhs",
     ]
 
 

--- a/neo/test/iotest/test_intanio.py
+++ b/neo/test/iotest/test_intanio.py
@@ -19,7 +19,7 @@ class TestIntanIO(
         "intan/intan_rhd_test_1.rhd",
         "intan/intan_fpc_test_231117_052630/info.rhd",
         "intan/intan_fps_test_231117_052500/info.rhd",
-        "intan/intan_fpc_rhs_test_240329_091537/info.rhs",
+        "intan/intan_fpc_rhs_test_240329_091637/info.rhs",
         "intan/intan_fps_rhs_test_240329_091636/info.rhs",
     ]
 

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -16,8 +16,8 @@ class TestIntanRawIO(
         "intan/intan_rhd_test_1.rhd",
         "intan/intan_fpc_test_231117_052630/info.rhd",
         "intan/intan_fps_test_231117_052500/info.rhd",
-        "intan/intan_fpc_rhs_test_240329_091536/info.rhs",
-        "intan/intan_fps_rhs_test_240329_091637/info.rhs",
+        "intan/intan_fpc_rhs_test_240329_091537/info.rhs",
+        "intan/intan_fps_rhs_test_240329_091636/info.rhs",
     ]
 
 

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -17,7 +17,7 @@ class TestIntanRawIO(
         "intan/intan_fpc_test_231117_052630/info.rhd",
         "intan/intan_fps_test_231117_052500/info.rhd",
         "intan/intan_fpc_rhs_test_240329_091637/info.rhs",
-        "intan/intan_fps_rhs_test_240329_091636/info.rhs",
+        "intan/intan_fps_rhs_test_240329_091536/info.rhs",
     ]
 
 

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -16,6 +16,8 @@ class TestIntanRawIO(
         "intan/intan_rhd_test_1.rhd",
         "intan/intan_fpc_test_231117_052630/info.rhd",
         "intan/intan_fps_test_231117_052500/info.rhd",
+        "intan/intan_fpc_rhs_test_240329_091536/info.rhs",
+        "intan/intan_fps_rhs_test_240329_091637/info.rhs",
     ]
 
 

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -16,7 +16,7 @@ class TestIntanRawIO(
         "intan/intan_rhd_test_1.rhd",
         "intan/intan_fpc_test_231117_052630/info.rhd",
         "intan/intan_fps_test_231117_052500/info.rhd",
-        "intan/intan_fpc_rhs_test_240329_091537/info.rhs",
+        "intan/intan_fpc_rhs_test_240329_091637/info.rhs",
         "intan/intan_fps_rhs_test_240329_091636/info.rhs",
     ]
 


### PR DESCRIPTION
This will be adding support for `RHX` rhs files with a separate header for `rhs` files. We haven't officially update RHS support since RHS 1.0 and we are on 3.x so this may take a bit of work. We will add tests files soon so that we can properly test this.

TODOS
* [x] ~~Add support for supply and aux channels in RHS~~ Turns out that there isn't any from newest docs!
* [x] Add support for `one-file-per-signal`
* [x] Add support for `one-file-per-channel`
* [x] Add test files for new formats
* [x] Add access to digital channels like we did for rhd
* [x]  Try to understand the stim channels to see if we need to make updates
* [x] Add channel_number_dict for one-file-per-signal
* [x] Add analog-out in the one-file-per-channel-dict function

Neuroconv provenance https://github.com/catalystneuro/neuroconv/issues/789