### PR TITLE
Add the possilibity of opening intan files even if corrupted.

### DIFF
--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -46,7 +46,7 @@ class IntanRawIO(BaseRawIO):
     ignore_integrity_checks: bool, default: False
         If True, data that violates integrity assumptions will be loaded. At the moment the only integrity
         check we perform is that timestamps are continuous. Setting this to True will ignore this check and set
-        the attribute `discontinous_timestamps` to True if the timestamps are not continous. This attribute can be checked 
+        the attribute `discontinuous_timestamps` to True if the timestamps are not continous. This attribute can be checked 
         after parsing the header to see if the timestamps are continuous or not.
     Notes
     -----
@@ -88,7 +88,7 @@ class IntanRawIO(BaseRawIO):
         BaseRawIO.__init__(self)
         self.filename = filename
         self.ignore_integrity_checks = ignore_integrity_checks
-        self.discontinous_timestamps = False
+        self.discontinuous_timestamps = False
 
 
     def _source_name(self):
@@ -192,7 +192,7 @@ class IntanRawIO(BaseRawIO):
         discontinuous_timestamps = np.diff(timestamp) != 1
         timestamps_are_not_contiguous = np.any(discontinuous_timestamps)
         if timestamps_are_not_contiguous:
-            self.discontinous_timestamps = True
+            self.discontinuous_timestamps = True
             if not self.ignore_integrity_checks:
                 error_msg = (
                     "Timestamps are not continuous, this could be due to a corrupted file or an inappropriate file merge. "

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -197,7 +197,7 @@ class IntanRawIO(BaseRawIO):
                 error_msg = (
                     "Timestamps are not continuous, this could be due to a corrupted file or an inappropriate file merge. "
                     "Initialize the reader with `load_data_unsafely=True` to ignore this error and open the file. \n"
-                    f"Indexes of discontinuous timestamps: {timestamp[discontinuous_timestamps]}"
+                    f"Timestamps around discontinuities: {timestamp[discontinuous_timestamps]}"
                 )
                 raise NeoReadWriteError(error_msg)
 

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -189,8 +189,8 @@ class IntanRawIO(BaseRawIO):
             time_stream_index = max(self._raw_data.keys())
             timestamp = self._raw_data[time_stream_index][0]
         
-        timestamps_are_not_contigious = np.any(np.diff(timestamp) != 1)
-        if timestamps_are_not_contigious:
+        timestamps_are_not_contiguous = np.any(np.diff(timestamp) != 1)
+        if timestamps_are_not_contiguous:
             self.unsafe_timestamps = True
             if not self.load_data_unsafely:
                 error_msg = (

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -43,10 +43,10 @@ class IntanRawIO(BaseRawIO):
     ----------
     filename: str, default: ''
         name of the 'rhd' or 'rhs' data file
-    load_data_unsafely: bool, default: False
+    ignore_integrity_checks: bool, default: False
         If True, data that violates integrity assumptions will be loaded. At the moment the only integrity
         check we perform is that timestamps are continuous. Setting this to True will ignore this check and set
-        the attribute `unsafe_timestamps` to True if the timestamps are not continous. This attribute can be checked 
+        the attribute `discontinous_timestamps` to True if the timestamps are not continous. This attribute can be checked 
         after parsing the header to see if the timestamps are continuous or not.
     Notes
     -----
@@ -83,12 +83,12 @@ class IntanRawIO(BaseRawIO):
     extensions = ["rhd", "rhs", "dat"]
     rawmode = "one-file"
 
-    def __init__(self, filename="", load_data_unsafely=False):
+    def __init__(self, filename="", ignore_integrity_checks=False):
 
         BaseRawIO.__init__(self)
         self.filename = filename
-        self.load_data_unsafely = load_data_unsafely
-        self.unsafe_timestamps = False
+        self.ignore_integrity_checks = ignore_integrity_checks
+        self.discontinous_timestamps = False
 
 
     def _source_name(self):
@@ -192,11 +192,11 @@ class IntanRawIO(BaseRawIO):
         discontinuous_timestamps = np.diff(timestamp) != 1
         timestamps_are_not_contiguous = np.any(discontinuous_timestamps)
         if timestamps_are_not_contiguous:
-            self.unsafe_timestamps = True
-            if not self.load_data_unsafely:
+            self.discontinous_timestamps = True
+            if not self.ignore_integrity_checks:
                 error_msg = (
                     "Timestamps are not continuous, this could be due to a corrupted file or an inappropriate file merge. "
-                    "Initialize the reader with `load_data_unsafely=True` to ignore this error and open the file. \n"
+                    "Initialize the reader with `ignore_integrity_checks=True` to ignore this error and open the file. \n"
                     f"Timestamps around discontinuities: {timestamp[discontinuous_timestamps]}"
                 )
                 raise NeoReadWriteError(error_msg)

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -19,8 +19,6 @@ Author: Samuel Garcia (Initial), Zach McKenzie & Heberto Mayorquin (Updates)
 """
 
 from pathlib import Path
-import os
-from collections import OrderedDict
 from packaging.version import Version as V
 import warnings
 
@@ -45,7 +43,7 @@ class IntanRawIO(BaseRawIO):
     ----------
     filename: str, default: ''
         name of the 'rhd' or 'rhs' data file
-    load_unsafe_data: bool, default: False
+    load_data_unsafely: bool, default: False
         If True, data that violates integrity assumptions will be loaded. At the moment the only integrity
         check we perform is that timestamps are continuous. Setting this to True will ignore this check and set
         the attribute `unsafe_timestamps` to True if the timestamps are not continous. This attribute can be checked 
@@ -85,11 +83,11 @@ class IntanRawIO(BaseRawIO):
     extensions = ["rhd", "rhs", "dat"]
     rawmode = "one-file"
 
-    def __init__(self, filename="", load_unsafe_data=True):
+    def __init__(self, filename="", load_data_unsafely=True):
 
         BaseRawIO.__init__(self)
         self.filename = filename
-        self.load_unsafe_data = load_unsafe_data
+        self.load_data_unsafely = load_data_unsafely
         self.unsafe_timestamps = False
 
 
@@ -194,10 +192,10 @@ class IntanRawIO(BaseRawIO):
         timestamps_are_not_contigious = np.any(np.diff(timestamp) != 1)
         if timestamps_are_not_contigious:
             self.unsafe_timestamps = True
-            if not self.load_unsafe_data:
+            if not self.load_data_unsafely:
                 error_msg = (
                     "Timestamps are not continuous, this could be due to a corrupted file or an inappropriate file merge. "
-                    "Initialize the reader with `load_unsafe_data=True` to ignore this error and open the file."
+                    "Initialize the reader with `load_data_unsafely=True` to ignore this error and open the file."
                 )
                 raise NeoReadWriteError(error_msg)
 

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -83,7 +83,7 @@ class IntanRawIO(BaseRawIO):
     extensions = ["rhd", "rhs", "dat"]
     rawmode = "one-file"
 
-    def __init__(self, filename="", load_data_unsafely=True):
+    def __init__(self, filename="", load_data_unsafely=False):
 
         BaseRawIO.__init__(self)
         self.filename = filename
@@ -189,13 +189,15 @@ class IntanRawIO(BaseRawIO):
             time_stream_index = max(self._raw_data.keys())
             timestamp = self._raw_data[time_stream_index][0]
         
-        timestamps_are_not_contiguous = np.any(np.diff(timestamp) != 1)
+        discontinuous_timestamps = np.diff(timestamp) != 1
+        timestamps_are_not_contiguous = np.any(discontinuous_timestamps)
         if timestamps_are_not_contiguous:
             self.unsafe_timestamps = True
             if not self.load_data_unsafely:
                 error_msg = (
                     "Timestamps are not continuous, this could be due to a corrupted file or an inappropriate file merge. "
-                    "Initialize the reader with `load_data_unsafely=True` to ignore this error and open the file."
+                    "Initialize the reader with `load_data_unsafely=True` to ignore this error and open the file. \n"
+                    f"Indexes of discontinuous timestamps: {timestamp[discontinuous_timestamps]}"
                 )
                 raise NeoReadWriteError(error_msg)
 


### PR DESCRIPTION
Hi,
Currently, we have a check to determine if the timestamps associated with the data exhibit discontinuities. If they do, we throw an assertion and prevent the file from being read. I believe this is beneficial as it serves as a strong signal that the user should take a closer look at the file. This assertion is warranted.

But I also believe that once we infrormed the users that there is an error we should still allow the users to open the file if so they desired. This is good for two reasons:
1) Users can use the machinery of neo to find out what might have been wrong which would be a valuable service.
2) Sometimes, there is no other way, that is, the person who ran the experiments is not longer available but people might still want to analyze the data. I think this is a user case that should be covered.

This PR allows this to happen by introducing another boolean at instantiation that overpass this error and open the file anway. That is, it just allows the desired behavior with a boolean and keeps the default as it is for backwards compatbility.

