### PR TITLE
Testing: adding python 3.12 to core tests

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -26,17 +26,32 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # "macos-latest",
-        python-version: ['3.8', '3.9', '3.10', '3.11']
-        numpy-version: ['1.20.3', '1.21.6', '1.22.4', '1.23.5', '1.24.1', '1.25.1']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        numpy-version: ['1.20.3', '1.21.6', '1.22.4', '1.23.5', '1.24.1', '1.25.1', '1.26.4']
         exclude:
            - python-version: '3.8'
              numpy-version: '1.25.1'
+           - python-version: '3.8'
+             numpy-version: '1.26.4'
            - python-version: '3.10'
              numpy-version: '1.20.3'
            - python-version: '3.11'
              numpy-version: '1.20.3'
            - python-version: '3.11'
              numpy-version: '1.21.6'
+           - python-version: '3.12'
+             numpy-version: '1.20.3'
+           # python 3.12 only works on latest numpy
+           - python-version: '3.12'
+             numpy-version: '1.21.6'
+           - python-version: '3.12'
+             numpy-version: '1.22.4'
+           - python-version: '3.12'
+             numpy-version: '1.23.5'
+           - python-version: '3.12'
+             numpy-version: '1.24.1'
+           - python-version: '3.12'
+             numpy-version: '1.25.1'
     steps:
         - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v4


### PR DESCRIPTION
So I added 3.12 to the matrix. 3.8 goes off support in October but by then 3.13 should be released. We probably shouldn't get too far behind testing the python versions.

Only annoying things is that because of deprecations only numpy 1.26 is compatible. But I added that to tests as well. Once we remove 3.8 this will also clean-up nicely.