### PR TITLE
Release notes for 0.13.1, plus an update to the list of authors.

### DIFF
--- a/doc/source/authors.rst
+++ b/doc/source/authors.rst
@@ -27,6 +27,7 @@ and may not be the current affiliation of a contributor.
 * Kyler Brown
 * Mikkel Elle Lepperød [11]
 * C Daniel Meliza [12]
+* Michael Denker [13, 29]
 * Julia Sprenger [13, 6]
 * Maximilian Schmidt [13]
 * Johanna Senk [13]
@@ -65,20 +66,23 @@ and may not be the current affiliation of a contributor.
 * Thomas Perret [25]
 * Kyle Johnsen [26, 27]
 * Zach McKenzie [28]
-* Moritz Alexander Kern
+* Moritz Alexander Kern [29]
 * Joscha Schmiedt
-* Daniel P. Crepeau
-* Divyansh Gupta
-* Nate Dolensek
-* Philipp Hornauer
+* Daniel P. Crepeau [30]
+* Divyansh Gupta [31]
+* Nate Dolensek [3]
+* Philipp Hornauer [32]
 * Robert Wolff
-* Jules Lebert
+* Jules Lebert [33]
 * Benjamin Heasly
-* Baptiste Grimaud
-* Cody Baker
-* Fernando J. Chaure
+* Baptiste Grimaud [34]
+* Cody Baker [24]
+* Fernando J. Chaure [35]
 * Filipe*github
 * Matthias Klumpp
+* Greg Knoll [36]
+* Chris Halcrow [37]
+* Szonja Weigl [24]
 
 1. Centre de Recherche en Neuroscience de Lyon, CNRS UMR5292 - INSERM U1028 - Universite Claude Bernard Lyon 1
 2. Unité de Neuroscience, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France
@@ -108,6 +112,16 @@ and may not be the current affiliation of a contributor.
 26. Georgia Institute of Technology
 27. Emory University
 28. Harvard Medical School
+29. Institute for Advanced Simulation (IAS-6), Forschungszentrum Jülich, Germany
+30. Dark Horse Neuro, Inc.
+31. IST Austria
+32. Department of Biosystems Science and Engineering, ETH Zürich, Basel, Switzerland
+33. University College London
+34. École Normale Supérieure Paris-Saclay
+35. Institute of Biomedical Engineering, University of Buenos Aires, Argentina
+36. Bernstein Center for Computational Neuroscience, Berlin, Germany
+37. University of Edinburgh
+
 
 If we've somehow missed you off the list we're very sorry - please let us know.
 

--- a/doc/source/releases.rst
+++ b/doc/source/releases.rst
@@ -6,6 +6,7 @@ Release notes
 .. toctree::
    :maxdepth: 1
 
+   releases/0.13.1.rst
    releases/0.13.0.rst
    releases/0.12.0.rst
    releases/0.11.1.rst

--- a/doc/source/releases/0.13.1.rst
+++ b/doc/source/releases/0.13.1.rst
@@ -1,0 +1,42 @@
+========================
+Neo 0.13.1 release notes
+========================
+
+7th May 2024
+
+
+This release of Neo contains a lot of improvements to code quality and documentation,
+still with a focus on the planned 1.0 release,
+together with, as usual, bug fixes and performance improvements in IO modules.
+
+See all `pull requests`_ included in this release and the `list of closed issues`_.
+
+Code and documentation quality
+------------------------------
+
+Particular thanks go to Zach McKenzie, who has checked, and rewritten if necessary, every docstring in the project,
+to ensure they all have a consistent style.
+Zach has also updated and improved the :doc:`../examples/index` in the Sphinx documentation.
+
+The Neo code base contained a lot of ``assert``\s that should be exceptions.
+These have all been replaced with appropriate exceptions (again by Zach McKenzie).
+A new exception class, :class:`NeoReadWriteError` has been introduced.
+
+Bug fixes and improvements in IO modules
+----------------------------------------
+
+Bug fixes and/or improvements have been made to :class:`SpikeGLXIO`, :class:`OpenEphysIO`, :class:`SpikeGadgetsIO`,
+:class:`MaxwellIO`, :class:`AxonIO`, :class:`IntanIO`, :class:`TDTIO`, :class:`NeuralynxIO` and :class:`BlackrockIO`.
+
+
+Acknowledgements
+----------------
+
+Thanks to Zach McKenzie, Andrew Davison, Heberto Mayorquin, Alessio Buccino, Samuel Garcia, Peter N. Steinmetz,
+Aitor Morales-Gregorio, Greg Knoll, Chris Halcrow and Szonja Weigl for their contributions to this release.
+
+.. generated with git shortlog --since=2024-02-02 -sne then checking Github for PRs merged since the last release but with commits before then
+
+.. _`list of closed issues`: https://github.com/NeuralEnsemble/python-neo/issues?q=is%3Aissue+milestone%3A0.13.1+is%3Aclosed
+.. _`pull requests`: https://github.com/NeuralEnsemble/python-neo/pulls?q=is%3Apr+is%3Aclosed+merged%3A%3E2024-02-02+milestone%3A0.13.1
+.. _`examples gallery`: https://neo.readthedocs.io/en/latest/examples/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neo"
-version = "0.13.1.dev"
+version = "0.13.1"
 authors = [{name = "Neo authors and contributors"}]
 description = "Neo is a package for representing electrophysiology data in Python, together with support for reading a wide range of neurophysiology file formats"
 readme = "README.rst"


### PR DESCRIPTION
These notes assume that #1338 gets merged before the release. If it doesn't get merged, remove the mention of BlackrockIO.

Note that I added affiliations for new contributors where I could find them. If you see yourself in the author list and there's no affiliation given, please let us know in the comments if you'd like your affiliation to be added. If there's an error in your affiliation, please also let us know.