### PR TITLE
Fix: fix typo in datetime regex

### DIFF
--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -120,7 +120,7 @@ class NlxHeader(OrderedDict):
             datetime2_regex=r"-TimeClosed (?P<date>\S+) (?P<time>\S+)",
             filename_regex=r'-OriginalFileName "?(?P<filename>\S+)"?',
             datetimeformat=r"%Y/%m/%d %H:%M:%S",
-            datetime2format=r"%Y/%m/%d %H:%M:%S.f",
+            datetime2format=r"%Y/%m/%d %H:%M:%S.%f",
         ),
         # Cheetah after v 5.6.4 and default for others such as Pegasus
         "def": dict(


### PR DESCRIPTION
Fixes #1492

There is a typo in the date time regex used for Neuralynx headers.

The issue was introduced in commit baba820

Issue: #1492 