### PR TITLE
Plexon2 support for apple 64 bits

### DIFF
--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -131,11 +131,11 @@ class Plexon2RawIO(BaseRawIO):
         # Open the file.
         self.pl2reader.pl2_open_file(self.filename)
 
-
-        # # Verify the file handle is valid.
-        # if self.pl2reader._file_handle.value == 0:
-        #     self.pl2reader._print_error()
-        #     raise Exception(f"Opening {self.filename} failed.")
+        if not (platform.system() == "Linux"):
+            # Verify the file handle is valid.
+            if self.pl2reader._file_handle.value == 0:
+                self.pl2reader._print_error()
+                raise Exception(f"Opening {self.filename} failed.")
 
     def _source_name(self):
         return self.filename

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -157,7 +157,6 @@ class Plexon2RawIO(BaseRawIO):
         Source = namedtuple("Source", "id name sampling_rate n_samples")
         for c in range(self.pl2reader.pl2_file_info.m_TotalNumberOfAnalogChannels):
             achannel_info = self.pl2reader.pl2_get_analog_channel_info(c)
-
             # only consider active channels
             if not achannel_info.m_ChannelEnabled:
                 continue
@@ -273,8 +272,10 @@ class Plexon2RawIO(BaseRawIO):
                     # python is 1..12 https://docs.python.org/3/library/datetime.html#datetime.datetime
                     # so month needs to be tm_mon+1; also tm_sec could cause problems in the case of leap
                     # seconds, but this is harder to defend against.
+                    year = tmo.tm_year  # This has base 1900 in the c++ struct specification so we need to add 1900
+                    year += 1900
                     dt = datetime(
-                        year=tmo.tm_year,
+                        year=year,
                         month=tmo.tm_mon + 1,
                         day=tmo.tm_mday,
                         hour=tmo.tm_hour,
@@ -328,7 +329,6 @@ class Plexon2RawIO(BaseRawIO):
                 "m_OneBasedChannelInTrode",
                 "m_Source",
                 "m_Channel",
-                "m_Name",
                 "m_MaximumNumberOfFragments",
             ]
 

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -132,10 +132,10 @@ class Plexon2RawIO(BaseRawIO):
         self.pl2reader.pl2_open_file(self.filename)
 
 
-        # Verify the file handle is valid.
-        if self.pl2reader._file_handle.value == 0:
-            self.pl2reader._print_error()
-            raise Exception(f"Opening {self.filename} failed.")
+        # # Verify the file handle is valid.
+        # if self.pl2reader._file_handle.value == 0:
+        #     self.pl2reader._print_error()
+        #     raise Exception(f"Opening {self.filename} failed.")
 
     def _source_name(self):
         return self.filename

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -107,7 +107,7 @@ class Plexon2RawIO(BaseRawIO):
         # download default PL2 dll once if not yet available
         if pl2_dll_file_path is None:
             architecture = platform.architecture()[0]
-            if architecture == "64bit" and platform.system() == "Windows":
+            if architecture == "64bit" and platform.system() in ["Windows", "Darwin"]: 
                 file_name = "PL2FileReader64.dll"
             else:  # Apparently wine uses the 32 bit version in linux
                 file_name = "PL2FileReader.dll"

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -120,7 +120,7 @@ class Plexon2RawIO(BaseRawIO):
                 dist = urlopen(url=url)
 
                 with open(pl2_dll_file_path, "wb") as f:
-                    print(f"Downloading plexon dll to {pl2_dll_file_path}")
+                    warnings.warn(f"dll file does not exist, downloading plexon dll to {pl2_dll_file_path}")
                     f.write(dist.read())
 
         # Instantiate wrapper for Windows DLL

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -128,7 +128,7 @@ class Plexon2RawIO(BaseRawIO):
 
         self.pl2reader = PyPL2FileReader(pl2_dll_file_path=pl2_dll_file_path)
 
-        reading_attempts = 3
+        reading_attempts = 10
         for attempt in range(reading_attempts):
             self.pl2reader.pl2_open_file(self.filename)
             

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -131,6 +131,12 @@ class Plexon2RawIO(BaseRawIO):
         # Open the file.
         self.pl2reader.pl2_open_file(self.filename)
 
+
+        # Verify the file handle is valid.
+        if self.pl2reader._file_handle.value == 0:
+            self.pl2reader._print_error()
+            raise Exception(f"Opening {self.filename} failed.")
+
     def _source_name(self):
         return self.filename
 

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -128,14 +128,19 @@ class Plexon2RawIO(BaseRawIO):
 
         self.pl2reader = PyPL2FileReader(pl2_dll_file_path=pl2_dll_file_path)
 
-        # Open the file.
-        self.pl2reader.pl2_open_file(self.filename)
-
-        if not (platform.system() == "Linux"):
+        reading_attempts = 3
+        for attempt in range(reading_attempts):
+            self.pl2reader.pl2_open_file(self.filename)
+            
             # Verify the file handle is valid.
-            if self.pl2reader._file_handle.value == 0:
-                self.pl2reader._print_error()
-                raise Exception(f"Opening {self.filename} failed.")
+            if self.pl2reader._file_handle.value != 0:
+                # File handle is valid, exit the loop early
+                break
+            else:
+                if attempt == reading_attempts - 1:
+                    self.pl2reader._print_error()
+                    raise IOError(f"Opening {self.filename} failed after {reading_attempts} attempts.")
+
 
     def _source_name(self):
         return self.filename

--- a/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
+++ b/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
@@ -635,7 +635,6 @@ class PyPL2FileReader:
         if not result:
             self._print_error()
             return None
-
         return pl2_spike_channel_info
 
     def pl2_get_spike_channel_info_by_source(self, source_id, one_based_channel_index_in_source):

--- a/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
+++ b/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
@@ -626,11 +626,12 @@ class PyPL2FileReader:
 
         
         pl2_spike_channel_info = PL2SpikeChannelInfo()
+        print("---------------------")
         print(type(channel_name) ,channel_name, )
         result = self.pl2_dll.PL2_GetSpikeChannelInfoByName(
             self._file_handle, channel_name, ctypes.byref(pl2_spike_channel_info)
         )
-
+        print("----------------------------------")
         if not result:
             self._print_error()
             return None

--- a/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
+++ b/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
@@ -624,8 +624,9 @@ class PyPL2FileReader:
             }
         ]
 
+        
         pl2_spike_channel_info = PL2SpikeChannelInfo()
-
+        print(type(channel_name) ,channel_name, )
         result = self.pl2_dll.PL2_GetSpikeChannelInfoByName(
             self._file_handle, channel_name, ctypes.byref(pl2_spike_channel_info)
         )

--- a/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
+++ b/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
@@ -25,7 +25,6 @@ else:
 
     from zugbruecke import CtypesSession
     if platform.system() == "Darwin":
-        # On MacOS, the default log level of zugbruecke is too high
         ctypes = CtypesSession(log_level=100, arch = 'win64')
     else:
         ctypes = CtypesSession(log_level=100)

--- a/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
+++ b/neo/rawio/plexon2rawio/pypl2/pypl2lib.py
@@ -24,8 +24,11 @@ else:
         raise ImportError("Wine is not installed. Please install wine to use the PL2FileReader.dll")
 
     from zugbruecke import CtypesSession
-
-    ctypes = CtypesSession(log_level=100)
+    if platform.system() == "Darwin":
+        # On MacOS, the default log level of zugbruecke is too high
+        ctypes = CtypesSession(log_level=100, arch = 'win64')
+    else:
+        ctypes = CtypesSession(log_level=100)
 
 
 class tm(ctypes.Structure):
@@ -610,7 +613,7 @@ class PyPL2FileReader:
 
         self.pl2_dll.PL2_GetSpikeChannelInfoByName.argtypes = (
             ctypes.c_int,
-            ctypes.c_char * len(channel_name),
+            ctypes.POINTER(ctypes.c_char),
             ctypes.POINTER(PL2SpikeChannelInfo),
         )
 
@@ -624,14 +627,11 @@ class PyPL2FileReader:
             }
         ]
 
-        
         pl2_spike_channel_info = PL2SpikeChannelInfo()
-        print("---------------------")
-        print(type(channel_name) ,channel_name, )
+
         result = self.pl2_dll.PL2_GetSpikeChannelInfoByName(
             self._file_handle, channel_name, ctypes.byref(pl2_spike_channel_info)
         )
-        print("----------------------------------")
         if not result:
             self._print_error()
             return None
@@ -745,7 +745,7 @@ class PyPL2FileReader:
 
         self.pl2_dll.PL2_GetSpikeChannelDataByName.argtypes = (
             ctypes.c_int,
-            ctypes.c_char,
+            ctypes.POINTER(ctypes.c_char),
             ctypes.POINTER(ctypes.c_ulonglong),
             ctypes.POINTER(ctypes.c_ulonglong),
             ctypes.POINTER(ctypes.c_ushort),


### PR DESCRIPTION
To support plexon on mac we might need to change the logic to download the corresponding ddl:

Neuroconv linked PR:
https://github.com/catalystneuro/neuroconv/issues/204

