### PR TITLE
RawBinarySignalIRawIO: add `dat` extension as possibility

### DIFF
--- a/neo/rawio/rawbinarysignalrawio.py
+++ b/neo/rawio/rawbinarysignalrawio.py
@@ -36,7 +36,7 @@ class RawBinarySignalRawIO(BaseRawIO):
     Parameters
     ----------
     filename: str, default: ''
-        The *.raw or *.bin binary file to load
+        The *.raw, *.bin, or *.dat binary file to load
     dtype: np.dtype, default: 'int16'
         The dtype that the data is stored with. Must be acceptable by the numpy.dtype constructor
     sampling_rate: float, default: 10000.0
@@ -51,7 +51,7 @@ class RawBinarySignalRawIO(BaseRawIO):
         The offset for the bytes
     """
 
-    extensions = ["raw", "bin"]
+    extensions = ["raw", "bin", "dat"]
     rawmode = "one-file"
 
     def __init__(


### PR DESCRIPTION
`.dat` is super common for raw binary files. If we want a raw binary reader at the neo level we should make sure it is included in possible extensions.