### PR TITLE
Added a sorted to the listdir of the files in neuralynx folder to avo…

### DIFF
--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -213,7 +213,7 @@ class NeuralynxRawIO(BaseRawIO):
         event_annotations = []
 
         if self.rawmode == "one-dir":
-            filenames = os.listdir(self.dirname)
+            filenames = sorted(os.listdir(self.dirname))
         else:
             filenames = self.include_filenames
 


### PR DESCRIPTION
This pull request is fixing an issue coming from this : https://github.com/NeuralEnsemble/python-neo/pull/1440

The issue was causing mixed channel ids : https://github.com/SpikeInterface/spikeinterface/issues/3248 when loading data into spikeinterface.

We need to keep the `sorted()` when doing an `os.listdir()` here because the list directory depends on the os. 
This avoids mixing the filenames when reading the headers. 

Thanks,
Anthony