### PR TITLE
Clean-up unused imports and standardized order

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -18,21 +18,13 @@ the old object.
 """
 
 import logging
-
-try:
-    import scipy.signal
-except ImportError as err:
-    HAVE_SCIPY = False
-else:
-    HAVE_SCIPY = True
+from copy import deepcopy
 
 import numpy as np
 import quantities as pq
 
 from neo.core.baseneo import BaseNeo, MergeError, merge_annotations, intersect_annotations
 from neo.core.dataobject import DataObject
-from copy import copy, deepcopy
-
 from neo.core.basesignal import BaseSignal
 
 logger = logging.getLogger("Neo")
@@ -612,8 +604,9 @@ class AnalogSignal(BaseSignal):
         -----
         For resampling the signal with a fixed number of samples, see `resample` method.
         """
-
-        if not HAVE_SCIPY:
+        try:
+            import scipy.signal
+        except ImportError as err:
             raise ImportError("Decimating requires availability of scipy.signal")
 
         # Resampling is only permitted along the time axis (axis=0)
@@ -655,8 +648,10 @@ class AnalogSignal(BaseSignal):
         For reducing the number of samples to a fraction of the original, see `downsample` method
         """
 
-        if not HAVE_SCIPY:
-            raise ImportError("Resampling requires availability of scipy.signal")
+        try:
+            import scipy.signal
+        except ImportError as err:
+            raise ImportError("Decimating requires availability of scipy.signal")
 
         # Resampling is only permitted along the time axis (axis=0)
         if "axis" in kwargs:

--- a/neo/core/basesignal.py
+++ b/neo/core/basesignal.py
@@ -14,7 +14,6 @@ Only child objects :class:`AnalogSignal` and :class:`IrregularlySampledSignal`
 can be created.
 """
 
-import copy
 import logging
 from copy import deepcopy
 
@@ -123,7 +122,7 @@ class BaseSignal(DataObject):
         new_signal._copy_data_complement(self)
         # _copy_data_complement can't always copy array annotations,
         # so this needs to be done locally
-        new_signal.array_annotations = copy.deepcopy(self.array_annotations)
+        new_signal.array_annotations = deepcopy(self.array_annotations)
         return new_signal
 
     def _get_required_attributes(self, signal, units):

--- a/neo/core/dataobject.py
+++ b/neo/core/dataobject.py
@@ -10,6 +10,7 @@ import warnings
 
 import quantities as pq
 import numpy as np
+
 from neo.core.baseneo import BaseNeo, _check_annotations
 
 

--- a/neo/core/epoch.py
+++ b/neo/core/epoch.py
@@ -5,7 +5,7 @@ This module defines :class:`Epoch`, an array of epochs.
 :module:`neo.core.baseneo`.
 """
 
-from copy import deepcopy, copy
+from copy import deepcopy
 from numbers import Number
 
 import numpy as np

--- a/neo/core/event.py
+++ b/neo/core/event.py
@@ -5,7 +5,7 @@ This module defines :class:`Event`, an array of events.
 :module:`neo.core.baseneo`.
 """
 
-from copy import deepcopy, copy
+from copy import deepcopy
 
 import numpy as np
 import quantities as pq

--- a/neo/core/group.py
+++ b/neo/core/group.py
@@ -6,7 +6,6 @@ It replaces and extends the grouping function of the former :class:`ChannelIndex
 and :class:`Unit`.
 """
 
-from os import close
 from neo.core.container import Container
 from neo.core.analogsignal import AnalogSignal
 from neo.core.container import Container

--- a/neo/core/imagesequence.py
+++ b/neo/core/imagesequence.py
@@ -17,9 +17,11 @@ created by slicing. This is where attributes are copied over from
 the old object.
 """
 
-from neo.core.analogsignal import AnalogSignal, _get_sampling_rate
+
 import quantities as pq
 import numpy as np
+
+from neo.core.analogsignal import AnalogSignal, _get_sampling_rate
 from neo.core.baseneo import BaseNeo
 from neo.core.basesignal import BaseSignal
 from neo.core.dataobject import DataObject

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -19,14 +19,8 @@ created by slicing. This is where attributes are copied over from
 the old object.
 """
 
-from copy import deepcopy, copy
+from copy import deepcopy
 
-try:
-    import scipy.signal
-except ImportError as err:
-    HAVE_SCIPY = False
-else:
-    HAVE_SCIPY = True
 
 import numpy as np
 import quantities as pq
@@ -457,7 +451,9 @@ class IrregularlySampledSignal(BaseSignal):
             The original :class:`AnalogSignal` is not modified.
         """
 
-        if not HAVE_SCIPY:
+        try:
+            import scipy.signal
+        except ImportError:
             raise ImportError("Resampling requires availability of scipy.signal")
 
         # Resampling is only permitted along the time axis (axis=0)

--- a/neo/core/objectlist.py
+++ b/neo/core/objectlist.py
@@ -4,6 +4,7 @@ and handle relationships within the Neo Block-Segment-Data hierarchy.
 """
 
 import sys
+
 from neo.core.baseneo import BaseNeo
 
 

--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -9,8 +9,6 @@ from :module:`neo.core.container`.
 from datetime import datetime
 from copy import deepcopy
 
-import numpy as np
-
 
 from neo.core.analogsignal import AnalogSignal
 from neo.core.container import Container

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -25,7 +25,7 @@ import quantities as pq
 from neo.core.baseneo import BaseNeo, MergeError, merge_annotations
 from neo.core.dataobject import DataObject, ArrayDict
 # need this to avoid circular import issue
-import neo.io
+import neo
 
 
 def check_has_dimensions_time(*values) -> None:
@@ -818,7 +818,7 @@ class SpikeTrain(DataObject):
         compatible, an Exception is raised.
         """
         for other in others:
-            if isinstance(other, neo.io.SpikeTrainProxy):
+            if isinstance(other, neo.io.proxyobjects.SpikeTrainProxy):
                 raise MergeError(
                     "Cannot merge, SpikeTrainProxy objects cannot be merged"
                     "into regular SpikeTrain objects, please load them first."

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -17,16 +17,14 @@ created by slicing. This is where attributes are copied over from
 the old object.
 """
 
-import neo
-import sys
-
-from copy import deepcopy, copy
+from copy import deepcopy
 import warnings
 
 import numpy as np
 import quantities as pq
 from neo.core.baseneo import BaseNeo, MergeError, merge_annotations
 from neo.core.dataobject import DataObject, ArrayDict
+from neo.io.proxyobjects import SpikeTrainProxy
 
 
 def check_has_dimensions_time(*values) -> None:
@@ -819,7 +817,7 @@ class SpikeTrain(DataObject):
         compatible, an Exception is raised.
         """
         for other in others:
-            if isinstance(other, neo.io.proxyobjects.SpikeTrainProxy):
+            if isinstance(other, SpikeTrainProxy):
                 raise MergeError(
                     "Cannot merge, SpikeTrainProxy objects cannot be merged"
                     "into regular SpikeTrain objects, please load them first."

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -24,7 +24,8 @@ import numpy as np
 import quantities as pq
 from neo.core.baseneo import BaseNeo, MergeError, merge_annotations
 from neo.core.dataobject import DataObject, ArrayDict
-from neo.io.proxyobjects import SpikeTrainProxy
+# need this to avoid circular import issue
+import neo.io
 
 
 def check_has_dimensions_time(*values) -> None:
@@ -817,7 +818,7 @@ class SpikeTrain(DataObject):
         compatible, an Exception is raised.
         """
         for other in others:
-            if isinstance(other, SpikeTrainProxy):
+            if isinstance(other, neo.io.SpikeTrainProxy):
                 raise MergeError(
                     "Cannot merge, SpikeTrainProxy objects cannot be merged"
                     "into regular SpikeTrain objects, please load them first."

--- a/neo/core/spiketrainlist.py
+++ b/neo/core/spiketrainlist.py
@@ -7,8 +7,10 @@ neuron/channel the spike is from).
 """
 
 import warnings
+
 import numpy as np
 import quantities as pq
+
 from .spiketrain import SpikeTrain, normalize_times_array
 from .objectlist import ObjectList
 

--- a/neo/core/view.py
+++ b/neo/core/view.py
@@ -6,6 +6,7 @@ It replaces the indexing function of the former :class:`ChannelIndex`.
 """
 
 import numpy as np
+
 from .baseneo import BaseNeo
 from .basesignal import BaseSignal
 from .dataobject import ArrayDict

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -281,7 +281,7 @@ from collections import Counter
 # if it is not present, use the neurosharectypesio to load files
 try:
     import neuroshare as ns
-except ImportError as err:
+except ModuleNotFoundError as err:
     from neo.io.neurosharectypesio import NeurosharectypesIO as NeuroshareIO
 
     # print("\n neuroshare library not found, loading data with ctypes" )

--- a/neo/io/asciiimageio.py
+++ b/neo/io/asciiimageio.py
@@ -1,6 +1,7 @@
+import numpy as np
+
 from .baseio import BaseIO
 from neo.core import ImageSequence, Segment, Block
-import numpy as np
 
 
 class AsciiImageIO(BaseIO):

--- a/neo/io/axonio.py
+++ b/neo/io/axonio.py
@@ -1,8 +1,9 @@
+import quantities as pq
+
 from neo.io.basefromrawio import BaseFromRaw
 from neo.rawio.axonrawio import AxonRawIO
+from neo.core import Segment, AnalogSignal
 
-from neo.core import Block, Segment, AnalogSignal, Event
-import quantities as pq
 
 
 class AxonIO(AxonRawIO, BaseFromRaw):

--- a/neo/io/blkio.py
+++ b/neo/io/blkio.py
@@ -1,10 +1,14 @@
-from .baseio import BaseIO
-from neo.core import ImageSequence, Segment, Block
-import numpy as np
 import struct
 import os
 import math
-import quantities as pq
+
+import numpy as np
+
+from .baseio import BaseIO
+from neo.core import ImageSequence, Segment, Block
+
+
+
 
 
 class BlkIO(BaseIO):

--- a/neo/io/brainwaredamio.py
+++ b/neo/io/brainwaredamio.py
@@ -35,7 +35,6 @@ import quantities as pq
 
 # needed core neo modules
 from neo.core import AnalogSignal, Block, Group, Segment
-
 # need to subclass BaseIO
 from neo.io.baseio import BaseIO
 

--- a/neo/io/brainwaref32io.py
+++ b/neo/io/brainwaref32io.py
@@ -33,7 +33,6 @@ import quantities as pq
 
 # needed core neo modules
 from neo.core import Block, Group, Segment, SpikeTrain, NeoReadWriteError
-
 # need to subclass BaseIO
 from neo.io.baseio import BaseIO
 

--- a/neo/io/brainwaresrcio.py
+++ b/neo/io/brainwaresrcio.py
@@ -47,7 +47,6 @@ import quantities as pq
 
 # needed core neo modules
 from neo.core import Block, Event, Group, Segment, SpikeTrain
-
 # need to subclass BaseIO
 from neo.io.baseio import BaseIO
 

--- a/neo/io/elphyio.py
+++ b/neo/io/elphyio.py
@@ -85,7 +85,6 @@ import quantities as pq
 
 # I need to subclass BaseIO
 from neo.io.baseio import BaseIO
-
 # to import from core
 from neo.core import Block, Segment, AnalogSignal, Event, SpikeTrain, NeoReadWriteError
 

--- a/neo/io/igorproio.py
+++ b/neo/io/igorproio.py
@@ -13,7 +13,9 @@ Also contributing: Rick Gerkin
 
 from warnings import warn
 import pathlib
+
 import quantities as pq
+
 from neo.io.baseio import BaseIO
 from neo.core import Block, Segment, AnalogSignal, NeoReadWriteError
 

--- a/neo/io/klustakwikio.py
+++ b/neo/io/klustakwikio.py
@@ -14,7 +14,6 @@ weren't set. Consider removing those annotations if they are redundant.
 """
 
 import re
-import glob
 import logging
 from pathlib import Path
 import shutil
@@ -22,10 +21,8 @@ import shutil
 # note neo.core need only numpy and quantities
 import numpy as np
 
-
 # I need to subclass BaseIO
 from neo.io.baseio import BaseIO
-
 from neo.core import Block, Segment, Group, SpikeTrain
 
 # Pasted version of feature file format spec

--- a/neo/io/kwikio.py
+++ b/neo/io/kwikio.py
@@ -16,13 +16,11 @@ import numpy as np
 import quantities as pq
 import os
 
-
 # I need to subclass BaseIO
 from neo.io.baseio import BaseIO
 
 # to import from core
-from neo.core import Segment, SpikeTrain, Epoch, AnalogSignal, Block, Group
-import neo.io.tools
+from neo.core import Segment, SpikeTrain, AnalogSignal, Block, Group
 
 
 class KwikIO(BaseIO):

--- a/neo/io/nestio.py
+++ b/neo/io/nestio.py
@@ -16,6 +16,7 @@ Authors: Julia Sprenger, Maximilian Schmidt, Johanna Senk
 import os.path
 import warnings
 from datetime import datetime
+
 import numpy as np
 import quantities as pq
 

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -27,7 +27,6 @@ import itertools
 from uuid import uuid4
 import warnings
 from packaging.version import Version
-from itertools import chain
 
 import quantities as pq
 import numpy as np
@@ -789,7 +788,7 @@ class NixIO(BaseIO):
 
         # link signals and image sequences
         objnames = []
-        for obj in chain(
+        for obj in itertools.chain(
             neo_group.analogsignals,
             neo_group.irregularlysampledsignals,
             neo_group.imagesequences,
@@ -805,7 +804,7 @@ class NixIO(BaseIO):
 
         # link events, epochs and spiketrains
         objnames = []
-        for obj in chain(
+        for obj in itertools.chain(
             neo_group.events,
             neo_group.epochs,
             neo_group.spiketrains,

--- a/neo/io/nwbio.py
+++ b/neo/io/nwbio.py
@@ -24,6 +24,7 @@ from json.decoder import JSONDecodeError
 
 import numpy as np
 import quantities as pq
+
 from neo.core import Segment, SpikeTrain, Epoch, Event, AnalogSignal, IrregularlySampledSignal, Block, ImageSequence
 from neo.io.baseio import BaseIO
 from neo.io.proxyobjects import (

--- a/neo/io/proxyobjects.py
+++ b/neo/io/proxyobjects.py
@@ -9,13 +9,13 @@ ineherits neo.rawio.
 
 """
 
-import numpy as np
-import quantities as pq
 import logging
 
+import numpy as np
+import quantities as pq
+
+
 from neo.core.baseneo import BaseNeo
-
-
 from neo.core import AnalogSignal, Epoch, Event, SpikeTrain
 from neo.core.dataobject import ArrayDict
 

--- a/neo/io/rawbinarysignalio.py
+++ b/neo/io/rawbinarysignalio.py
@@ -10,12 +10,8 @@ Author: sgarcia
 
 """
 
-import os
-
 import numpy as np
-import quantities as pq
 
-from neo.io.baseio import BaseIO
 from neo.core import Segment, AnalogSignal, NeoReadWriteError
 
 from neo.io.basefromrawio import BaseFromRaw

--- a/neo/io/tiffio.py
+++ b/neo/io/tiffio.py
@@ -2,13 +2,13 @@
 Neo IO module for optical imaging data stored as a folder of TIFF images.
 """
 
-import os
-
-import numpy as np
-from neo.core import ImageSequence, Segment, Block
-from .baseio import BaseIO
 import glob
 import re
+
+import numpy as np
+
+from neo.core import ImageSequence, Segment, Block
+from .baseio import BaseIO
 
 
 class TiffIO(BaseIO):

--- a/neo/io/tools.py
+++ b/neo/io/tools.py
@@ -4,12 +4,8 @@ Tools for IO coder:
     SPikeTrains
 """
 
-try:
-    from collections.abc import MutableSequence
-except ImportError:
-    from collections import MutableSequence
 
-import numpy as np
+from collections.abc import MutableSequence
 
 from neo.core import (
     AnalogSignal,

--- a/neo/rawio/alphaomegarawio.py
+++ b/neo/rawio/alphaomegarawio.py
@@ -23,14 +23,12 @@ Author: Thomas Perret <thomas.perret@isc.cnrs.fr>
 """
 
 import io
-import logging
 import mmap
-import os
 import struct
 
 from collections import defaultdict
 from datetime import datetime
-from itertools import chain
+
 from pathlib import Path, PureWindowsPath
 
 import numpy as np

--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -46,6 +46,12 @@ reads abf files - would be good to cross-check
 
 """
 
+import struct
+import datetime
+from io import open, BufferedReader
+
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -54,16 +60,6 @@ from .baserawio import (
     _event_channel_dtype,
 )
 from neo.core import NeoReadWriteError
-
-import numpy as np
-
-import struct
-import datetime
-import os
-from io import open, BufferedReader
-
-import numpy as np
-
 
 class AxonRawIO(BaseRawIO):
     """

--- a/neo/rawio/bci2000rawio.py
+++ b/neo/rawio/bci2000rawio.py
@@ -3,14 +3,6 @@ BCI2000RawIO is a class to read BCI2000 .dat files.
 https://www.bci2000.org/mediawiki/index.php/Technical_Reference:BCI2000_File_Format
 """
 
-from .baserawio import (
-    BaseRawIO,
-    _signal_channel_dtype,
-    _signal_stream_dtype,
-    _spike_channel_dtype,
-    _event_channel_dtype,
-)
-from neo.core import NeoReadWriteError
 
 import numpy as np
 import re
@@ -20,6 +12,14 @@ try:
 except ImportError:
     from urllib import url2pathname as unquote
 
+from .baserawio import (
+    BaseRawIO,
+    _signal_channel_dtype,
+    _signal_stream_dtype,
+    _spike_channel_dtype,
+    _event_channel_dtype,
+)
+from neo.core import NeoReadWriteError
 
 class BCI2000RawIO(BaseRawIO):
     """

--- a/neo/rawio/biocamrawio.py
+++ b/neo/rawio/biocamrawio.py
@@ -7,6 +7,10 @@ https://www.3brain.com/products/single-well/biocam-x
 Authors: Alessio Buccino, Robert Wolff
 """
 
+
+import json
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -14,9 +18,6 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-
-import numpy as np
-import json
 
 
 class BiocamRawIO(BaseRawIO):

--- a/neo/rawio/brainvisionrawio.py
+++ b/neo/rawio/brainvisionrawio.py
@@ -7,6 +7,11 @@ S. More.
 Author: Samuel Garcia
 """
 
+import os
+import re
+
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -16,13 +21,6 @@ from .baserawio import (
 )
 
 from neo.core import NeoReadWriteError
-
-import numpy as np
-
-import datetime
-import os
-import re
-
 
 class BrainVisionRawIO(BaseRawIO):
     """Class for reading BrainVision files

--- a/neo/rawio/cedrawio.py
+++ b/neo/rawio/cedrawio.py
@@ -20,6 +20,10 @@ Please note that the SONPY package:
 Author : Samuel Garcia
 """
 
+
+
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -27,10 +31,6 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-
-import numpy as np
-from copy import deepcopy
-
 
 class CedRawIO(BaseRawIO):
     """

--- a/neo/rawio/edfrawio.py
+++ b/neo/rawio/edfrawio.py
@@ -10,14 +10,6 @@ EDF Format Specifications: https://www.edfplus.info/
 Author: Julia Sprenger
 """
 
-from .baserawio import (
-    BaseRawIO,
-    _signal_channel_dtype,
-    _signal_stream_dtype,
-    _spike_channel_dtype,
-    _event_channel_dtype,
-)
-
 import numpy as np
 
 try:
@@ -27,6 +19,13 @@ try:
 except ImportError:
     HAS_PYEDF = False
 
+from .baserawio import (
+    BaseRawIO,
+    _signal_channel_dtype,
+    _signal_stream_dtype,
+    _spike_channel_dtype,
+    _event_channel_dtype,
+)
 
 class EDFRawIO(BaseRawIO):
     """

--- a/neo/rawio/elanrawio.py
+++ b/neo/rawio/elanrawio.py
@@ -16,6 +16,12 @@ Author: Samuel Garcia
 
 """
 
+import datetime
+import re
+import pathlib
+
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -25,13 +31,6 @@ from .baserawio import (
 )
 
 from neo.core import NeoReadWriteError
-
-import numpy as np
-
-import datetime
-import re
-import pathlib
-
 
 class ElanRawIO(BaseRawIO):
     """

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -24,6 +24,7 @@ from packaging.version import Version
 import warnings
 
 import numpy as np
+
 from neo.core import NeoReadWriteError
 
 from .baserawio import (

--- a/neo/rawio/maxwellrawio.py
+++ b/neo/rawio/maxwellrawio.py
@@ -23,6 +23,8 @@ from pathlib import Path
 import platform
 from urllib.request import urlopen
 
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -32,8 +34,6 @@ from .baserawio import (
 )
 
 from neo.core import NeoReadWriteError
-
-import numpy as np
 
 
 class MaxwellRawIO(BaseRawIO):

--- a/neo/rawio/mearecrawio.py
+++ b/neo/rawio/mearecrawio.py
@@ -9,6 +9,10 @@ https://link.springer.com/article/10.1007/s12021-020-09467-7
 Author : Alessio Buccino
 """
 
+from copy import deepcopy
+
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -16,10 +20,6 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-
-import numpy as np
-from copy import deepcopy
-
 
 class MEArecRawIO(BaseRawIO):
     """

--- a/neo/rawio/medrawio.py
+++ b/neo/rawio/medrawio.py
@@ -6,6 +6,10 @@ Uses the dhn-med-py python package, created by Dark Horse Neuro, Inc.
 Authors: Dan Crepeau, Matt Stead
 """
 
+
+
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -13,9 +17,6 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-
-import numpy as np
-
 
 class MedRawIO(BaseRawIO):
     """

--- a/neo/rawio/micromedrawio.py
+++ b/neo/rawio/micromedrawio.py
@@ -7,6 +7,12 @@ Completed with matlab Guillaume BECQ code.
 Author: Samuel Garcia
 """
 
+import datetime
+import struct
+import io
+
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -16,14 +22,6 @@ from .baserawio import (
 )
 
 from neo.core import NeoReadWriteError
-
-import numpy as np
-
-import datetime
-import os
-import struct
-import io
-
 
 class StructFile(io.BufferedReader):
     def read_f(self, fmt, offset=None):

--- a/neo/rawio/neuroexplorerrawio.py
+++ b/neo/rawio/neuroexplorerrawio.py
@@ -22,6 +22,9 @@ http://www.neuroexplorer.com/downloadspage/
 Author: Samuel Garcia, luc estebanez, mark hollenbeck
 
 """
+from collections import OrderedDict
+
+import numpy as np
 
 from .baserawio import (
     BaseRawIO,
@@ -32,10 +35,6 @@ from .baserawio import (
 )
 
 from neo.core import NeoReadWriteError
-
-import numpy as np
-from collections import OrderedDict
-import datetime
 
 
 class NeuroExplorerRawIO(BaseRawIO):

--- a/neo/rawio/neuroscoperawio.py
+++ b/neo/rawio/neuroscoperawio.py
@@ -18,6 +18,9 @@ Author: Samuel Garcia
 
 from pathlib import Path
 
+import numpy as np
+from xml.etree import ElementTree
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -25,9 +28,6 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-
-import numpy as np
-from xml.etree import ElementTree
 
 
 class NeuroScopeRawIO(BaseRawIO):

--- a/neo/rawio/nixrawio.py
+++ b/neo/rawio/nixrawio.py
@@ -7,7 +7,6 @@ It supports all kinds of NEO objects.
 Author: Chek Yin Choi, Julia Sprenger
 """
 
-import os.path
 
 import numpy as np
 

--- a/neo/rawio/openephysbinaryrawio.py
+++ b/neo/rawio/openephysbinaryrawio.py
@@ -10,9 +10,7 @@ Author: Julia Sprenger, Samuel Garcia, and Alessio Buccino
 """
 
 import os
-import re
 import json
-
 from pathlib import Path
 
 import numpy as np

--- a/neo/rawio/openephysrawio.py
+++ b/neo/rawio/openephysrawio.py
@@ -20,7 +20,6 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-
 from neo.core import NeoReadWriteError
 
 

--- a/neo/rawio/rawbinarysignalrawio.py
+++ b/neo/rawio/rawbinarysignalrawio.py
@@ -17,6 +17,10 @@ Important release note:
 Author: Samuel Garcia
 """
 
+import numpy as np
+
+import os
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -24,11 +28,6 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-
-import numpy as np
-
-import os
-import sys
 
 
 class RawBinarySignalRawIO(BaseRawIO):

--- a/neo/rawio/rawmcsrawio.py
+++ b/neo/rawio/rawmcsrawio.py
@@ -14,6 +14,8 @@ could be written instead of this ersatz.
 Author: Samuel Garcia
 """
 
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -21,12 +23,6 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-
-import numpy as np
-
-import os
-import sys
-
 
 class RawMCSRawIO(BaseRawIO):
     """

--- a/neo/rawio/spike2rawio.py
+++ b/neo/rawio/spike2rawio.py
@@ -17,6 +17,9 @@ This IO support old (<v6) and new files (>v7) of spike2
 Author: Samuel Garcia
 
 """
+from collections import OrderedDict
+
+import numpy as np
 
 from .baserawio import (
     BaseRawIO,
@@ -25,12 +28,7 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-
 from neo.core import NeoReadWriteError
-
-import numpy as np
-from collections import OrderedDict
-
 
 class Spike2RawIO(BaseRawIO):
     """

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -50,6 +50,12 @@ Author : Samuel Garcia
 Some functions are copied from Graham Findlay
 """
 
+from pathlib import Path
+import os
+import re
+
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -57,13 +63,6 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-
-from pathlib import Path
-import os
-import re
-
-import numpy as np
-
 
 class SpikeGLXRawIO(BaseRawIO):
     """

--- a/neo/rawio/tdtrawio.py
+++ b/neo/rawio/tdtrawio.py
@@ -25,6 +25,13 @@ Alternative package for loading the tdt format:
 https://pypi.org/project/tdt
 """
 
+import numpy as np
+import os
+import re
+import warnings
+from collections import OrderedDict
+from pathlib import Path
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -34,14 +41,6 @@ from .baserawio import (
 )
 
 from neo.core import NeoReadWriteError
-
-import numpy as np
-import os
-import re
-import warnings
-from collections import OrderedDict
-from pathlib import Path
-
 
 class TdtRawIO(BaseRawIO):
     extensions = ["tbk", "tdx", "tev", "tin", "tnt", "tsq", "sev", "txt"]

--- a/neo/rawio/winedrrawio.py
+++ b/neo/rawio/winedrrawio.py
@@ -9,6 +9,9 @@ Author: Samuel Garcia
 
 """
 
+
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -17,11 +20,6 @@ from .baserawio import (
     _event_channel_dtype,
     _common_sig_characteristics,
 )
-
-import numpy as np
-
-import os
-import sys
 
 
 class WinEdrRawIO(BaseRawIO):

--- a/neo/rawio/winwcprawio.py
+++ b/neo/rawio/winwcprawio.py
@@ -8,6 +8,10 @@ http://spider.science.strath.ac.uk/sipbs/software.htm
 Author: Samuel Garcia
 """
 
+import struct
+
+import numpy as np
+
 from .baserawio import (
     BaseRawIO,
     _signal_channel_dtype,
@@ -16,11 +20,6 @@ from .baserawio import (
     _event_channel_dtype,
     _common_sig_characteristics,
 )
-
-import numpy as np
-
-import struct
-
 
 class WinWcpRawIO(BaseRawIO):
     """


### PR DESCRIPTION
Inspired by @h-mayorquin and his cleaning up of imports on spikeinterface.

Also we use scipy for 3 functions total and the top import is really slowing down the import time. I moved the import to those functions since I don't know how often people actually use them.