### PR TITLE
Intan digital channel extraction for header attached and one file per signal format

### DIFF
--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -113,7 +113,8 @@ class IntanRawIO(BaseRawIO):
         return self.filename
 
     def _parse_header(self):
-
+        
+        self.filename  = Path(self.filename)
 
         # Input checks
         if not self.filename.is_file():

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -123,14 +123,14 @@ class IntanRawIO(BaseRawIO):
             raise ValueError(f"{self.filename} is not a valid Intan file. Expected .rhd or .rhs extension")
 
         # see comment below for RHD which explains the division between file types
-        if self.self.filename.suffix == ".rhs":
+        if self.filename.suffix == ".rhs":
             if self.filename.name == "info.rhs":
                 if any((self.filename.parent / file).exists() for file in one_file_per_signal_filenames_rhs):
                     self.file_format = "one-file-per-signal"
-                    raw_file_paths_dict = create_one_file_per_signal_dict_rhs(dirname=filename.parent)
+                    raw_file_paths_dict = create_one_file_per_signal_dict_rhs(dirname=self.filename.parent)
                 else:
                     self.file_format = "one-file-per-channel"
-                    raw_file_paths_dict = create_one_file_per_channel_dict_rhs(dirname=filename.parent)
+                    raw_file_paths_dict = create_one_file_per_channel_dict_rhs(dirname=self.filename.parent)
             else:
                 self.file_format = "header-attached"
 


### PR DESCRIPTION
@zm711 this is a follow-up of  https://github.com/NeuralEnsemble/python-neo/pull/1476 

This makes the extraction of the digital channels work like all the other data in neo (and therefore spikeinterface) so user does not need to do any post-processing. The post-processing was derived from the data sheet, the python [conversion script that intan provides for python](https://intantech.com/downloads.html?tabSelect=Software&yPos=68.57142639160156) and [the matlab version](https://github.com/dattalab/spike_finder/blob/master/read_Intan_RHD2000_file.m) of the same operation .

Let me know what you think.

@luiztauffer

I tested this on Nelson data like this (using this branch and from spikeinterface):

```python
from pathlib import Path

intan_data_folder = Path.home() / "Downloads" 
assert intan_data_folder.is_dir()

file_path = intan_data_folder / "pm231213a_240205_240205_152654.rhd"
assert file_path.is_file()


from spikeinterface.extractors import IntanRecordingExtractor

recording = IntanRecordingExtractor(file_path=file_path, stream_name="USB board digital input channel", all_annotations=True)
recording
```
<div style='border:1px solid #ddd; padding:10px;'><strong>IntanRecordingExtractor: 3 channels - 30.0kHz - 1 segments - 1,800,064 samples - 60.00s (1.00 minutes) - uint16 dtype - 10.30 MiB</strong></div><details style='margin-left: 10px;'>  <summary><strong>Channel IDs</strong></summary><ul>['DIGITAL-IN-12' 'DIGITAL-IN-13' 'DIGITAL-IN-14'] </details><details style='margin-left: 10px;'>  <summary><strong>Annotations</strong></summary><ul><li> <strong> is_filtered </strong>: False</li><li> <strong> name </strong>: USB board digital input channel</li><li> <strong> stream_id </strong>: 4</li><li> <strong> file_origin </strong>: /home/heberto/Downloads/pm231213a_240205_240205_152654.rhd</li><li> <strong> intan_version </strong>: 3.3</li><li> <strong> actual_upper_bandwidth </strong>: 7603.76513671875</li><li> <strong> desired_lower_bandwidth </strong>: 0.10000000149011612</li><li> <strong> note1 </strong>: </li><li> <strong> actual_impedance_test_frequency </strong>: 1000.0</li><li> <strong> notch_filter_mode </strong>: 0</li><li> <strong> num_temp_sensor_channels </strong>: 0</li><li> <strong> desired_upper_bandwidth </strong>: 7500.0</li><li> <strong> desired_impedance_test_frequency </strong>: 1000.0</li><li> <strong> note2 </strong>: </li><li> <strong> nb_signal_group </strong>: 7</li><li> <strong> actual_dsp_cutoff_frequency </strong>: 1.165827989578247</li><li> <strong> eval_board_mode </strong>: 0</li><li> <strong> note3 </strong>: </li><li> <strong> desired_dsp_cutoff_frequency </strong>: 1.0</li><li> <strong> actual_lower_bandwidth </strong>: 0.09452909976243973</li><li> <strong> notch_filter </strong>: False</li><li> <strong> dsp_enabled </strong>: 1</li></ul> </details><details style='margin-left: 10px;'><summary><strong>Channel Properties</strong></summary><ul><details><summary> <strong> gain_to_uV </strong> </summary>[1. 1. 1.]</details><details><summary> <strong> offset_to_uV </strong> </summary>[0. 0. 0.]</details><details><summary> <strong> channel_names </strong> </summary>['DIGITAL-IN-12' 'DIGITAL-IN-13' 'DIGITAL-IN-14']</details><details><summary> <strong> channel_ids </strong> </summary>['DIGITAL-IN-12' 'DIGITAL-IN-13' 'DIGITAL-IN-14']</details><details><summary> <strong> native_order </strong> </summary>[12 13 14]</details><details><summary> <strong> chip_channel_num </strong> </summary>[0 0 0]</details><details><summary> <strong> electrode_impedance_phase </strong> </summary>[0. 0. 0.]</details><details><summary> <strong> spike_scope_digital_trigger_channel </strong> </summary>[0 0 0]</details><details><summary> <strong> electrode_impedance_magnitude </strong> </summary>[0. 0. 0.]</details><details><summary> <strong> spike_scope_digital_edge_polarity </strong> </summary>[0 0 0]</details><details><summary> <strong> spike_scope_trigger_mode </strong> </summary>[1 1 1]</details><details><summary> <strong> board_stream_num </strong> </summary>[0 0 0]</details><details><summary> <strong> custom_order </strong> </summary>[12 13 14]</details><details><summary> <strong> spike_scope_voltage_thresh </strong> </summary>[0 0 0]</details></ul></details>

```
full_traces = recording.get_traces()
partial_traces = recording.get_traces(start_frame=0, end_frame=3_000, channel_ids=["DIGITAL-IN-12", "DIGITAL-IN-14" ])

np.allclose(full_traces[0:3_000, [0, 2]], partial_traces)
```

Can you check if the output makes sense in the light of the experiment you are converting? The signal looks correct but nothing like ecological validation.