### PR TITLE
Neuroscope: fix scale of signals.

### DIFF
--- a/neo/rawio/neuroscoperawio.py
+++ b/neo/rawio/neuroscoperawio.py
@@ -92,9 +92,9 @@ class NeuroScopeRawIO(BaseRawIO):
             for xml_rc in xml_chx:
                 channel_group[int(xml_rc.text)] = grp_index
 
+        sig_dtype = "int16"
         if nbits == 16:
-            sig_dtype = "int16"
-            gain = voltage_range / (2**16) / amplification / 1000.0
+            gain = voltage_range * 1000 / (2**nbits) / amplification
             # ~ elif nbits==32:
             # Not sure if it is int or float
             # ~ dt = 'int32'

--- a/neo/rawio/neuroscoperawio.py
+++ b/neo/rawio/neuroscoperawio.py
@@ -93,6 +93,8 @@ class NeuroScopeRawIO(BaseRawIO):
                 channel_group[int(xml_rc.text)] = grp_index
 
         sig_dtype = "int16"
+        # scale to convert sample values to voltage in mV = range of recording in volts *
+        #  1000 mV/V /(number of bits * amplification)
         if nbits == 16:
             gain = voltage_range * 1000 / (2**nbits) / amplification
             # ~ elif nbits==32:

--- a/neo/test/rawiotest/test_neuroscoperawio.py
+++ b/neo/test/rawiotest/test_neuroscoperawio.py
@@ -1,6 +1,7 @@
-import unittest
 import logging
+import os
 from pathlib import Path
+import unittest
 
 from neo.rawio.neuroscoperawio import NeuroScopeRawIO
 from neo.test.rawiotest.common_rawio_test import BaseTestRawIO
@@ -16,6 +17,17 @@ class TestNeuroScopeRawIO(BaseTestRawIO, unittest.TestCase):
         "neuroscope/test1/test1.dat",
         "neuroscope/dataset_1/YutaMouse42-151117.eeg",
     ]
+
+    def test_signal_scale(self):
+        local_test_dir = get_local_testing_data_folder()
+        fname = os.path.join(local_test_dir, "neuroscope/test1/test1.xml")
+        reader = NeuroScopeRawIO(filename=fname)
+        reader.parse_header()
+
+        gain = reader.header['signal_channels'][0]['gain']
+
+        # scale is in mV = range of recording in volts * 1000 mV/V /(number of bits * ampification)
+        self.assertAlmostEqual(20.0 * 1000 / (2**16 * 1000), gain)
 
     def test_binary_argument_with_non_canonical_xml_file(self):
 


### PR DESCRIPTION
Need to multiply not divide by 1000 for mV scale.