### PR TITLE
Fix digital streams in Intan for the `one-file-per-channel` format in rhd.

### DIFF
--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           path: ~/ephy_testing_data
           key: ${{ runner.os }}-datasets-${{ steps.ephy_testing_data.outputs.dataset_hash }}
-          # restore-keys: ${{ runner.os }}-datasets-
+          restore-keys: ${{ runner.os }}-datasets-
 
       - uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           path: ~/ephy_testing_data
           key: ${{ runner.os }}-datasets-${{ steps.ephy_testing_data.outputs.dataset_hash }}
-          restore-keys: ${{ runner.os }}-datasets-
+          # restore-keys: ${{ runner.os }}-datasets-
 
       - uses: conda-incubator/setup-miniconda@v3
         with:

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -598,7 +598,7 @@ def read_rhs(filename, file_format: str):
     for sig_type in [5, 6]:
         if file_format in ["header-attached", "one-file-per-signal"]:
             if len(channels_by_type[sig_type]) > 0:
-                name = {4: "DIGITAL-IN", 5: "DIGITAL-OUT"}[sig_type]
+                name = {5: "DIGITAL-IN", 6: "DIGITAL-OUT"}[sig_type]
                 chan_info = channels_by_type[sig_type][0]
                 # So currently until we have get_digitalsignal_chunk we need to do a tiny hack to
                 # make this memory map work correctly. So since our digital data is not organized

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -537,6 +537,7 @@ def read_rhs(filename, file_format: str):
         channel_number_dict[10] = channel_number_dict[0]
         for chan_info in channels_by_type[0]:
             chan_info_dc = dict(chan_info)
+            name = chan_info["native_channel_name"]
             chan_info_dc["native_channel_name"] = name + "_DC"
             chan_info_dc["sampling_rate"] = sr
             chan_info_dc["units"] = "mV"
@@ -546,7 +547,6 @@ def read_rhs(filename, file_format: str):
             chan_info_dc["dtype"] = "uint16"
             ordered_channels.append(chan_info_dc)
             if file_format == "header-attached":
-                name = chan_info["native_channel_name"]
                 data_dtype += [(name + "_DC", "uint16", BLOCK_SIZE)]
             else:
                 data_dtype[10] = "uint16"

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -52,9 +52,9 @@ class IntanRawIO(BaseRawIO):
     check for the file extension and will gather the header information based on the
     extension. Additionally it functions with RHS v 1.0 and RHD 1.0, 1.1, 1.2, 1.3, 2.0,
     3.0, and 3.1 files.
-    
+
     * The reader can handle three file formats 'header-attached', 'one-file-per-signal' and
-    'one-file-per-channel'. 
+    'one-file-per-channel'.
 
     * Intan files contain amplifier channels labeled 'A', 'B' 'C' or 'D'
     depending on the port in which they were recorded along with the following
@@ -514,7 +514,6 @@ def read_rhs(filename, file_format: str):
 
     # 0: RHS2000 amplifier channel.
     for chan_info in channels_by_type[0]:
-        name = chan_info["native_channel_name"]
         chan_info["sampling_rate"] = sr
         chan_info["units"] = "uV"
         chan_info["gain"] = 0.195
@@ -528,6 +527,7 @@ def read_rhs(filename, file_format: str):
             chan_info["dtype"] = "int16"
         ordered_channels.append(chan_info)
         if file_format == "header-attached":
+            name = chan_info["native_channel_name"]
             data_dtype += [(name, "uint16", BLOCK_SIZE)]
         else:
             data_dtype[0] = "int16"
@@ -536,7 +536,6 @@ def read_rhs(filename, file_format: str):
         # if we have dc amp we need to grab the correct number of channels
         channel_number_dict[10] = channel_number_dict[0]
         for chan_info in channels_by_type[0]:
-            name = chan_info["native_channel_name"]
             chan_info_dc = dict(chan_info)
             chan_info_dc["native_channel_name"] = name + "_DC"
             chan_info_dc["sampling_rate"] = sr
@@ -547,6 +546,7 @@ def read_rhs(filename, file_format: str):
             chan_info_dc["dtype"] = "uint16"
             ordered_channels.append(chan_info_dc)
             if file_format == "header-attached":
+                name = chan_info["native_channel_name"]
                 data_dtype += [(name + "_DC", "uint16", BLOCK_SIZE)]
             else:
                 data_dtype[10] = "uint16"
@@ -556,7 +556,6 @@ def read_rhs(filename, file_format: str):
     if file_format != "one-file-per-channel":
         channel_number_dict[11] = channel_number_dict[0]  # should be one stim / amplifier channel
         for chan_info in channels_by_type[0]:
-            name = chan_info["native_channel_name"]
             chan_info_stim = dict(chan_info)
             chan_info_stim["native_channel_name"] = name + "_STIM"
             chan_info_stim["sampling_rate"] = sr
@@ -569,6 +568,7 @@ def read_rhs(filename, file_format: str):
             chan_info_stim["dtype"] = "uint16"
             ordered_channels.append(chan_info_stim)
             if file_format == "header-attached":
+                name = chan_info["native_channel_name"]
                 data_dtype += [(name + "_STIM", "uint16", BLOCK_SIZE)]
             else:
                 data_dtype[11] = "uint16"
@@ -579,12 +579,8 @@ def read_rhs(filename, file_format: str):
 
     # 3: Analog input channel.
     # 4: Analog output channel.
-    for sig_type in [
-        3,
-        4
-    ]:
+    for sig_type in [3, 4]:
         for chan_info in channels_by_type[sig_type]:
-            name = chan_info["native_channel_name"]
             chan_info["sampling_rate"] = sr
             chan_info["units"] = "V"
             chan_info["gain"] = 0.0003125
@@ -592,6 +588,7 @@ def read_rhs(filename, file_format: str):
             chan_info["dtype"] = "uint16"
             ordered_channels.append(chan_info)
             if file_format == "header-attached":
+                name = chan_info["native_channel_name"]
                 data_dtype += [(name, "uint16", BLOCK_SIZE)]
             else:
                 data_dtype[sig_type] = "uint16"
@@ -607,7 +604,7 @@ def read_rhs(filename, file_format: str):
                 # make this memory map work correctly. So since our digital data is not organized
                 # by channel like analog/ADC are we have to overwrite the native name to create
                 # a single permanent name that we can find with channel id
-                chan_info["native_channel_name"] = name                
+                chan_info["native_channel_name"] = name
                 chan_info["sampling_rate"] = sr
                 chan_info["units"] = "TTL"  # arbitrary units TTL for logic
                 chan_info["gain"] = 1.0
@@ -617,7 +614,7 @@ def read_rhs(filename, file_format: str):
                 if file_format == "header-attached":
                     data_dtype += [(name, "uint16", BLOCK_SIZE)]
                 else:
-                    data_dtype[sig_type] = "uint16"      
+                    data_dtype[sig_type] = "uint16"
         elif file_format == "one-file-per-channel":
             for chan_info in channels_by_type[sig_type]:
                 chan_info["sampling_rate"] = sr
@@ -627,7 +624,6 @@ def read_rhs(filename, file_format: str):
                 chan_info["dtype"] = "uint16"
                 ordered_channels.append(chan_info)
                 data_dtype[sig_type] = "uint16"
-    
 
     if global_info["notch_filter_mode"] == 2 and global_info["major_version"] >= V("3.0"):
         global_info["notch_filter"] = "60Hz"
@@ -891,7 +887,7 @@ def read_rhd(filename, file_format: str):
                 # make this memory map work correctly. So since our digital data is not organized
                 # by channel like analog/ADC are we have to overwrite the native name to create
                 # a single permanent name that we can find with channel id
-                chan_info["native_channel_name"] = name                
+                chan_info["native_channel_name"] = name
                 chan_info["sampling_rate"] = sr
                 chan_info["units"] = "TTL"  # arbitrary units TTL for logic
                 chan_info["gain"] = 1.0
@@ -901,7 +897,7 @@ def read_rhd(filename, file_format: str):
                 if file_format == "header-attached":
                     data_dtype += [(name, "uint16", BLOCK_SIZE)]
                 else:
-                    data_dtype[sig_type] = "uint16"      
+                    data_dtype[sig_type] = "uint16"
         elif file_format == "one-file-per-channel":
             for chan_info in channels_by_type[sig_type]:
                 chan_info["sampling_rate"] = sr
@@ -911,9 +907,6 @@ def read_rhd(filename, file_format: str):
                 chan_info["dtype"] = "uint16"
                 ordered_channels.append(chan_info)
                 data_dtype[sig_type] = "uint16"
-    
-    
- 
 
     if global_info["notch_filter_mode"] == 2 and version >= V("3.0"):
         global_info["notch_filter"] = "60Hz"

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -615,6 +615,7 @@ def read_rhs(filename, file_format: str):
                     data_dtype += [(name, "uint16", BLOCK_SIZE)]
                 else:
                     data_dtype[sig_type] = "uint16"
+        # This case behaves as a binary with 0 and 1 coded as uint16
         elif file_format == "one-file-per-channel":
             for chan_info in channels_by_type[sig_type]:
                 chan_info["sampling_rate"] = sr

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -66,8 +66,8 @@ class IntanRawIO(BaseRawIO):
     4: 'USB board digital input channel',
     5: 'USB board digital output channel'
 
-    * For the "header-attached" format to the structure of the digital input and output channels these can be accessed
-    as one long vector, which must be post-processed.
+    * For the "header-attached" and "one-file-per-signal" formats, the structure of the digital input and output channels
+    these can be accessed as one long vector, which must be post-processed. 
 
     Examples
     --------
@@ -557,6 +557,7 @@ def read_rhs(filename, file_format: str):
         channel_number_dict[11] = channel_number_dict[0]  # should be one stim / amplifier channel
         for chan_info in channels_by_type[0]:
             chan_info_stim = dict(chan_info)
+            name = chan_info["native_channel_name"]
             chan_info_stim["native_channel_name"] = name + "_STIM"
             chan_info_stim["sampling_rate"] = sr
             # stim channel are complicated because they are coded
@@ -568,7 +569,6 @@ def read_rhs(filename, file_format: str):
             chan_info_stim["dtype"] = "uint16"
             ordered_channels.append(chan_info_stim)
             if file_format == "header-attached":
-                name = chan_info["native_channel_name"]
                 data_dtype += [(name + "_STIM", "uint16", BLOCK_SIZE)]
             else:
                 data_dtype[11] = "uint16"

--- a/neo/test/iotest/test_intanio.py
+++ b/neo/test/iotest/test_intanio.py
@@ -16,13 +16,13 @@ class TestIntanIO(
     entities_to_download = ["intan"]
     entities_to_test = [
         "intan/intan_rhs_test_1.rhs",  # Format header-attached 
-        "intan/intan_rhd_test_1.rhd",  # Format header attach
+        "intan/intan_rhd_test_1.rhd",  # Format header-attached
+        "intan/rhs_fpc_multistim_240514_082243/rhs_fpc_multistim_240514_082243.rhs",  # Format header-attached newer version
         "intan/intan_fpc_test_231117_052630/info.rhd",  # Format one-file-per-channel
         "intan/intan_fps_test_231117_052500/info.rhd",  # Format one file per signal
         "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
         "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
-        "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel
-        # "intan/rhs_fpc_multistim_240514_082243/info.rhs",  # Multiple digital channels one-file-per-channel rhs
+        "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel rhd
     ]
 
 

--- a/neo/test/iotest/test_intanio.py
+++ b/neo/test/iotest/test_intanio.py
@@ -22,7 +22,7 @@ class TestIntanIO(
         "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
         "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
         "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel
-        "intan/rhs_fpc_multistim_240514_082243/info.rhs",  # Multiple digital channels one-file-per-channel rhs
+        # "intan/rhs_fpc_multistim_240514_082243/info.rhs",  # Multiple digital channels one-file-per-channel rhs
     ]
 
 

--- a/neo/test/iotest/test_intanio.py
+++ b/neo/test/iotest/test_intanio.py
@@ -15,12 +15,14 @@ class TestIntanIO(
     ioclass = IntanIO
     entities_to_download = ["intan"]
     entities_to_test = [
-        "intan/intan_rhs_test_1.rhs",
-        "intan/intan_rhd_test_1.rhd",
-        "intan/intan_fpc_test_231117_052630/info.rhd",
-        "intan/intan_fps_test_231117_052500/info.rhd",
-        "intan/intan_fpc_rhs_test_240329_091637/info.rhs",
-        "intan/intan_fps_rhs_test_240329_091536/info.rhs",
+        "intan/intan_rhs_test_1.rhs",  # Format header-attached 
+        "intan/intan_rhd_test_1.rhd",  # Format header attach
+        "intan/intan_fpc_test_231117_052630/info.rhd",  # Format one-file-per-channel
+        "intan/intan_fps_test_231117_052500/info.rhd",  # Format one file per signal
+        "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
+        "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
+        "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel
+        "intan/rhd_fps_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-signal
     ]
 
 

--- a/neo/test/iotest/test_intanio.py
+++ b/neo/test/iotest/test_intanio.py
@@ -22,7 +22,7 @@ class TestIntanIO(
         "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
         "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
         "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel
-        "intan/rhd_fps_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-signal
+        "intan/rhs_fpc_multistim_240514_082243/info.rhs",  # Multiple digital channels one-file-per-channel rhs
     ]
 
 

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -19,7 +19,7 @@ class TestIntanRawIO(
         # "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
         # "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
         "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel
-        "intan/rhd_fps_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-signal
+        "intan/rhs_fpc_multistim_240514_082243/info.rhs",  # Multiple digital channels one-file-per-channel rhs
     ]
 
 

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -12,14 +12,14 @@ class TestIntanRawIO(
     rawioclass = IntanRawIO
     entities_to_download = ["intan"]
     entities_to_test = [
-        "intan/intan_rhs_test_1.rhs",
-        "intan/intan_rhd_test_1.rhd",
-        "intan/intan_fpc_test_231117_052630/info.rhd",
-        "intan/intan_fps_test_231117_052500/info.rhd",
-        "intan/intan_fpc_rhs_test_240329_091637/info.rhs",
-        "intan/intan_fps_rhs_test_240329_091536/info.rhs",
-        # "intan/rhd_fpc_multistim_240514_082044/info.rhd",
-        # "intan/rhd_fps_multistim_240514_082044/info.rhd",
+        "intan/intan_rhs_test_1.rhs",  # Format header-attached 
+        "intan/intan_rhd_test_1.rhd",  # Format header attach
+        "intan/intan_fpc_test_231117_052630/info.rhd",  # Format one-file-per-channel
+        "intan/intan_fps_test_231117_052500/info.rhd",  # Format one file per signal
+        "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
+        "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
+        # "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel
+        # "intan/rhd_fps_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-signal
     ]
 
 

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -12,15 +12,16 @@ class TestIntanRawIO(
     rawioclass = IntanRawIO
     entities_to_download = ["intan"]
     entities_to_test = [
-        # "intan/intan_rhs_test_1.rhs",  # Format header-attached 
-        # "intan/intan_rhd_test_1.rhd",  # Format header attach
-        # "intan/intan_fpc_test_231117_052630/info.rhd",  # Format one-file-per-channel
-        # "intan/intan_fps_test_231117_052500/info.rhd",  # Format one file per signal
-        # "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
-        # "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
-        "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel
-        "intan/rhs_fpc_multistim_240514_082243/info.rhs",  # Multiple digital channels one-file-per-channel rhs
+        "intan/intan_rhs_test_1.rhs",  # Format header-attached 
+        "intan/intan_rhd_test_1.rhd",  # Format header attach
+        "intan/intan_fpc_test_231117_052630/info.rhd",  # Format one-file-per-channel
+        "intan/intan_fps_test_231117_052500/info.rhd",  # Format one file per signal
+        "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
+        "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
+        "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel rhd
+        # "intan/rhs_fpc_multistim_240514_082243/rhs_fpc_multistim_240514_082243.rhs",  # Multiple digital channels one-file-per-channel rhs
     ]
+
 
 
 if __name__ == "__main__":

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -13,13 +13,13 @@ class TestIntanRawIO(
     entities_to_download = ["intan"]
     entities_to_test = [
         "intan/intan_rhs_test_1.rhs",  # Format header-attached 
-        "intan/intan_rhd_test_1.rhd",  # Format header attach
+        "intan/intan_rhd_test_1.rhd",  # Format header-attached
+        "intan/rhs_fpc_multistim_240514_082243/rhs_fpc_multistim_240514_082243.rhs",  # Format header-attached newer version
         "intan/intan_fpc_test_231117_052630/info.rhd",  # Format one-file-per-channel
         "intan/intan_fps_test_231117_052500/info.rhd",  # Format one file per signal
         "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
         "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
         "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel rhd
-        # "intan/rhs_fpc_multistim_240514_082243/rhs_fpc_multistim_240514_082243.rhs",  # Multiple digital channels one-file-per-channel rhs
     ]
 
 

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -12,12 +12,12 @@ class TestIntanRawIO(
     rawioclass = IntanRawIO
     entities_to_download = ["intan"]
     entities_to_test = [
-        "intan/intan_rhs_test_1.rhs",  # Format header-attached 
-        "intan/intan_rhd_test_1.rhd",  # Format header attach
-        "intan/intan_fpc_test_231117_052630/info.rhd",  # Format one-file-per-channel
-        "intan/intan_fps_test_231117_052500/info.rhd",  # Format one file per signal
-        "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
-        "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
+        # "intan/intan_rhs_test_1.rhs",  # Format header-attached 
+        # "intan/intan_rhd_test_1.rhd",  # Format header attach
+        # "intan/intan_fpc_test_231117_052630/info.rhd",  # Format one-file-per-channel
+        # "intan/intan_fps_test_231117_052500/info.rhd",  # Format one file per signal
+        # "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
+        # "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
         "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel
         "intan/rhd_fps_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-signal
     ]

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -18,8 +18,8 @@ class TestIntanRawIO(
         "intan/intan_fps_test_231117_052500/info.rhd",  # Format one file per signal
         "intan/intan_fpc_rhs_test_240329_091637/info.rhs",  # Format one-file-per-channel
         "intan/intan_fps_rhs_test_240329_091536/info.rhs",   # Format one-file-per-signal
-        # "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel
-        # "intan/rhd_fps_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-signal
+        "intan/rhd_fpc_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-channel
+        "intan/rhd_fps_multistim_240514_082044/info.rhd",  # Multiple digital channels one-file-per-signal
     ]
 
 

--- a/neo/test/rawiotest/test_intanrawio.py
+++ b/neo/test/rawiotest/test_intanrawio.py
@@ -18,6 +18,8 @@ class TestIntanRawIO(
         "intan/intan_fps_test_231117_052500/info.rhd",
         "intan/intan_fpc_rhs_test_240329_091637/info.rhs",
         "intan/intan_fps_rhs_test_240329_091536/info.rhs",
+        # "intan/rhd_fpc_multistim_240514_082044/info.rhd",
+        # "intan/rhd_fps_multistim_240514_082044/info.rhd",
     ]
 
 


### PR DESCRIPTION
For the `header-attached` and the `one-file-per-signal` the digital channels are interleaved  and need a bitwise operators to separate the channels but this is not the case for the `one-file-per-channel` where each digital channel is separated and is already uint16 with 0 and 1s.

This PR patches this behavior so the digital channels can be correctly retrieved for the case of the `one-file-per-channel`.  Unfortunatlely, we don't have a multiple digital channels in the test examples on git to test for this behavior. Any idea on how to test for this @zm711 ?

I tested this for data that I have and it works.