### PR TITLE
Fix-ate plexon signal streams

### DIFF
--- a/neo/rawio/plexonrawio.py
+++ b/neo/rawio/plexonrawio.py
@@ -255,7 +255,7 @@ class PlexonRawIO(BaseRawIO):
                     0.5 * (2 ** global_header["BitsPerSpikeSample"]) * h["Gain"] * h["PreampGain"]
                 )
             offset = 0.0
-            s   tream_id = "0"
+            stream_id = "0"  # This is overwritten later
             sig_channels.append((name, str(chan_id), sampling_rate, sig_dtype, units, gain, offset, stream_id))
 
         sig_channels = np.array(sig_channels, dtype=_signal_channel_dtype)

--- a/neo/rawio/plexonrawio.py
+++ b/neo/rawio/plexonrawio.py
@@ -298,7 +298,7 @@ class PlexonRawIO(BaseRawIO):
             self._sig_sampling_rate = {}
 
             for stream_index, (channel_prefix, sr, length) in enumerate(buffer_stream_groups):
-                # The users of plexon can modify the channel names, is not common but in that case
+                # The users of plexon can modify the prefix of the channel names (e.g. `my_prefix` instead of `WB`). This is not common but in that case
                 # We assign the channel_prefix both as stream_name and stream_id
                 stream_name = channel_prefix_to_stream_name.get(channel_prefix, channel_prefix)
                 stream_id = channel_prefix_to_stream_id.get(channel_prefix, channel_prefix)

--- a/neo/rawio/plexonrawio.py
+++ b/neo/rawio/plexonrawio.py
@@ -275,7 +275,7 @@ class PlexonRawIO(BaseRawIO):
             channels_prefixes = np.asarray([re.match(pattern, name).group(0) for name in sig_channels["name"]])
             buffer_stream_groups = set(zip(channels_prefixes, sig_channels["sampling_rate"], all_sig_length))
 
-            # There are explanations of the streams bassed on channel names
+            # There are explanations of the streams based on channel names
             # provided by a Plexon Engineer, see here:
             # https://github.com/NeuralEnsemble/python-neo/pull/1495#issuecomment-2184256894
             channel_prefix_to_stream_name = {

--- a/neo/rawio/plexonrawio.py
+++ b/neo/rawio/plexonrawio.py
@@ -231,7 +231,10 @@ class PlexonRawIO(BaseRawIO):
         # signals channels
         sig_channels = []
         all_sig_length = []
-        chan_loop = trange(nb_sig_chan, desc="Parsing signal channels", leave=True, disable=not self.progress_bar)
+        if self.progress_bar:
+            chan_loop = trange(nb_sig_chan, desc="Parsing signal channels", leave=True)
+        else:
+            chan_loop = range(nb_sig_chan)
         for chan_index in chan_loop:
             h = slowChannelHeaders[chan_index]
             name = h["Name"].decode("utf8")
@@ -252,7 +255,7 @@ class PlexonRawIO(BaseRawIO):
                     0.5 * (2 ** global_header["BitsPerSpikeSample"]) * h["Gain"] * h["PreampGain"]
                 )
             offset = 0.0
-            stream_id = "0"
+            s   tream_id = "0"
             sig_channels.append((name, str(chan_id), sampling_rate, sig_dtype, units, gain, offset, stream_id))
 
         sig_channels = np.array(sig_channels, dtype=_signal_channel_dtype)

--- a/neo/rawio/plexonrawio.py
+++ b/neo/rawio/plexonrawio.py
@@ -298,8 +298,10 @@ class PlexonRawIO(BaseRawIO):
             self._sig_sampling_rate = {}
 
             for stream_index, (channel_prefix, sr, length) in enumerate(buffer_stream_groups):
+                # The users of plexon can modify the channel names, is not common but in that case
+                # We assign the channel_prefix both as stream_name and stream_id
                 stream_name = channel_prefix_to_stream_name.get(channel_prefix, channel_prefix)
-                stream_id = channel_prefix_to_stream_id[channel_prefix]
+                stream_id = channel_prefix_to_stream_id.get(channel_prefix, channel_prefix)
 
                 mask = (sig_channels["sampling_rate"] == sr) & (all_sig_length == length)
                 sig_channels["stream_id"][mask] = stream_id

--- a/neo/rawio/plexonrawio.py
+++ b/neo/rawio/plexonrawio.py
@@ -261,7 +261,7 @@ class PlexonRawIO(BaseRawIO):
             signal_streams = np.array([], dtype=_signal_stream_dtype)
 
         else:
-            # detect groups (aka streams)
+            # Detect streams
             all_sig_length = np.asarray(all_sig_length)
 
             # names are WBX, FPX, SPKCX, AI, etc
@@ -387,7 +387,7 @@ class PlexonRawIO(BaseRawIO):
         t_stop = float(self._last_timestamps) / self._global_ssampling_rate
         if hasattr(self, "_signal_length"):
             for stream_index in self._signal_length:
-                t_stop_sig = self._signal_length[stream_index] / self._sig_sampling_rate[stream_id]
+                t_stop_sig = self._signal_length[stream_index] / self._sig_sampling_rate[stream_index]
                 t_stop = max(t_stop, t_stop_sig)
         return t_stop
 

--- a/neo/rawio/plexonrawio.py
+++ b/neo/rawio/plexonrawio.py
@@ -263,7 +263,7 @@ class PlexonRawIO(BaseRawIO):
         else:
             # detect groups (aka streams)
             all_sig_length = np.asarray(all_sig_length)
-            
+
             # names are WBX, FPX, SPKCX, AI, etc
             channels_prefixes = np.asarray([x[:2] for x in sig_channels["name"]])
             buffer_stream_groups = set(zip(channels_prefixes, sig_channels["sampling_rate"], all_sig_length))
@@ -276,6 +276,7 @@ class PlexonRawIO(BaseRawIO):
                 "FP": "FPl-Low Pass Filtered ",
                 "SP": "SPKC-High Pass Filtered",
                 "AI": "AI-Auxiliary Input",
+                "V1": "V1",  # TODO determine, possible video
             }
 
             # Using a mapping to ensure consistent order of stream_index
@@ -284,17 +285,17 @@ class PlexonRawIO(BaseRawIO):
                 "FP": "1",
                 "SP": "2",
                 "AI": "3",
+                "V1": "4",
             }
-            
+
             signal_streams = []
             self._signal_length = {}
             self._sig_sampling_rate = {}
-            
-            
+
             for stream_index, (channel_prefix, sr, length) in enumerate(buffer_stream_groups):
                 stream_name = channel_prefix_to_stream_name[channel_prefix]
                 stream_id = channel_prefix_to_stream_id[channel_prefix]
-                
+
                 mask = (sig_channels["sampling_rate"] == sr) & (all_sig_length == length)
                 sig_channels["stream_id"][mask] = stream_id
 

--- a/neo/test/iotest/test_plexonio.py
+++ b/neo/test/iotest/test_plexonio.py
@@ -18,6 +18,7 @@ class TestPlexonIO(
         "plexon/File_plexon_1.plx",
         "plexon/File_plexon_2.plx",
         "plexon/File_plexon_3.plx",
+        "plexon/4chDemoPLX.plx"
     ]
 
 

--- a/neo/test/rawiotest/test_plexonrawio.py
+++ b/neo/test/rawiotest/test_plexonrawio.py
@@ -15,6 +15,7 @@ class TestPlexonRawIO(
         "plexon/File_plexon_1.plx",
         "plexon/File_plexon_2.plx",
         "plexon/File_plexon_3.plx",
+        "plexon/4chDemoPLX.plx"
     ]
 
 


### PR DESCRIPTION
This PR solves two things:
1) Should solve https://github.com/NeuralEnsemble/python-neo/issues/1523 by using consistent stream_ids defined by plexon channel prefixes that are stable  (see [here](https://github.com/NeuralEnsemble/python-neo/pull/1495#issuecomment-2184256894)
2) It adds human readable and meaningful stream names. Right now they are called "Signal + {stream_id}" and after this PR, they will be:

```python
            channel_prefix_to_stream_name = {
                "WB": "WB-Wideband",
                "FP": "FPl-Low Pass Filtered ",
                "SP": "SPKC-High Pass Filtered",
                "AI": "AI-Auxiliary Input",
            }

```

Not that this moves forward the poject in https://github.com/SpikeInterface/spikeinterface/issues/3197 that aims to have "logical streams" and relegate "buffer streams" to an internal implementation detail of the raw io API.
