### PR TITLE
Add support for Neuralynx NVT files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,4 @@ doc/*.nwb
 *.smr
 B95.zip
 grouped_ephys
-test.py
+nvt_test.py

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ doc/*.nwb
 *.smr
 B95.zip
 grouped_ephys
+test.py

--- a/neo/io/neuralynxio.py
+++ b/neo/io/neuralynxio.py
@@ -16,12 +16,13 @@ from neo.rawio.neuralynxrawio.neuralynxrawio import NeuralynxRawIO
 class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
     """
     Class for reading data from Neuralynx files.
-    This IO supports NCS, NEV, NSE and NTT file formats.
+    This IO supports NCS, NEV, NSE, NTT and NVT file formats.
 
     NCS contains signals for one channel
     NEV contains events
     NSE contains spikes and waveforms for mono electrodes
     NTT contains spikes and waveforms for tetrodes
+    NVT contains coordinates and head angles for video tracking
     """
 
     _prefered_signal_group_mode = "group-by-same-units"
@@ -35,6 +36,7 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
         cache_path="same_as_resource",
         exclude_filename=None,
         keep_original_times=False,
+        ignore_nvt=False,
     ):
         """
         Initialise IO instance
@@ -59,6 +61,11 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
             Preserve original time stamps as in data files. By default datasets are
             shifted to begin at t_start = 0*pq.second.
             Default: False
+        ignore_nvt : bool
+            Ignore NVT files when loading data. This is only a temporary argument before
+            support for multiple NVT files are added. Turn it on if there are multiple NVT 
+            files in the directory.
+            Default: False
         """
         NeuralynxRawIO.__init__(
             self,
@@ -68,6 +75,7 @@ class NeuralynxIO(NeuralynxRawIO, BaseFromRaw):
             cache_path=cache_path,
             exclude_filename=exclude_filename,
             keep_original_times=keep_original_times,
+            ignore_nvt=ignore_nvt,
         )
         if self.rawmode == "one-file":
             BaseFromRaw.__init__(self, filename)

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -87,8 +87,8 @@ class NeuralynxRawIO(BaseRawIO):
         Otherwise set 0 of time to first time in dataset
     strict_gap_mode: bool, default: True
         Detect gaps using strict mode or not.
-          * strict_gap_mode = True then a gap is consider when timstamp difference between two
-            consequtive data packet is more than one sample interval.
+          * strict_gap_mode = True then a gap is consider when timestamp difference between two
+            consecutive data packet is more than one sample interval.
           * strict_gap_mode = False then a gap has an increased tolerance. Some new system with different clock need this option
             otherwise, too many gaps are detected
 

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -66,6 +66,21 @@ class NlxHeader(OrderedDict):
         ("AcquisitionSystem", "", None),
         ("ReferenceChannel", "", None),
         ("NLX_Base_Class_Type", "", None),  # in version 4 and earlier versions of Cheetah
+        ("VideoFormat", "", None),
+        ("IntensityThreshold", "", None),
+        ("RedThreshold", "", None),
+        ("GreenThreshold", "", None),
+        ("BlueThreshold", "", None),
+        ("Saturation", "", int),
+        ("Hue", "", int),
+        ("Brightness", "", int),
+        ("Contrast", "", int),
+        ("Sharpness", "", int),
+        ("DirectionOffset", "", int),
+        ("Resolution", "", None),
+        ("CameraDelay", "", int),
+        ("EnableFieldEstimation", "field_estimation_enabled", _to_bool),
+        ("TargetDist", "", None),
     ]
 
     # Filename and datetime may appear in header lines starting with # at
@@ -170,16 +185,17 @@ class NlxHeader(OrderedDict):
         :param filename: name of ncs file, used for extracting channel number
         :param txt_header: header text
         """
+        print(txt_header)
         # find keys
         for k1, k2, type_ in NlxHeader.txt_header_keys:
-            pattern = r"-(?P<name>" + k1 + r")\s+(?P<value>[\S ]*)"
+            pattern = r"-(?P<name>" + k1 + r")\s+(?P<value>.+)"
             matches = re.findall(pattern, txt_header)
             for match in matches:
                 if k2 == "":
                     name = match[0]
                 else:
                     name = k2
-                value = match[1].rstrip(" ")
+                value = match[1].replace("\t", " ").replace("\r", "").rstrip(" ")
                 if type_ is not None:
                     value = type_(value)
                 self[name] = value
@@ -243,6 +259,36 @@ class NlxHeader(OrderedDict):
             assert len(self["InputRange"]) == len(
                 chid_entries
             ), "Number of channel ids does not match input range values."
+        if "Resolution" in self:
+            ir_entries = re.findall(r"\w+", self["Resolution"])
+            if len(ir_entries) == 1:
+                self["Resolution"] = [int(ir_entries[0])] * len(chid_entries)
+            else:
+                self["Resolution"] = [int(e) for e in ir_entries]
+        if "IntensityThreshold" in self:
+            ir_entries = re.findall(r"\w+", self["IntensityThreshold"])
+            if len(ir_entries) == 1:
+                self["IntensityThreshold"] = [int(ir_entries[0])] * len(chid_entries)
+            else:
+                self["IntensityThreshold"] = [int(e) for e in ir_entries]
+        if "RedThreshold" in self:
+            ir_entries = re.findall(r"\w+", self["RedThreshold"])
+            if len(ir_entries) == 1:
+                self["RedThreshold"] = [int(ir_entries[0])] * len(chid_entries)
+            else:
+                self["RedThreshold"] = [int(e) for e in ir_entries]
+        if "GreenThreshold" in self:
+            ir_entries = re.findall(r"\w+", self["GreenThreshold"])
+            if len(ir_entries) == 1:
+                self["GreenThreshold"] = [int(ir_entries[0])] * len(chid_entries)
+            else:
+                self["GreenThreshold"] = [int(e) for e in ir_entries]
+        if "BlueThreshold" in self:
+            ir_entries = re.findall(r"\w+", self["BlueThreshold"])
+            if len(ir_entries) == 1:
+                self["BlueThreshold"] = [int(ir_entries[0])] * len(chid_entries)
+            else:
+                self["BlueThreshold"] = [int(e) for e in ir_entries]
 
     def readTimeDate(self, txt_header):
         """

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -78,8 +78,8 @@ class NlxHeader(OrderedDict):
         ("Sharpness", "", int),
         ("DirectionOffset", "", int),
         ("Resolution", "", None),
-        ("CameraDelay", "", int),
-        ("EnableFieldEstimation", "field_estimation_enabled", _to_bool),
+        ("CameraDelay", "", float),
+        ("EnableFieldEstimation", "", _to_bool),
         ("TargetDist", "", None),
     ]
 

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -185,7 +185,6 @@ class NlxHeader(OrderedDict):
         :param filename: name of ncs file, used for extracting channel number
         :param txt_header: header text
         """
-        print(txt_header)
         # find keys
         for k1, k2, type_ in NlxHeader.txt_header_keys:
             pattern = r"-(?P<name>" + k1 + r")\s+(?P<value>.+)"


### PR DESCRIPTION
## Type of Change
- New feature

## Description
Added partial support for Neuralynx NVT files. for `NeuralynxIO` and `NeuralynxRawIO`, the x and y pixel coordinates and animal head angle from the nvt file are treated as dimensionless analog signals bundled into a signal stream separate from the NCS stream. `NlxHeader` can now read NVT files as well. For detailed output please refer to the Testing section below.

## Limitations
- Only supports loading a single NVT file (or a directory with a single NVT file in it) at a time.
- Only loads the dnextracted_x, dnextracted_y and dnextracted_angle data fields from NVT files. Other fields that could be potentially useful (dwPoints and dntargets) are not yet supported.
- The NVT is assumed to be in the same segment (sharing a common clock (time basis)) as the NCS files in the same directory.

As a temporary solution to the potential problems these limitations might cause, I added an optional `ignore_nvt` argument to the `NeuralynxIO` and `NeuralynxRawIO` classes. When enabled, `NeuralynxIO` and `NeuralynxRawIO` will behave like how they were before my changes. `NlxHeader` works fine without any problems during testing.

## Testing

Code was tested in accordance with the [official contribution guideline](https://neo.readthedocs.io/en/latest/contributing.html). Additionally, it was tested on my own lab's data. Listed below are some examples.

```
reader = NeuralynxIO(dir)
print(reader)
```

```
nb_block: 1
nb_segment:  [1]
signal_streams: [Stream (rate,#packet,t0): (1600.0, 7537, 16166107179) (chans: 13), Stream (rate,#frame,t0): (29.97, 72286, 16165954061) (chans: 3)]
signal_channels: [CSC2_2, CSC3_2, CSC4_2, CSC5_2 ... CSC1_2 , VT1 , VT1 , VT1]
spike_channels: [chTT1_1#0#0, chTT1_1#1#0, chTT1_1#2#0, chTT1_1#3#0 ... chTT4_1#15#8 , chTT4_1#15#9 , chTT4_1#15#10 , chTT4_1#15#13]
event_channels: [Events event_id=4 ttl=0]
```

Each of the `VT1` signal channel represents a data field (x, y pixel position and head angle).

```
print(reader.read_block().segments[0].analogsignals[1])
```

```
[[428. 349.  45.]
 [431. 345.  28.]
 [428. 349.  46.]
 ...
 [436. 334.  87.]
 [435. 334.  88.]
 [436. 334.  87.]] dimensionless
```

First column is x posiiton, second y position and thrid head angle in degrees.

```
print(reader.read_block().segments[0].analogsignals[0].array_annotations["Resolution"][0])
```

```
[720 480]
```

Video resolution from the NVT file header is passed into `array_annotations` for easy access. However because list type in `array_annotations` is buggy, it is passed as a literal string (`'[720 480]'`) and not a list. Though once it is accessed it can be easily converted into a list using `ast.literal_eval()` in the `ast` package.

## Additional Information
I should be able to make semi-regular contributions to this project. I don't have a good solution in mind to include the dwPoints and dntargets data fields as of now, but I should be able to fix the problem with loading multiple NVT files and implement proper segment assignment in the near future.

I opened this pull request dispite the above mentioned limitations because I think in most cases (at least in my lab and other labs I know of) there are only one NVT file in a given directory, and the files often share the same time basis (since they are likely from the same experiment session). So this current version should be helpful enough in most scenarios. With the `ignore_nvt` argument, users will also be able to revert back the code's behavior. So even if the new code causes problems, they could be easily avoided.