### PR TITLE
Improve intan reader error message for discontinuities

### DIFF
--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -106,7 +106,7 @@ class IntanRawIO(BaseRawIO):
         BaseRawIO.__init__(self)
         self.filename = filename
         self.ignore_integrity_checks = ignore_integrity_checks
-        self.discontinuous_timestamps = False   
+        self.discontinuous_timestamps = False
 
     def _source_name(self):
         return self.filename

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -196,7 +196,7 @@ class IntanRawIO(BaseRawIO):
                     self._raw_data[stream_index].append(channel_memmap)
 
         # Data Integrity checks
-        self.asert_timestamp_continuity()
+        self._assert_timestamp_continuity()
         
         # signals
         signal_channels = []
@@ -445,7 +445,7 @@ class IntanRawIO(BaseRawIO):
 
         return signal_data_memmap[i_start:i_stop, channel_indexes]
     
-    def assert_timestamp_continuity(self):
+    def _assert_timestamp_continuity(self):
         """
         Asserts the continuity of timestamps in the data.
 

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -233,7 +233,7 @@ class IntanRawIO(BaseRawIO):
 
                 error_msg += "+-----------------+-----------------+-----------------+-----------------------+\n"
 
-        raise NeoReadWriteError(error_msg)
+            raise NeoReadWriteError(error_msg)
         # signals
         signal_channels = []
         for c, chan_info in enumerate(self._ordered_channel_info):

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -233,7 +233,8 @@ class IntanRawIO(BaseRawIO):
 
                 error_msg += "+-----------------+-----------------+-----------------+-----------------------+\n"
 
-            raise NeoReadWriteError(error_msg)
+                raise NeoReadWriteError(error_msg)
+        
         # signals
         signal_channels = []
         for c, chan_info in enumerate(self._ordered_channel_info):

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -487,7 +487,7 @@ class IntanRawIO(BaseRawIO):
             self.discontinuous_timestamps = True
             if not self.ignore_integrity_checks:
                 error_msg = (
-                    "\n Timestamps are not continuous, likely due to a corrupted file or inappropriate file merge.\n"
+                    "\nTimestamps are not continuous, likely due to a corrupted file or inappropriate file merge.\n"
                     "To open the file anyway, initialize the reader with `ignore_integrity_checks=True`.\n\n"
                     "Discontinuities Found:\n"
                     "+-----------------+-----------------+-----------------+-----------------------+\n"  


### PR DESCRIPTION
I made a rookie mistake in a previous PR for this line:

```python
discontinuous_timestamps = np.diff(timestamp) != 1
timestamp[discontinuous_timestamps]
```

Because diff reduces size by 1 and then the above throws an error (within the other error).

This PR solves this and improves the format in which the discontinuities are presented for the benefit of the user.

This is how things look like for a dataset with one discontinuity that I am working on.

```python
  File "/home/heberto/development/spikeinterface/src/spikeinterface/extractors/neoextractors/neobaseextractor.py", line 27, in __init__
    self.neo_reader = self.get_neo_io_reader(self.NeoRawIOClass, **neo_kwargs)
  File "/home/heberto/development/spikeinterface/src/spikeinterface/extractors/neoextractors/neobaseextractor.py", line 66, in get_neo_io_reader
    neo_reader.parse_header()
  File "/home/heberto/development/python-neo/neo/rawio/baserawio.py", line 189, in parse_header
    self._parse_header()
  File "/home/heberto/development/python-neo/neo/rawio/intanrawio.py", line 236, in _parse_header
    raise NeoReadWriteError(error_msg)
neo.core.baseneo.NeoReadWriteError: Timestamps are not continuous, likely due to a corrupted file or inappropriate file merge.
To open the file anyway, initialize the reader with `ignore_integrity_checks=True`.

Discontinuities Found:
+-----------------+-----------------+-----------------+-----------------------+
| Discontinuity   | Previous        | Next            | Time Difference       |
| Index           | (Frames)        | (Frames)        | (Seconds)             |
+-----------------+-----------------+-----------------+-----------------------+
|      24,229,713 |      24,209,712 |      25,092,726 |             44.150700 |
+-----------------+-----------------+-----------------+-----------------------+
```

