### PR TITLE
IntanRawIO: Fix memmap order for Intan one-file-per-stream

### DIFF
--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -179,6 +179,9 @@ class IntanRawIO(BaseRawIO):
             self._raw_data = np.memmap(self.filename, dtype=memmap_data_dtype, mode="r", offset=header_size)
 
         # for 'one-file-per-signal' we have one memory map / neo stream
+        # based on https://github.com/NeuralEnsemble/python-neo/issues/1556 and the recommendations on the
+        # Intan website the data appears to be ordered column-major ('F') rather than row-major ('C') so
+        # when making our memmaps we should do order='F'
         elif self.file_format == "one-file-per-signal":
             self._raw_data = {}
             for stream_index, (stream_index_key, stream_datatype) in enumerate(memmap_data_dtype.items()):
@@ -188,7 +191,7 @@ class IntanRawIO(BaseRawIO):
                 dtype_size = np.dtype(stream_datatype).itemsize
                 n_samples = size_in_bytes // (dtype_size * num_channels)
                 signal_stream_memmap = np.memmap(
-                    file_path, dtype=stream_datatype, mode="r", shape=(num_channels, n_samples)
+                    file_path, dtype=stream_datatype, mode="r", shape=(num_channels, n_samples), order='F',
                 ).T
                 self._raw_data[stream_index] = signal_stream_memmap
 

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -179,9 +179,7 @@ class IntanRawIO(BaseRawIO):
             self._raw_data = np.memmap(self.filename, dtype=memmap_data_dtype, mode="r", offset=header_size)
 
         # for 'one-file-per-signal' we have one memory map / neo stream
-        # based on https://github.com/NeuralEnsemble/python-neo/issues/1556 and the recommendations on the
-        # Intan website the data appears to be ordered column-major ('F') rather than row-major ('C') so
-        # when making our memmaps we should do order='F'
+        # based on https://github.com/NeuralEnsemble/python-neo/issues/1556 bug in versions 0.13.1, .2, .3
         elif self.file_format == "one-file-per-signal":
             self._raw_data = {}
             for stream_index, (stream_index_key, stream_datatype) in enumerate(memmap_data_dtype.items()):
@@ -191,8 +189,8 @@ class IntanRawIO(BaseRawIO):
                 dtype_size = np.dtype(stream_datatype).itemsize
                 n_samples = size_in_bytes // (dtype_size * num_channels)
                 signal_stream_memmap = np.memmap(
-                    file_path, dtype=stream_datatype, mode="r", shape=(num_channels, n_samples), order='F',
-                ).T
+                    file_path, dtype=stream_datatype, mode="r", shape=(n_samples, num_channels), order='C',
+                )
                 self._raw_data[stream_index] = signal_stream_memmap
 
         # for one-file-per-channel we have one memory map / channel stored as a list / neo stream


### PR DESCRIPTION
Fixes #1556 

Data before fix:
![image](https://github.com/user-attachments/assets/c8c69c64-e728-46b8-96a9-aa5ff86617ef)


Data after fix:

![image](https://github.com/user-attachments/assets/030cf408-1503-4aa1-94d8-46dee565acc2)


Basically, since Intan was designed to be easily read with Matlab (their example work is to use `fread` which is column-major reading) we should make our memmap with `order='F'`.

@h-mayorquin want to look over this quickly and @alejoe91 I think this can be a quick review as long as everyone is agreed. See the linked issue for more information.

Can you test this @Tevin-yue?

NOTE: this is simulated data so it should look like a repeating motif of simulated "spikes".