### PR TITLE
[No Merge] Added command to unlock annex repo to restore files from symbolic links.

### DIFF
--- a/neo/utils/datasets.py
+++ b/neo/utils/datasets.py
@@ -64,6 +64,7 @@ def download_dataset(repo=default_testing_repo, remote_path=None, local_folder=N
         # make sure git repo is in clean state
         repo = dataset.repo
         repo.call_git(["checkout", "--force", "master"])
+        repo.unlock(remote_path)
         dataset.update(merge=True)
     else:
         dataset = datalad.api.install(path=local_folder, source=repo)


### PR DESCRIPTION
fixes #1550 

I did a little digging and I think the problems with downloaded files being replaced with 1KB symbolic links has to do with the way annex repositories work. I added an "unlock" command after the forced checkout and it seems to fix the issue on my Windows computer.