### PR TITLE
Improved brainvision header parsing.

### DIFF
--- a/neo/rawio/brainvisionrawio.py
+++ b/neo/rawio/brainvisionrawio.py
@@ -92,8 +92,22 @@ class BrainVisionRawIO(BaseRawIO):
                 channel_desc = channel_infos[f"Ch{c+1}"]
             except KeyError:
                 channel_desc = channel_infos[f"ch{c + 1}"]
-            name, ref, res, units = channel_desc.split(",")
-            units = units.replace("µ", "u")
+            # split up channel description, handling default values
+            cds = channel_desc.split(",")
+            name = cds[0]
+            if len(cds) >= 2:
+                ref = cds[1]
+            else:
+                ref = ""
+            if len(cds) >= 3:
+                res = cds[2]
+            else:
+                res = "1.0"
+            if len(cds) == 4:
+                units = cds[3]
+            else:
+                units = "u"
+            units = units.replace("µ", "u") # Brainvision spec for specific unicode
             chan_id = str(c + 1)
             if sig_dtype == np.int16 or sig_dtype == np.int32:
                 gain = float(res)

--- a/neo/test/rawiotest/test_brainvisionrawio.py
+++ b/neo/test/rawiotest/test_brainvisionrawio.py
@@ -20,6 +20,7 @@ class TestBrainVisionRawIO(
         "brainvision/File_brainvision_3_float32.vhdr",
         "brainvision/File_brainvision_3_int16.vhdr",
         "brainvision/File_brainvision_3_int32.vhdr",
+        "brainvision/File_brainvision_4_float32.vhdr",
     ]
 
     entities_to_download = ["brainvision"]


### PR DESCRIPTION
The primary change allows channel descriptions in the header .vhdr file to conform to specification with some defaults for columns.

The test change simply tests the new files in https://gin.g-node.org/NeuralEnsemble/ephy_testing_data/pulls/140 , which should be merged before this.