### PR TITLE
Testing: Run IO-tests on multiple python versions

### DIFF
--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.11']
     defaults:
       # by default run in bash mode (required for conda usage)
       run:

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -75,7 +75,7 @@ jobs:
         if: steps.cache-conda-env.outputs.cache-hit != 'true'
         run: |
           conda env update --name neo-test-env --file environment_testing.yml --prune
-          conda update python=${{ matrix.python-version }}
+          conda install python=${{ matrix.python-version }}
 
       - name: Configure git
         run: |

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.9', ]
+        python-version: ['3.9', '3.10', '3.11']
     defaults:
       # by default run in bash mode (required for conda usage)
       run:

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -13,7 +13,7 @@ concurrency:  # Cancel previous workflows on the same pull request
 
 jobs:
   build-and-test:
-    name: Test on (${{ inputs.os }})
+    name: Test on (${{ inputs.os }}) (${{ matrix.python-version}})
     runs-on: ${{ inputs.os }}
     strategy:
       fail-fast: true
@@ -75,6 +75,7 @@ jobs:
         if: steps.cache-conda-env.outputs.cache-hit != 'true'
         run: |
           conda env update --name neo-test-env --file environment_testing.yml --prune
+          conda update python= ${{ matrix.python-version }}
 
       - name: Configure git
         run: |

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -75,7 +75,7 @@ jobs:
         if: steps.cache-conda-env.outputs.cache-hit != 'true'
         run: |
           conda env update --name neo-test-env --file environment_testing.yml --prune
-          conda update python= ${{ matrix.python-version }}
+          conda update python=${{ matrix.python-version }}
 
       - name: Configure git
         run: |

--- a/environment_testing.yml
+++ b/environment_testing.yml
@@ -2,6 +2,5 @@ name: neo-test-env
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
   - datalad
   - pip


### PR DESCRIPTION
Since python is deprecating alot of standard library stuff and we have some more legacy IOs we should probably test against multiple python versions. This tests against 
3.9, 3.10, and 3.11. We can add 3.12 to see what will break later for the IOs.