### PR TITLE
SpikeGLX: add Ultra and NP-Opto types

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -441,7 +441,7 @@ def extract_stream_info(meta_file, meta):
         if (
             "imDatPrb_type" not in meta
             or meta["imDatPrb_type"] == "0"
-            or meta["imDatPrb_type"] in ("1015", "1022", "1030", "1031", "1032")
+            or meta["imDatPrb_type"] in ("1015", "1022", "1030", "1031", "1032", "1100", "1121", "1300")
         ):
             # This work with NP 1.0 case with different metadata versions
             # https://github.com/billkarsh/SpikeGLX/blob/15ec8898e17829f9f08c226bf04f46281f106e5f/Markdown/Metadata_30.md

--- a/neo/test/rawiotest/test_spikeglxrawio.py
+++ b/neo/test/rawiotest/test_spikeglxrawio.py
@@ -29,6 +29,8 @@ class TestSpikeGLXRawIO(BaseTestRawIO, unittest.TestCase):
         "spikeglx/NP2_with_sync",
         "spikeglx/NP2_no_sync",
         "spikeglx/NP2_subset_with_sync",
+        # NP-ultra
+        "spikeglx/np_ultra_stub",
     ]
 
     def test_with_location(self):


### PR DESCRIPTION
Fixes #1451 

also adding Ultra-beta variant (1121) ant NP-Opto (1300). All these models are based on NP1.0 technology

@CodyCBakerPhD 