### PR TITLE
Add test that all rawios accept `slice(None)`

### DIFF
--- a/neo/rawio/medrawio.py
+++ b/neo/rawio/medrawio.py
@@ -240,9 +240,18 @@ class MedRawIO(BaseRawIO):
             self.sess.set_channel_active(self._stream_info[stream_index]["raw_chans"])
             num_channels = len(self._stream_info[stream_index]["raw_chans"])
             self.sess.set_reference_channel(self._stream_info[stream_index]["raw_chans"][0])
+        
+        # in the case we have a slice or we give an ArrayLike we need to iterate through the channels
+        # in order to activate them.
         else:
-            if any(channel_indexes < 0):
-                raise IndexError(f"Can not index negative channels: {channel_indexes}")
+            if isinstance(channel_indexes, slice):
+                start = channel_indexes.start or 0
+                stop = channel_indexes.stop or len(self._stream_info[stream_index]["raw_chans"])
+                step = channel_indexes.step or 1
+                channel_indexes = [ch for ch in range(start, stop, step)]
+            else:
+                if any(channel_indexes < 0):
+                    raise IndexError(f"Can not index negative channels: {channel_indexes}")
             # Set all channels to be inactive, then selectively set some of them to be active
             self.sess.set_channel_inactive("all")
             for i, channel_idx in enumerate(channel_indexes):

--- a/neo/test/rawiotest/rawio_compliance.py
+++ b/neo/test/rawiotest/rawio_compliance.py
@@ -172,7 +172,7 @@ def read_analogsignals(reader):
         channel_names = signal_channels["name"][mask]
         channel_ids = signal_channels["id"][mask]
 
-        # acces by channel inde/ids/names should give the same chunk
+        # acces by channel index/ids/names should give the same chunk
         channel_indexes2 = channel_indexes[::2]
         channel_names2 = channel_names[::2]
         channel_ids2 = channel_ids[::2]
@@ -213,6 +213,29 @@ def read_analogsignals(reader):
                 channel_names=channel_names2,
             )
             np.testing.assert_array_equal(raw_chunk0, raw_chunk1)
+
+        # test slice(None). This should return the same array as giving
+        # all channel indexes or using None as an argument in `get_analogsignal_chunk`
+        # see https://github.com/NeuralEnsemble/python-neo/issues/1533
+
+        raw_chunk_slice_none = reader.get_analogsignal_chunk(
+            block_index=block_index,
+            seg_index=seg_index,
+            i_start=i_start,
+            i_stop=i_stop,
+            stream_index=stream_index,
+            channel_indexes=slice(None)
+        )
+        raw_chunk_channel_indexes = reader.get_analogsignal_chunk(
+            block_index=block_index,
+            seg_index=seg_index,
+            i_start=i_start,
+            i_stop=i_stop,
+            stream_index=stream_index,
+            channel_indexes=channel_indexes
+        )
+
+        np.testing.assert_array_equal(raw_chunk_slice_none, raw_chunk_channel_indexes)
 
         # test prefer_slice=True/False
         if nb_chan >= 3:


### PR DESCRIPTION
Fixes #1533.

This was found in the SpikeInterface full-test suite where an option is exposed to `prefer_slice` which will attempt to give a slice for `channel_indexes`. The `get_analogsignal_chunk` docstring says that it should accept slices, so we should test that all rawios are actually compliant for this requirement. If any of rawios fail this test then we need to fix them.