### PR TITLE
Fix pl2 channel enabled bug

### DIFF
--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -157,7 +157,7 @@ class Plexon2RawIO(BaseRawIO):
         for c in range(self.pl2reader.pl2_file_info.m_TotalNumberOfAnalogChannels):
             achannel_info = self.pl2reader.pl2_get_analog_channel_info(c)
             # only consider active channels
-            if not achannel_info.m_ChannelRecordingEnabled:
+            if not (achannel_info.m_ChannelEnabled and achannel_info.m_ChannelRecordingEnabled):
                 continue
 
             # assign to matching stream or create new stream based on signal characteristics
@@ -199,7 +199,7 @@ class Plexon2RawIO(BaseRawIO):
             schannel_info = self.pl2reader.pl2_get_spike_channel_info(c)
 
             # only consider active channels
-            if not schannel_info.m_ChannelRecordingEnabled:
+            if not (schannel_info.m_ChannelEnabled and schannel_info.m_ChannelRecordingEnabled):
                 continue
 
             for channel_unit_id in range(schannel_info.m_NumberOfUnits):
@@ -223,7 +223,7 @@ class Plexon2RawIO(BaseRawIO):
             echannel_info = self.pl2reader.pl2_get_digital_channel_info(i)
 
             # only consider active channels
-            if not echannel_info.m_ChannelRecordingEnabled:
+            if not (echannel_info.m_ChannelEnabled and echannel_info.m_ChannelRecordingEnabled):
                 continue
 
             # event channels are characterized by (name, id, type), with type in ['event', 'epoch']

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -157,7 +157,7 @@ class Plexon2RawIO(BaseRawIO):
         for c in range(self.pl2reader.pl2_file_info.m_TotalNumberOfAnalogChannels):
             achannel_info = self.pl2reader.pl2_get_analog_channel_info(c)
             # only consider active channels
-            if not achannel_info.m_ChannelEnabled:
+            if not achannel_info.m_ChannelRecordingEnabled:
                 continue
 
             # assign to matching stream or create new stream based on signal characteristics
@@ -199,7 +199,7 @@ class Plexon2RawIO(BaseRawIO):
             schannel_info = self.pl2reader.pl2_get_spike_channel_info(c)
 
             # only consider active channels
-            if not schannel_info.m_ChannelEnabled:
+            if not schannel_info.m_ChannelRecordingEnabled:
                 continue
 
             for channel_unit_id in range(schannel_info.m_NumberOfUnits):
@@ -223,7 +223,7 @@ class Plexon2RawIO(BaseRawIO):
             echannel_info = self.pl2reader.pl2_get_digital_channel_info(i)
 
             # only consider active channels
-            if not echannel_info.m_ChannelEnabled:
+            if not echannel_info.m_ChannelRecordingEnabled:
                 continue
 
             # event channels are characterized by (name, id, type), with type in ['event', 'epoch']


### PR DESCRIPTION
Neo fails to load a PL2 file if there are channels within the source that are disabled for recording, though otherwise enabled to be visualized. This patch fixes that. See below for details.

PL2 files are recorded using the "PlexControl" application. When setting up an experiment, the researcher has access to a number of controls for each channel. Included among these are the following two options:

(1) Enabled -- this corresponds to the "m_ChannelEnabled" flag in each channel header
(2) Record Enabled -- this corresponds to the "m_ChannelRecordingEnabled" flag in each channel header

The first option determines whether the channel's incoming data even makes it to the PlexControl application for visualization. The second option determines whether the incoming data for that channel is recorded to disk. The two options are decoupled in software, which means there are 4 possible scenarios:

1. m_ChannelEnabled=True and m_ChannelRecordingEnabled=True --> Here, data for the channel makes it to PlexControl and is recorded to disk
2. m_ChannelEnabled=True and m_ChannelRecordingEnabled=False --> Here, data for the channel makes it to PlexControl but is not recorded to disk
3. m_ChannelEnabled=False and m_ChannelRecordingEnabled=True --> Here, data for the channel does not make it to PlexControl and so there is nothing to record to disk
4. m_ChannelEnabled=False and m_ChannelRecordingEnabled=False --> Here, data for the channel does not make it to PlexControl and nothing is recorded to disk

Only Scenario 1 results in data being recorded to disk.

The code in plexon2rawio.py wants to consider only active channels, i.e., channels for which there is data. The original code defines active channels based solely on m_ChannelEnabled, which means that in Scenario 2 the code breaks when it looks for data that isn't there. The fix is to define active channels using both m_ChannelEnabled and m_ChannelRecordingEnabled.