### PR TITLE
Refactor Neuralynx file header processing

### DIFF
--- a/neo/rawio/neuralynxrawio/ncssections.py
+++ b/neo/rawio/neuralynxrawio/ncssections.py
@@ -37,6 +37,19 @@ gaps from those introduced by a quirk of the hardware, recording software, or fi
 import math
 import numpy as np
 
+from enum import IntEnum, auto
+
+
+class AcqType(IntEnum):
+    PRE4 = auto()
+    BML = auto()
+    DIGITALLYNX = auto()
+    DIGITALLYNXSX = auto()
+    CHEETAH64 = auto()
+    RAWDATAFILE = auto()
+    CHEETAH560 = auto()
+    ATLAS = auto()
+    UNKNOWN = auto()
 
 class NcsSections:
     """
@@ -250,7 +263,7 @@ class NcsSectionsFactory:
         acqType = nlxHdr.type_of_recording()
         freq = nlxHdr["sampling_rate"]
 
-        if acqType == "PRE4":
+        if acqType == AcqType.PRE4:
             # Old Neuralynx style with truncated whole microseconds for actual sampling. This
             # restriction arose from the sampling being based on a master 1 MHz clock.
             microsPerSampUsed = math.floor(NcsSectionsFactory.get_micros_per_samp_for_freq(freq))
@@ -266,7 +279,8 @@ class NcsSectionsFactory:
             ncsSects.sampFreqUsed = sampFreqUsed
             ncsSects.microsPerSampUsed = microsPerSampUsed
 
-        elif acqType in ["DIGITALLYNX", "DIGITALLYNXSX", "CHEETAH64", "CHEETAH560", "RAWDATAFILE"]:
+        elif acqType in [AcqType.DIGITALLYNX, AcqType.DIGITALLYNXSX, AcqType.CHEETAH64,
+                          AcqType.CHEETAH560, AcqType.RAWDATAFILE]:
             # digital lynx style with fractional frequency and micros per samp determined from block times
             if gapTolerance is None:
                 if strict_gap_mode:
@@ -293,7 +307,7 @@ class NcsSectionsFactory:
             ncsSects.sampFreqUsed = sampFreqUsed
             ncsSects.microsPerSampUsed = NcsSectionsFactory.get_micros_per_samp_for_freq(sampFreqUsed)
 
-        elif acqType == "BML" or acqType == "ATLAS":
+        elif acqType == AcqType.BML or acqType == AcqType.ATLAS:
             # BML & ATLAS style with fractional frequency and micros per samp
             if strict_gap_mode:
                 # this is the old behavior, maybe we could put 0.9 sample interval no ?

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -4,6 +4,8 @@ import os
 import re
 from collections import OrderedDict
 
+from neo.rawio.neuralynxrawio.ncssections import AcqType
+
 
 class NlxHeader(OrderedDict):
     """
@@ -345,52 +347,50 @@ class NlxHeader(OrderedDict):
         """
         Determines type of recording in Ncs file with this header.
 
-        RETURN:
-            one of 'PRE4','BML','DIGITALLYNX','DIGITALLYNXSX','CHEETAH64', 'RAWDATAFILE',
-            'CHEETAH560', 'UNKNOWN'
+        RETURN: NcsSections.AcqType
         """
 
         if "NLX_Base_Class_Type" in self:
 
             # older style standard neuralynx acquisition with rounded sampling frequency
             if self["NLX_Base_Class_Type"] == "CscAcqEnt":
-                return "PRE4"
+                return AcqType.PRE4
 
             # BML style with fractional frequency and microsPerSamp
             elif self["NLX_Base_Class_Type"] == "BmlAcq":
-                return "BML"
+                return AcqType.BML
 
             else:
-                return "UNKNOWN"
+                return AcqType.UNKNOWN
 
         elif "HardwareSubSystemType" in self:
 
             # DigitalLynx
             if self["HardwareSubSystemType"] == "DigitalLynx":
-                return "DIGITALLYNX"
+                return AcqType.DIGITALLYNX
 
             # DigitalLynxSX
             elif self["HardwareSubSystemType"] == "DigitalLynxSX":
-                return "DIGITALLYNXSX"
+                return AcqType.DIGITALLYNXSX
 
             # Cheetah64
             elif self["HardwareSubSystemType"] == "Cheetah64":
-                return "CHEETAH64"
+                return AcqType.CHEETAH64
 
             # RawDataFile
             elif self["HardwareSubSystemType"] == "RawDataFile":
-                return "RAWDATAFILE"
+                return AcqType.RAWDATAFILE
 
             else:
-                return "UNKNOWN"
+                return AcqType.UNKNOWN
 
         elif "FileType" in self:
 
             if "FileVersion" in self and self["FileVersion"] in ["3.2", "3.3", "3.4"]:
-                return self["AcquisitionSystem"].split()[1].upper()
+                return AcqType[self["AcquisitionSystem"].split()[1].upper()]
 
             else:
-                return "CHEETAH560"  # only known case of FileType without FileVersion
+                return AcqType.CHEETAH560  # only known case of FileType without FileVersion
 
         else:
-            return "UNKNOWN"
+            return AcqType.UNKNOWN

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -70,7 +70,6 @@ class NlxHeader(OrderedDict):
         ("NLX_Base_Class_Type", "", None),  # in version 4 and earlier versions of Cheetah
     ]
 
-
     def __init__(self, filename, props_only=False):
         """
         Factory function to build NlxHeader for a given file.
@@ -89,7 +88,7 @@ class NlxHeader(OrderedDict):
 
         self.read_properties(filename, txt_header)
         numChidEntries = self.convert_channel_ids_names(filename)
-        self.setApplicationAndVersion(txt_header)
+        self.setApplicationAndVersion()
         self.setBitToMicroVolt()
         self.setInputRanges(numChidEntries)
 
@@ -148,7 +147,7 @@ class NlxHeader(OrderedDict):
             assert len(self["bit_to_microVolt"]) == len( self["channel_ids"]), \
                 "Number of channel ids does not match bit_to_microVolt conversion factors."
 
-    def setApplicationAndVersion(self, txt_header):
+    def setApplicationAndVersion(self):
         """
         Set "ApplicationName" property and app_version attribute based on existing properties
         """
@@ -164,7 +163,7 @@ class NlxHeader(OrderedDict):
             assert len(match) == 1, "impossible to find application name and version"
             self["ApplicationName"], app_version = match[0]
         # BML Ncs file contain neither property, but 'NLX_Base_Class_Type'
-        elif "NLX_Base_Class_Type" in txt_header:
+        elif "NLX_Base_Class_Type" in self:
             self["ApplicationName"] = "BML"
             app_version = "2.0"
         # Neuraview Ncs file contained neither property nor NLX_Base_Class_Type information
@@ -347,7 +346,8 @@ class NlxHeader(OrderedDict):
         Determines type of recording in Ncs file with this header.
 
         RETURN:
-            one of 'PRE4','BML','DIGITALLYNX','DIGITALLYNXSX','UNKNOWN'
+            one of 'PRE4','BML','DIGITALLYNX','DIGITALLYNXSX','CHEETAH64', 'RAWDATAFILE',
+            'CHEETAH560', 'UNKNOWN'
         """
 
         if "NLX_Base_Class_Type" in self:

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from neo.rawio.neuralynxrawio.neuralynxrawio import NeuralynxRawIO
 from neo.rawio.neuralynxrawio.nlxheader import NlxHeader
-from neo.rawio.neuralynxrawio.ncssections import NcsSection, NcsSections, NcsSectionsFactory
+from neo.rawio.neuralynxrawio.ncssections import AcqType, NcsSection, NcsSections, NcsSectionsFactory
 from neo.test.rawiotest.common_rawio_test import BaseTestRawIO
 
 import logging
@@ -182,15 +182,15 @@ class TestNcsRecordingType(TestNeuralynxRawIO, unittest.TestCase):
     entities_to_test = []
 
     ncsTypeTestFiles = [
-        ("neuralynx/Cheetah_v4.0.2/original_data/CSC14_trunc.Ncs", "PRE4"),
-        ("neuralynx/Cheetah_v5.4.0/original_data/CSC5_trunc.Ncs", "DIGITALLYNX"),
-        ("neuralynx/Cheetah_v5.5.1/original_data/STet3a.nse", "DIGITALLYNXSX"),
-        ("neuralynx/Cheetah_v5.5.1/original_data/Tet3a.ncs", "DIGITALLYNXSX"),
-        ("neuralynx/Cheetah_v5.6.3/original_data/CSC1.ncs", "DIGITALLYNXSX"),
-        ("neuralynx/Cheetah_v5.6.3/original_data/TT1.ntt", "DIGITALLYNXSX"),
-        ("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs", "DIGITALLYNXSX"),
-        ("neuralynx/Cheetah_v6.3.2/incomplete_blocks/CSC1_reduced.ncs", "DIGITALLYNXSX"),
-        ("neuralynx/Pegasus_v2.1.1/Events_0008.nev", "ATLAS"),
+        ("neuralynx/Cheetah_v4.0.2/original_data/CSC14_trunc.Ncs", AcqType.PRE4),
+        ("neuralynx/Cheetah_v5.4.0/original_data/CSC5_trunc.Ncs", AcqType.DIGITALLYNX),
+        ("neuralynx/Cheetah_v5.5.1/original_data/STet3a.nse", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Cheetah_v5.5.1/original_data/Tet3a.ncs", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Cheetah_v5.6.3/original_data/CSC1.ncs", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Cheetah_v5.6.3/original_data/TT1.ntt", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Cheetah_v6.3.2/incomplete_blocks/CSC1_reduced.ncs", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Pegasus_v2.1.1/Events_0008.nev", AcqType.ATLAS),
     ]
 
     def test_recording_types(self):
@@ -375,12 +375,3 @@ class TestNlxHeader(TestNeuralynxRawIO, unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-    # test = TestNeuralynxRawIO()
-    # test.test_scan_ncs_files()
-    # test.test_exclude_filenames()
-    # test.test_include_filenames()
-
-    # test = TestNcsSectionsFactory()
-    # test.test_ncsblocks_partial()
-    # test.test_build_given_actual_frequency()


### PR DESCRIPTION
This moves much of the conversions and setting from read_properties into separate methods. Also make the acquisition type a proper IntEnum rather than simply strings.

This is in preparation for major changes to how the header entries are parsed to be more flexible.