### PR TITLE
Add filename property

### DIFF
--- a/neo/rawio/neuralynxrawio/ncssections.py
+++ b/neo/rawio/neuralynxrawio/ncssections.py
@@ -37,6 +37,19 @@ gaps from those introduced by a quirk of the hardware, recording software, or fi
 import math
 import numpy as np
 
+from enum import IntEnum, auto
+
+
+class AcqType(IntEnum):
+    PRE4 = auto()
+    BML = auto()
+    DIGITALLYNX = auto()
+    DIGITALLYNXSX = auto()
+    CHEETAH64 = auto()
+    RAWDATAFILE = auto()
+    CHEETAH560 = auto()
+    ATLAS = auto()
+    UNKNOWN = auto()
 
 class NcsSections:
     """
@@ -250,7 +263,7 @@ class NcsSectionsFactory:
         acqType = nlxHdr.type_of_recording()
         freq = nlxHdr["sampling_rate"]
 
-        if acqType == "PRE4":
+        if acqType == AcqType.PRE4:
             # Old Neuralynx style with truncated whole microseconds for actual sampling. This
             # restriction arose from the sampling being based on a master 1 MHz clock.
             microsPerSampUsed = math.floor(NcsSectionsFactory.get_micros_per_samp_for_freq(freq))
@@ -266,7 +279,8 @@ class NcsSectionsFactory:
             ncsSects.sampFreqUsed = sampFreqUsed
             ncsSects.microsPerSampUsed = microsPerSampUsed
 
-        elif acqType in ["DIGITALLYNX", "DIGITALLYNXSX", "CHEETAH64", "CHEETAH560", "RAWDATAFILE"]:
+        elif acqType in [AcqType.DIGITALLYNX, AcqType.DIGITALLYNXSX, AcqType.CHEETAH64,
+                          AcqType.CHEETAH560, AcqType.RAWDATAFILE]:
             # digital lynx style with fractional frequency and micros per samp determined from block times
             if gapTolerance is None:
                 if strict_gap_mode:
@@ -293,7 +307,7 @@ class NcsSectionsFactory:
             ncsSects.sampFreqUsed = sampFreqUsed
             ncsSects.microsPerSampUsed = NcsSectionsFactory.get_micros_per_samp_for_freq(sampFreqUsed)
 
-        elif acqType == "BML" or acqType == "ATLAS":
+        elif acqType == AcqType.BML or acqType == AcqType.ATLAS:
             # BML & ATLAS style with fractional frequency and micros per samp
             if strict_gap_mode:
                 # this is the old behavior, maybe we could put 0.9 sample interval no ?

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -11,6 +11,12 @@ class NlxHeader(OrderedDict):
     """
     Representation of basic information in all 16 kbytes Neuralynx file headers,
     including dates opened and closed if given.
+
+    The OrderedDict contains entries for each property given in the header with '-' in front
+    of the key value as well as an 'ApplicationName', 'ApplicationVersion', 'recording_opened'
+    and 'recording_closed' entries. The 'InputRange', 'channel_ids', 'channel_names' and
+    'bit_to_microvolt' properties are set to lists of entries for each channel which may be
+    in the file.  
     """
 
     HEADER_SIZE = 2**14  # Neuralynx files have a txt header of 16kB
@@ -93,6 +99,7 @@ class NlxHeader(OrderedDict):
         self.setApplicationAndVersion()
         self.setBitToMicroVolt()
         self.setInputRanges(numChidEntries)
+        # :TODO: needs to also handle filename property
 
         if not props_only:
             self.readTimeDate(txt_header)

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -79,6 +79,96 @@ class NlxHeader(OrderedDict):
         ("NLX_Base_Class_Type", "", None),  # in version 4 and earlier versions of Cheetah
     ]
 
+    # Filename and datetime may appear in header lines starting with # at
+    # beginning of header or in later versions as a property. The exact format
+    # used depends on the application name and its version as well as the
+    # -FileVersion property. Examples of each known case are shown below in comments.
+    #
+    # There are now separate patterns for the in header line and in properties cases which cover
+    # the known variations in each case. They are compiled here once for efficiency.
+    openDatetime1_pat = re.compile(r"## (Time|Date) Opened:* \((m/d/y|mm/dd/yyy)\): (?P<date>\S+)"\
+                                      r"\s+(\(h:m:s\.ms\)|At Time:) (?P<time>\S+)")
+    openDatetime2_pat = re.compile(r"-TimeCreated (?P<date>\S+) (?P<time>\S+)")
+    closeDatetime1_pat = re.compile(r"## (Time|Date) Closed:* \((m/d/y|mm/dd/yyy)\): " \
+                                        r"(?P<date>\S+)\s+(\(h:m:s\.ms\)|At Time:) (?P<time>\S+)")
+    closeDatetime2_pat = re.compile(r"-TimeClosed (?P<date>\S+) (?P<time>\S+)")
+
+    # BML - example
+    # ######## Neuralynx Data File Header
+    # ## File Name: null
+    # ## Time Opened: (m/d/y): 12/11/15  At Time: 11:37:39.000
+
+    # Cheetah after version 1 and before version 5 - example
+    # ######## Neuralynx Data File Header
+    # ## File Name F:\2000-01-01_18-28-39\RMH3.ncs
+    # ## Time Opened (m/d/y): 1/1/2000  (h:m:s.ms) 18:28:39.821
+    # ## Time Closed (m/d/y): 1/1/2000  (h:m:s.ms) 9:58:41.322
+
+    # Cheetah version 4.0.2 - example
+    # ######## Neuralynx Data File Header
+    # ## File Name: D:\Cheetah_Data\2003-10-4_10-2-58\CSC14.Ncs
+    # ## Time Opened: (m/d/y): 10/4/2003  At Time: 10:3:0.578
+
+    # Cheetah version 5.4.0 - example
+    # ######## Neuralynx Data File Header
+    # ## File Name C:\CheetahData\2000-01-01_00-00-00\CSC5.ncs
+    # ## Time Opened (m/d/y): 1/01/2001  At Time: 0:00:00.000
+    # ## Time Closed (m/d/y): 1/01/2001  At Time: 00:00:00.000
+
+    # Cheetah version 5.5.1 - example
+    # ######## Neuralynx Data File Header
+    # ## File Name C:\CheetahData\2013-11-29_17-05-05\Tet3a.ncs
+    # ## Time Opened (m/d/y): 11/29/2013  (h:m:s.ms) 17:5:16.793
+    # ## Time Closed (m/d/y): 11/29/2013  (h:m:s.ms) 18:3:13.603
+
+    # Cheetah version 5.6.0 - example
+    # ## File Name: F:\processing\sum-big-board\252-1375\recording-20180107\2018-01-07_15-14-54\04. tmaze1-no-light-start To tmaze1-light-stop\VT1_fixed.nvt
+    # ## Time Opened: (m/d/y): 2/5/2018 At Time: 18:5:12.654
+
+    # Cheetah version 5.6.3 - example
+    # ######## Neuralynx Data File Header
+    # ## File Name C:\CheetahData\2016-11-28_21-50-00\CSC1.ncs
+    # ## Time Opened (m/d/y): 11/28/2016  (h:m:s.ms) 21:50:33.322
+    # ## Time Closed (m/d/y): 11/28/2016  (h:m:s.ms) 22:44:41.145
+
+    # Cheetah version 5.7.4 - example
+    # ######## Neuralynx Data File Header
+    # and then properties
+    # -OriginalFileName "C:\CheetahData\2017-02-16_17-55-55\CSC1.ncs"
+    # -TimeCreated 2017/02/16 17:56:04
+    # -TimeClosed 2017/02/16 18:01:18
+
+    # Cheetah version 6.3.2 - example
+    # ######## Neuralynx Data File Header
+    # and then properties
+    # -OriginalFileName "G:\CheetahDataD\2019-07-12_13-21-32\CSC1.ncs"
+    # -TimeCreated 2019/07/12 13:21:32
+    # -TimeClosed 2019/07/12 15:07:55
+
+    # Cheetah version 6.4.1dev - example
+    # ######## Neuralynx Data File Header
+    # and then properties
+    # -OriginalFileName "D:\CheetahData\2021-02-26_15-46-33\CSC1.ncs"
+    # -TimeCreated 2021/02/26 15:46:52
+    # -TimeClosed 2021/10/12 09:07:58
+
+    # neuraview version 2 - example
+    # ######## Neuralynx Data File Header
+    # ## File Name: L:\McHugh Lab\Recording\2015-06-24_18-05-11\NeuraviewEventMarkers-20151214_SleepScore.nev
+    # ## Date Opened: (mm/dd/yyy): 12/14/2015 At Time: 15:58:32
+    # ## Date Closed: (mm/dd/yyy): 12/14/2015 At Time: 15:58:32
+
+    # pegasus version 2.1.1 and Cheetah beyond version 5.6.4 - example
+    # ######## Neuralynx Data File Header
+    # and then properties
+    # -OriginalFileName D:\Pegasus Data\Dr_NM\1902\2019-06-28_17-36-50\Events_0008.nev
+    # -TimeCreated 2019/06/28 17:36:50
+    # -TimeClosed 2019/06/28 17:45:48
+
+    # regular expressions to match filename
+    filename_regex = [r"## File Name (?P<filename>\S+)",
+                      r'-OriginalFileName "?(?P<filename>\S+)"?']
+
     def __init__(self, filename, props_only=False):
         """
         Factory function to build NlxHeader for a given file.
@@ -163,7 +253,7 @@ class NlxHeader(OrderedDict):
         # BML Ncs file contain neither property, but 'NLX_Base_Class_Type'
         elif "NLX_Base_Class_Type" in self:
             self["ApplicationName"] = "BML"
-            app_version = "2.0"
+            app_version = "1.0"
         # Neuraview Ncs file contained neither property nor NLX_Base_Class_Type information
         else:
             self["ApplicationName"] = "Neuraview"
@@ -204,151 +294,26 @@ class NlxHeader(OrderedDict):
 
         return len(chid_entries)
 
-    # Filename and datetime may appear in header lines starting with # at
-    # beginning of header or in later versions as a property. The exact format
-    # used depends on the application name and its version as well as the
-    # -FileVersion property. Examples of each known case are shown below in comments.
-    #
-    # There are 4 styles understood by this code and the patterns used for parsing
-    # the items within each are stored in a dictionary. Each dictionary is then
-    # stored in main dictionary keyed by an abbreviation for the style.
-    header_pattern_dicts = {
-        # BML - example
-        # ######## Neuralynx Data File Header
-        # ## File Name: null
-        # ## Time Opened: (m/d/y): 12/11/15  At Time: 11:37:39.000
-
-        # Cheetah after version 1 and before version 5 - example
-        # ######## Neuralynx Data File Header
-        # ## File Name F:\2000-01-01_18-28-39\RMH3.ncs
-        # ## Time Opened (m/d/y): 1/1/2000  (h:m:s.ms) 18:28:39.821
-        # ## Time Closed (m/d/y): 1/1/2000  (h:m:s.ms) 9:58:41.322
-
-        # Cheetah version 4.0.2 - example
-        # ######## Neuralynx Data File Header
-        # ## File Name: D:\Cheetah_Data\2003-10-4_10-2-58\CSC14.Ncs
-        # ## Time Opened: (m/d/y): 10/4/2003  At Time: 10:3:0.578
-
-        # Cheetah version 5.4.0 - example
-        # ######## Neuralynx Data File Header
-        # ## File Name C:\CheetahData\2000-01-01_00-00-00\CSC5.ncs
-        # ## Time Opened (m/d/y): 1/01/2001  At Time: 0:00:00.000
-        # ## Time Closed (m/d/y): 1/01/2001  At Time: 00:00:00.000
-
-        # Cheetah version 5.5.1 - example
-        # ######## Neuralynx Data File Header
-        # ## File Name C:\CheetahData\2013-11-29_17-05-05\Tet3a.ncs
-        # ## Time Opened (m/d/y): 11/29/2013  (h:m:s.ms) 17:5:16.793
-        # ## Time Closed (m/d/y): 11/29/2013  (h:m:s.ms) 18:3:13.603
-
-        # Cheetah version 5.6.0 - example
-        # ## File Name: F:\processing\sum-big-board\252-1375\recording-20180107\2018-01-07_15-14-54\04. tmaze1-no-light-start To tmaze1-light-stop\VT1_fixed.nvt
-        # ## Time Opened: (m/d/y): 2/5/2018 At Time: 18:5:12.654
-
-        # Cheetah version 5.6.3 - example
-        # ######## Neuralynx Data File Header
-        # ## File Name C:\CheetahData\2016-11-28_21-50-00\CSC1.ncs
-        # ## Time Opened (m/d/y): 11/28/2016  (h:m:s.ms) 21:50:33.322
-        # ## Time Closed (m/d/y): 11/28/2016  (h:m:s.ms) 22:44:41.145
-
-        # Cheetah version 5.7.4 - example
-        # ######## Neuralynx Data File Header
-        # and then properties
-        # -OriginalFileName "C:\CheetahData\2017-02-16_17-55-55\CSC1.ncs"
-        # -TimeCreated 2017/02/16 17:56:04
-        # -TimeClosed 2017/02/16 18:01:18
-
-        # Cheetah version 6.3.2 - example
-        # ######## Neuralynx Data File Header
-        # and then properties
-        # -OriginalFileName "G:\CheetahDataD\2019-07-12_13-21-32\CSC1.ncs"
-        # -TimeCreated 2019/07/12 13:21:32
-        # -TimeClosed 2019/07/12 15:07:55
-
-        # Cheetah version 6.4.1dev - example
-        # ######## Neuralynx Data File Header
-        # and then properties
-        # -OriginalFileName "D:\CheetahData\2021-02-26_15-46-33\CSC1.ncs"
-        # -TimeCreated 2021/02/26 15:46:52
-        # -TimeClosed 2021/10/12 09:07:58
-
-        # neuraview version 2 - example
-        # ######## Neuralynx Data File Header
-        # ## File Name: L:\McHugh Lab\Recording\2015-06-24_18-05-11\NeuraviewEventMarkers-20151214_SleepScore.nev
-        # ## Date Opened: (mm/dd/yyy): 12/14/2015 At Time: 15:58:32
-        # ## Date Closed: (mm/dd/yyy): 12/14/2015 At Time: 15:58:32
-
-        # pegasus version 2.1.1 and Cheetah beyond version 5.6.4 - example
-        # ######## Neuralynx Data File Header
-        # and then properties
-        # -OriginalFileName D:\Pegasus Data\Dr_NM\1902\2019-06-28_17-36-50\Events_0008.nev
-        # -TimeCreated 2019/06/28 17:36:50
-        # -TimeClosed 2019/06/28 17:45:48
-
-        "combined": dict(
-            openDatetime1_regex=r"## (Time|Date) Opened:* \((m/d/y|mm/dd/yyy)\): (?P<date>\S+)" \
-                            r"\s+(\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
-            openDatetime2_regex=r"-TimeCreated (?P<date>\S+) (?P<time>\S+)",
-            closeDatetime1_regex=r"## (Time|Date) Closed:* \((m/d/y|mm/dd/yyy)\): (?P<date>\S+)" \
-                            r"\s+(\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
-            closeDatetime2_regex=r"-TimeClosed (?P<date>\S+) (?P<time>\S+)",
-        )
-    }
-
-    # regular expressions to match filename
-    filename_regex = [r"## File Name (?P<filename>\S+)",
-                       r'-OriginalFileName "?(?P<filename>\S+)"?']
-    
     def readTimeDate(self, txt_header):
         """
-        Read time and date from text of header appropriate for app name and version
-
-        :TODO: this works for current examples but is not likely actually related
-        to app version in this manner.
+        Read time and date from text of header
         """
-        an = self["ApplicationName"]
-        if an == "Cheetah":
-            av = self["ApplicationVersion"]
-            if av <= Version("2"):  # version 1 uses same as older versions
-                hpd = NlxHeader.header_pattern_dicts["combined"]
-            elif av < Version("5"):
-                hpd = NlxHeader.header_pattern_dicts["combined"]
-            elif av <= Version("5.4.0"):
-                hpd = NlxHeader.header_pattern_dicts["combined"]
-            elif av == Version("5.6.0"):
-                hpd = NlxHeader.header_pattern_dicts["combined"]
-            elif av <= Version("5.6.4"):
-                hpd = NlxHeader.header_pattern_dicts["combined"]
-            else:
-                hpd = NlxHeader.header_pattern_dicts["combined"]
-        elif an == "BML":
-            hpd = NlxHeader.header_pattern_dicts["combined"]
-            av = Version("2")
-        elif an == "Neuraview":
-            hpd = NlxHeader.header_pattern_dicts["combined"]
-            av = Version("2")
-        elif an == "Pegasus":
-            hpd = NlxHeader.header_pattern_dicts["combined"]
-            av = Version("2")
-        else:
-            an = "Unknown"
-            av = "NA"
-            hpd = NlxHeader.header_pattern_dicts["combined"]
 
         # opening time
-        sr = re.search(hpd["openDatetime1_regex"], txt_header)
-        if not sr: sr=re.search(hpd["openDatetime2_regex"], txt_header)
+        sr = NlxHeader.openDatetime1_pat.search(txt_header)
+        if not sr: sr=NlxHeader.openDatetime2_pat.search(txt_header)
         if not sr:
             raise IOError(
-                f"No matching header open date/time for application {an} " + f"version {av}. Please contact developers."
+                f"No matching header open date/time for application {self['ApplicationName']} " +
+                f"version {self['ApplicationVersion']}. Please contact developers."
             )
         else:
             dt1 = sr.groupdict()
             self['recording_opened'] = dateutil.parser.parse(f"{dt1['date']} {dt1['time']}")
 
         # close time, if available
-        sr = re.search(hpd["closeDatetime1_regex"], txt_header)
-        if not sr: sr=re.search(hpd["closeDatetime2_regex"], txt_header)
+        sr = NlxHeader.closeDatetime1_pat.search(txt_header)
+        if not sr: sr=NlxHeader.closeDatetime2_pat.search(txt_header)
         if sr:
             dt2 = sr.groupdict()
             self['recording_closed'] = dateutil.parser.parse(f"{dt2['date']} {dt2['time']}")

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -217,31 +217,61 @@ class NlxHeader(OrderedDict):
     # the items within each are stored in a dictionary. Each dictionary is then
     # stored in main dictionary keyed by an abbreviation for the style.
     header_pattern_dicts = {
-        # BML
+        # BML - example
+        # ######## Neuralynx Data File Header
+        # ## File Name: null
+        # ## Time Opened: (m/d/y): 12/11/15  At Time: 11:37:39.000
         "bml": dict(
             datetime1_regex=r"## Time Opened: \(m/d/y\): (?P<date>\S+)" r"  At Time: (?P<time>\S+)",
             filename_regex=r"## File Name: (?P<filename>\S+)",
             datetimeformat="%m/%d/%y %H:%M:%S.%f",
         ),
-        # Cheetah after version 1 and before version 5
+        # Cheetah after version 1 and before version 5 - example
+        # ######## Neuralynx Data File Header
+        # ## File Name F:\2000-01-01_18-28-39\RMH3.ncs
+        # ## Time Opened (m/d/y): 1/1/2000  (h:m:s.ms) 18:28:39.821
+        # ## Time Closed (m/d/y): 1/1/2000  (h:m:s.ms) 9:58:41.322
         "bv5": dict(
             datetime1_regex=r"## Time Opened: \(m/d/y\): (?P<date>\S+)" r"  At Time: (?P<time>\S+)",
             filename_regex=r"## File Name: (?P<filename>\S+)",
             datetimeformat="%m/%d/%Y %H:%M:%S.%f",
         ),
-        # Cheetah version 5.4.0
+        # Cheetah version 4.0.2 - example
+        # ######## Neuralynx Data File Header
+        # ## File Name: D:\Cheetah_Data\2003-10-4_10-2-58\CSC14.Ncs
+        # ## Time Opened: (m/d/y): 10/4/2003  At Time: 10:3:0.578
+
+        # Cheetah version 5.4.0 - example
+        # ######## Neuralynx Data File Header
+        # ## File Name C:\CheetahData\2000-01-01_00-00-00\CSC5.ncs
+        # ## Time Opened (m/d/y): 1/01/2001  At Time: 0:00:00.000
+        # ## Time Closed (m/d/y): 1/01/2001  At Time: 00:00:00.000
         "v5.4.0": dict(
             datetime1_regex=r"## Time Opened \(m/d/y\): (?P<date>\S+)" r"  At Time: (?P<time>\S+)",
             datetime2_regex=r"## Time Closed \(m/d/y\): (?P<date>\S+)" r"  At Time: (?P<time>\S+)",
             filename_regex=r"## File Name: (?P<filename>\S+)",
             datetimeformat="%m/%d/%Y %H:%M:%S.%f",
         ),
-        # Cheetah version 5.6.0, some range of versions in between
+        # Cheetah version 5.5.1 - example
+        # ######## Neuralynx Data File Header
+        # ## File Name C:\CheetahData\2013-11-29_17-05-05\Tet3a.ncs
+        # ## Time Opened (m/d/y): 11/29/2013  (h:m:s.ms) 17:5:16.793
+        # ## Time Closed (m/d/y): 11/29/2013  (h:m:s.ms) 18:3:13.603
+
+        # Cheetah version 5.6.0 - example
+        # ## File Name: F:\processing\sum-big-board\252-1375\recording-20180107\2018-01-07_15-14-54\04. tmaze1-no-light-start To tmaze1-light-stop\VT1_fixed.nvt
+        # ## Time Opened: (m/d/y): 2/5/2018 At Time: 18:5:12.654
         "v5.6.0": dict(
             datetime1_regex=r"## Time Opened: \(m/d/y\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
             filename_regex=r"## File Name: (?P<filename>\S+)",
             datetimeformat="%m/%d/%Y %H:%M:%S.%f",
         ),
+        # Cheetah version 5.6.3 - example
+        # ######## Neuralynx Data File Header
+        # ## File Name C:\CheetahData\2016-11-28_21-50-00\CSC1.ncs
+        # ## Time Opened (m/d/y): 11/28/2016  (h:m:s.ms) 21:50:33.322
+        # ## Time Closed (m/d/y): 11/28/2016  (h:m:s.ms) 22:44:41.145
+
         # Cheetah version 5 before and including v 5.6.4 as well as version 1
         "bv5.6.4": dict(
             datetime1_regex=r"## Time Opened \(m/d/y\): (?P<date>\S+)" r"  \(h:m:s\.ms\) (?P<time>\S+)",
@@ -249,12 +279,45 @@ class NlxHeader(OrderedDict):
             filename_regex=r"## File Name (?P<filename>\S+)",
             datetimeformat="%m/%d/%Y %H:%M:%S.%f",
         ),
+
+        # Cheetah version 5.7.4 - example
+        # ######## Neuralynx Data File Header
+        # and then properties
+        # -OriginalFileName "C:\CheetahData\2017-02-16_17-55-55\CSC1.ncs"
+        # -TimeCreated 2017/02/16 17:56:04
+        # -TimeClosed 2017/02/16 18:01:18
+
+        # Cheetah version 6.3.2 - example
+        # ######## Neuralynx Data File Header
+        # and then properties
+        # -OriginalFileName "G:\CheetahDataD\2019-07-12_13-21-32\CSC1.ncs"
+        # -TimeCreated 2019/07/12 13:21:32
+        # -TimeClosed 2019/07/12 15:07:55
+
+        # Cheetah version 6.4.1dev - example
+        # ######## Neuralynx Data File Header
+        # and then properties
+        # -OriginalFileName "D:\CheetahData\2021-02-26_15-46-33\CSC1.ncs"
+        # -TimeCreated 2021/02/26 15:46:52
+        # -TimeClosed 2021/10/12 09:07:58
+
+        # neuraview version 2 - example
+        # ######## Neuralynx Data File Header
+        # ## File Name: L:\McHugh Lab\Recording\2015-06-24_18-05-11\NeuraviewEventMarkers-20151214_SleepScore.nev
+        # ## Date Opened: (mm/dd/yyy): 12/14/2015 At Time: 15:58:32
+        # ## Date Closed: (mm/dd/yyy): 12/14/2015 At Time: 15:58:32
         "neuraview2": dict(
             datetime1_regex=r"## Date Opened: \(mm/dd/yyy\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
             datetime2_regex=r"## Date Closed: \(mm/dd/yyy\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
             filename_regex=r"## File Name: (?P<filename>\S+)",
             datetimeformat="%m/%d/%Y %H:%M:%S",
         ),
+        # pegasus version 2.1.1 - example
+        # ######## Neuralynx Data File Header
+        # and then properties
+        # -OriginalFileName D:\Pegasus Data\Dr_NM\1902\2019-06-28_17-36-50\Events_0008.nev
+        # -TimeCreated 2019/06/28 17:36:50
+        # -TimeClosed 2019/06/28 17:45:48
         "peg": dict(
             datetime1_regex=r"-TimeCreated (?P<date>\S+) (?P<time>\S+)",
             datetime2_regex=r"-TimeClosed (?P<date>\S+) (?P<time>\S+)",

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -277,8 +277,8 @@ class NlxHeader(OrderedDict):
         # ## Date Opened: (mm/dd/yyy): 12/14/2015 At Time: 15:58:32
         # ## Date Closed: (mm/dd/yyy): 12/14/2015 At Time: 15:58:32
         "neuraview2": dict(
-            datetime1_regex=r"## Date Opened: \(mm/dd/yyy\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
-            datetime2_regex=r"## Date Closed: \(mm/dd/yyy\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
+            datetime1_regex=r"## (Time|Date) Opened: \((m/d/y|mm/dd/yyy)\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
+            datetime2_regex=r"## (Time|Date) Closed: \((m/d/y|mm/dd/yyy)\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
             datetimeformat="%m/%d/%Y %H:%M:%S",
         ),
         # pegasus version 2.1.1 and Cheetah beyond version 5.6.4 - example
@@ -300,8 +300,8 @@ class NlxHeader(OrderedDict):
         ),
         # version with time open and closed in ## header lines
         "openClosedInHeader": dict(
-           datetime1_regex=r"## Time Opened \(m/d/y\): (?P<date>\S+)" r"  (\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
-           datetime2_regex=r"## Time Closed \(m/d/y\): (?P<date>\S+)" r"  (\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
+           datetime1_regex=r"## (Time|Date) Opened \(m/d/y\): (?P<date>\S+)" r"  (\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
+           datetime2_regex=r"## (Time|Date) Closed \(m/d/y\): (?P<date>\S+)" r"  (\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
            datetimeformat="%m/%d/%Y %H:%M:%S.%f",
         )
     }

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -97,18 +97,6 @@ class NlxHeader(OrderedDict):
         if not props_only:
             self.readTimeDate(txt_header)
 
-    @staticmethod
-    def build_with_properties_only(filename):
-        """
-        Builds a version of the header without time and date or other validity checking.
-
-        Intended mostly for utilities but may also be useful for some recalcitrant header formats.
-
-        :param filename: name of Neuralynx file.
-        :return: NlxHeader with properties from header text
-        """
-        res = OrderedDict()
-
     def read_properties(self, filename, txt_header):
         """
         Read properties from header and place in OrderedDictionary which this object is.

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -206,7 +206,7 @@ class NlxHeader(OrderedDict):
     # Filename and datetime may appear in header lines starting with # at
     # beginning of header or in later versions as a property. The exact format
     # used depends on the application name and its version as well as the
-    # -FileVersion property.
+    # -FileVersion property. Examples of each known case are shown below in comments.
     #
     # There are 4 styles understood by this code and the patterns used for parsing
     # the items within each are stored in a dictionary. Each dictionary is then
@@ -277,8 +277,10 @@ class NlxHeader(OrderedDict):
         # ## Date Opened: (mm/dd/yyy): 12/14/2015 At Time: 15:58:32
         # ## Date Closed: (mm/dd/yyy): 12/14/2015 At Time: 15:58:32
         "neuraview2": dict(
-            datetime1_regex=r"## (Time|Date) Opened: \((m/d/y|mm/dd/yyy)\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
-            datetime2_regex=r"## (Time|Date) Closed: \((m/d/y|mm/dd/yyy)\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
+            datetime1_regex=r"## (Time|Date) Opened:* \((m/d/y|mm/dd/yyy)\): (?P<date>\S+)" \
+                             r" At Time: (?P<time>\S+)",
+            datetime2_regex=r"## (Time|Date) Closed:* \((m/d/y|mm/dd/yyy)\): (?P<date>\S+)" \
+                             r" At Time: (?P<time>\S+)",
             datetimeformat="%m/%d/%Y %H:%M:%S",
         ),
         # pegasus version 2.1.1 and Cheetah beyond version 5.6.4 - example
@@ -300,8 +302,10 @@ class NlxHeader(OrderedDict):
         ),
         # version with time open and closed in ## header lines
         "openClosedInHeader": dict(
-           datetime1_regex=r"## (Time|Date) Opened \(m/d/y\): (?P<date>\S+)" r"  (\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
-           datetime2_regex=r"## (Time|Date) Closed \(m/d/y\): (?P<date>\S+)" r"  (\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
+           datetime1_regex=r"## (Time|Date) Opened:* \(m/d/y\): (?P<date>\S+)" \
+                            r"  (\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
+           datetime2_regex=r"## (Time|Date) Closed:* \(m/d/y\): (?P<date>\S+)" \
+                            r"  (\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
            datetimeformat="%m/%d/%Y %H:%M:%S.%f",
         )
     }
@@ -347,6 +351,9 @@ class NlxHeader(OrderedDict):
             hpd = NlxHeader.header_pattern_dicts["inProps"]
 
         # opening time
+        # :TODO: Processing for this and close time should be changed to not depend on storing
+        # in a particular formatted string by header type, but rather always should be
+        # formatted in one standard way. 
         sr = re.search(hpd["datetime1_regex"], txt_header)
         if not sr:
             raise IOError(

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -4,6 +4,8 @@ import os
 import re
 from collections import OrderedDict
 
+from neo.rawio.neuralynxrawio.ncssections import AcqType
+
 
 class NlxHeader(OrderedDict):
     """
@@ -345,52 +347,50 @@ class NlxHeader(OrderedDict):
         """
         Determines type of recording in Ncs file with this header.
 
-        RETURN:
-            one of 'PRE4','BML','DIGITALLYNX','DIGITALLYNXSX','CHEETAH64', 'RAWDATAFILE',
-            'CHEETAH560', 'UNKNOWN'
+        RETURN: NcsSections.AcqType
         """
 
         if "NLX_Base_Class_Type" in self:
 
             # older style standard neuralynx acquisition with rounded sampling frequency
             if self["NLX_Base_Class_Type"] == "CscAcqEnt":
-                return "PRE4"
+                return AcqType.PRE4
 
             # BML style with fractional frequency and microsPerSamp
             elif self["NLX_Base_Class_Type"] == "BmlAcq":
-                return "BML"
+                return AcqType.BML
 
             else:
-                return "UNKNOWN"
+                return AcqType.UNKNOWN
 
         elif "HardwareSubSystemType" in self:
 
             # DigitalLynx
             if self["HardwareSubSystemType"] == "DigitalLynx":
-                return "DIGITALLYNX"
+                return AcqType.DIGITALLYNX
 
             # DigitalLynxSX
             elif self["HardwareSubSystemType"] == "DigitalLynxSX":
-                return "DIGITALLYNXSX"
+                return AcqType.DIGITALLYNXSX
 
             # Cheetah64
             elif self["HardwareSubSystemType"] == "Cheetah64":
-                return "CHEETAH64"
+                return AcqType.CHEETAH64
 
             # RawDataFile
             elif self["HardwareSubSystemType"] == "RawDataFile":
-                return "RAWDATAFILE"
+                return AcqType.RAWDATAFILE
 
             else:
-                return "UNKNOWN"
+                return AcqType.UNKNOWN
 
         elif "FileType" in self:
 
             if "FileVersion" in self and self["FileVersion"] in ["3.2", "3.3", "3.4"]:
-                return self["AcquisitionSystem"].split()[1].upper()
+                return AcqType[self["AcquisitionSystem"].split()[1].upper()]
 
             else:
-                return "CHEETAH560"  # only known case of FileType without FileVersion
+                return AcqType.CHEETAH560  # only known case of FileType without FileVersion
 
         else:
-            return "UNKNOWN"
+            return AcqType.UNKNOWN

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -1,4 +1,3 @@
-import datetime
 import dateutil
 from packaging.version import Version
 import os
@@ -176,9 +175,8 @@ class NlxHeader(OrderedDict):
         :param props_only: if true, will not try and read time and date or check start
         """
         super(OrderedDict, self).__init__()
-        with open(filename, "rb") as f:
-            txt_header = f.read(NlxHeader.HEADER_SIZE)
-        txt_header = txt_header.strip(b"\x00").decode("latin-1")
+
+        txt_header = NlxHeader.get_text_header(filename)
 
         # must start with 8 # characters
         if not props_only and not txt_header.startswith("########"):
@@ -193,6 +191,16 @@ class NlxHeader(OrderedDict):
 
         if not props_only:
             self.readTimeDate(txt_header)
+
+    @staticmethod
+    def get_text_header(filename):
+        """
+        Accessory method to extract text in header. Useful for subclasses.
+        :param filename: name of Neuralynx file
+        """
+        with open(filename, "rb") as f:
+            txt_header = f.read(NlxHeader.HEADER_SIZE)
+        return txt_header.strip(b"\x00").decode("latin-1")
 
     def read_properties(self, filename, txt_header):
         """

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -16,7 +16,7 @@ class NlxHeader(OrderedDict):
     of the key value as well as an 'ApplicationName', 'ApplicationVersion', 'recording_opened'
     and 'recording_closed' entries. The 'InputRange', 'channel_ids', 'channel_names' and
     'bit_to_microvolt' properties are set to lists of entries for each channel which may be
-    in the file.  
+    in the file.
     """
 
     HEADER_SIZE = 2**14  # Neuralynx files have a txt header of 16kB
@@ -226,11 +226,7 @@ class NlxHeader(OrderedDict):
         # ## File Name F:\2000-01-01_18-28-39\RMH3.ncs
         # ## Time Opened (m/d/y): 1/1/2000  (h:m:s.ms) 18:28:39.821
         # ## Time Closed (m/d/y): 1/1/2000  (h:m:s.ms) 9:58:41.322
-        "bv5": dict(
-            datetime1_regex=r"## Time Opened: \(m/d/y\): (?P<date>\S+)" r"  At Time: (?P<time>\S+)",
-            filename_regex=r"## File Name: (?P<filename>\S+)",
-            datetimeformat="%m/%d/%Y %H:%M:%S.%f",
-        ),
+
         # Cheetah version 4.0.2 - example
         # ######## Neuralynx Data File Header
         # ## File Name: D:\Cheetah_Data\2003-10-4_10-2-58\CSC14.Ncs
@@ -256,11 +252,7 @@ class NlxHeader(OrderedDict):
         # Cheetah version 5.6.0 - example
         # ## File Name: F:\processing\sum-big-board\252-1375\recording-20180107\2018-01-07_15-14-54\04. tmaze1-no-light-start To tmaze1-light-stop\VT1_fixed.nvt
         # ## Time Opened: (m/d/y): 2/5/2018 At Time: 18:5:12.654
-        "v5.6.0": dict(
-            datetime1_regex=r"## Time Opened: \(m/d/y\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
-            filename_regex=r"## File Name: (?P<filename>\S+)",
-            datetimeformat="%m/%d/%Y %H:%M:%S.%f",
-        ),
+
         # Cheetah version 5.6.3 - example
         # ######## Neuralynx Data File Header
         # ## File Name C:\CheetahData\2016-11-28_21-50-00\CSC1.ncs
@@ -320,6 +312,11 @@ class NlxHeader(OrderedDict):
             datetimeformat=r"%Y/%m/%d %H:%M:%S",
             datetime2format=r"%Y/%m/%d %H:%M:%S.%f",
         ),
+        # general version for in date and time in ## header lines
+        "inHeader": dict(
+            datetime1_regex=r"## Time Opened: \(m/d/y\): (?P<date>\S+)" r"  At Time: (?P<time>\S+)",
+            datetimeformat="%m/%d/%y %H:%M:%S.%f",
+        )
     }
 
     def readTimeDate(self, txt_header):
@@ -335,17 +332,17 @@ class NlxHeader(OrderedDict):
             if av <= Version("2"):  # version 1 uses same as older versions
                 hpd = NlxHeader.header_pattern_dicts["bv5.6.4"]
             elif av < Version("5"):
-                hpd = NlxHeader.header_pattern_dicts["bv5"]
+                hpd = NlxHeader.header_pattern_dicts["inHeader"]
             elif av <= Version("5.4.0"):
                 hpd = NlxHeader.header_pattern_dicts["v5.4.0"]
             elif av == Version("5.6.0"):
-                hpd = NlxHeader.header_pattern_dicts["v5.6.0"]
+                hpd = NlxHeader.header_pattern_dicts["inHeader"]
             elif av <= Version("5.6.4"):
                 hpd = NlxHeader.header_pattern_dicts["bv5.6.4"]
             else:
                 hpd = NlxHeader.header_pattern_dicts["inProps"]
         elif an == "BML":
-            hpd = NlxHeader.header_pattern_dicts["bml"]
+            hpd = NlxHeader.header_pattern_dicts["inHeader"]
             av = Version("2")
         elif an == "Neuraview":
             hpd = NlxHeader.header_pattern_dicts["neuraview2"]

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -233,12 +233,7 @@ class NlxHeader(OrderedDict):
         # ## File Name C:\CheetahData\2000-01-01_00-00-00\CSC5.ncs
         # ## Time Opened (m/d/y): 1/01/2001  At Time: 0:00:00.000
         # ## Time Closed (m/d/y): 1/01/2001  At Time: 00:00:00.000
-        "v5.4.0": dict(
-            datetime1_regex=r"## Time Opened \(m/d/y\): (?P<date>\S+)" r"  At Time: (?P<time>\S+)",
-            datetime2_regex=r"## Time Closed \(m/d/y\): (?P<date>\S+)" r"  At Time: (?P<time>\S+)",
-            filename_regex=r"## File Name: (?P<filename>\S+)",
-            datetimeformat="%m/%d/%Y %H:%M:%S.%f",
-        ),
+
         # Cheetah version 5.5.1 - example
         # ######## Neuralynx Data File Header
         # ## File Name C:\CheetahData\2013-11-29_17-05-05\Tet3a.ncs
@@ -284,7 +279,6 @@ class NlxHeader(OrderedDict):
         "neuraview2": dict(
             datetime1_regex=r"## Date Opened: \(mm/dd/yyy\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
             datetime2_regex=r"## Date Closed: \(mm/dd/yyy\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
-            filename_regex=r"## File Name: (?P<filename>\S+)",
             datetimeformat="%m/%d/%Y %H:%M:%S",
         ),
         # pegasus version 2.1.1 and Cheetah beyond version 5.6.4 - example
@@ -296,7 +290,6 @@ class NlxHeader(OrderedDict):
         "inProps": dict(
             datetime1_regex=r"-TimeCreated (?P<date>\S+) (?P<time>\S+)",
             datetime2_regex=r"-TimeClosed (?P<date>\S+) (?P<time>\S+)",
-            filename_regex=r'-OriginalFileName "?(?P<filename>\S+)"?',
             datetimeformat=r"%Y/%m/%d %H:%M:%S",
             datetime2format=r"%Y/%m/%d %H:%M:%S.%f",
         ),
@@ -306,14 +299,17 @@ class NlxHeader(OrderedDict):
             datetimeformat="%m/%d/%y %H:%M:%S.%f",
         ),
         # version with time open and closed in ## header lines
-       "openClosedInHeader": dict(
-           datetime1_regex=r"## Time Opened \(m/d/y\): (?P<date>\S+)" r"  \(h:m:s\.ms\) (?P<time>\S+)",
-           datetime2_regex=r"## Time Closed \(m/d/y\): (?P<date>\S+)" r"  \(h:m:s\.ms\) (?P<time>\S+)",
-           filename_regex=r"## File Name (?P<filename>\S+)",
+        "openClosedInHeader": dict(
+           datetime1_regex=r"## Time Opened \(m/d/y\): (?P<date>\S+)" r"  (\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
+           datetime2_regex=r"## Time Closed \(m/d/y\): (?P<date>\S+)" r"  (\(h:m:s\.ms\)|At Time:) (?P<time>\S+)",
            datetimeformat="%m/%d/%Y %H:%M:%S.%f",
-       )
+        )
     }
 
+    # regular expressions to match filename
+    filename_regex = [r"## File Name (?P<filename>\S+)",
+                       r'-OriginalFileName "?(?P<filename>\S+)"?']
+    
     def readTimeDate(self, txt_header):
         """
         Read time and date from text of header appropriate for app name and version
@@ -329,7 +325,7 @@ class NlxHeader(OrderedDict):
             elif av < Version("5"):
                 hpd = NlxHeader.header_pattern_dicts["inHeader"]
             elif av <= Version("5.4.0"):
-                hpd = NlxHeader.header_pattern_dicts["v5.4.0"]
+                hpd = NlxHeader.header_pattern_dicts["openClosedInHeader"]
             elif av == Version("5.6.0"):
                 hpd = NlxHeader.header_pattern_dicts["inHeader"]
             elif av <= Version("5.6.4"):

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -300,25 +300,18 @@ class NlxHeader(OrderedDict):
             filename_regex=r"## File Name: (?P<filename>\S+)",
             datetimeformat="%m/%d/%Y %H:%M:%S",
         ),
-        # pegasus version 2.1.1 - example
+        # pegasus version 2.1.1 and Cheetah beyond version 5.6.4 - example
         # ######## Neuralynx Data File Header
         # and then properties
         # -OriginalFileName D:\Pegasus Data\Dr_NM\1902\2019-06-28_17-36-50\Events_0008.nev
         # -TimeCreated 2019/06/28 17:36:50
         # -TimeClosed 2019/06/28 17:45:48
-        "peg": dict(
+        "inProps": dict(
             datetime1_regex=r"-TimeCreated (?P<date>\S+) (?P<time>\S+)",
             datetime2_regex=r"-TimeClosed (?P<date>\S+) (?P<time>\S+)",
             filename_regex=r'-OriginalFileName "?(?P<filename>\S+)"?',
             datetimeformat=r"%Y/%m/%d %H:%M:%S",
             datetime2format=r"%Y/%m/%d %H:%M:%S.%f",
-        ),
-        # Cheetah after v 5.6.4 and default for others such as Pegasus
-        "def": dict(
-            datetime1_regex=r"-TimeCreated (?P<date>\S+) (?P<time>\S+)",
-            datetime2_regex=r"-TimeClosed (?P<date>\S+) (?P<time>\S+)",
-            filename_regex=r'-OriginalFileName "?(?P<filename>\S+)"?',
-            datetimeformat="%Y/%m/%d %H:%M:%S",
         ),
     }
 
@@ -343,7 +336,7 @@ class NlxHeader(OrderedDict):
             elif av <= Version("5.6.4"):
                 hpd = NlxHeader.header_pattern_dicts["bv5.6.4"]
             else:
-                hpd = NlxHeader.header_pattern_dicts["def"]
+                hpd = NlxHeader.header_pattern_dicts["inProps"]
         elif an == "BML":
             hpd = NlxHeader.header_pattern_dicts["bml"]
             av = Version("2")
@@ -351,12 +344,13 @@ class NlxHeader(OrderedDict):
             hpd = NlxHeader.header_pattern_dicts["neuraview2"]
             av = Version("2")
         elif an == "Pegasus":
-            hpd = NlxHeader.header_pattern_dicts["peg"]
+            hpd = NlxHeader.header_pattern_dicts["inProps"]
             av = Version("2")
         else:
             an = "Unknown"
             av = "NA"
-            hpd = NlxHeader.header_pattern_dicts["def"]
+            hpd = NlxHeader.header_pattern_dicts["inProps"]
+
         # opening time
         sr = re.search(hpd["datetime1_regex"], txt_header)
         if not sr:

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -70,7 +70,6 @@ class NlxHeader(OrderedDict):
         ("NLX_Base_Class_Type", "", None),  # in version 4 and earlier versions of Cheetah
     ]
 
-
     def __init__(self, filename, props_only=False):
         """
         Factory function to build NlxHeader for a given file.
@@ -89,7 +88,7 @@ class NlxHeader(OrderedDict):
 
         self.read_properties(filename, txt_header)
         numChidEntries = self.convert_channel_ids_names(filename)
-        self.setApplicationAndVersion(txt_header)
+        self.setApplicationAndVersion()
         self.setBitToMicroVolt()
         self.setInputRanges(numChidEntries)
 
@@ -148,7 +147,7 @@ class NlxHeader(OrderedDict):
             assert len(self["bit_to_microVolt"]) == len( self["channel_ids"]), \
                 "Number of channel ids does not match bit_to_microVolt conversion factors."
 
-    def setApplicationAndVersion(self, txt_header):
+    def setApplicationAndVersion(self):
         """
         Set "ApplicationName" property and app_version attribute based on existing properties
         """
@@ -164,7 +163,7 @@ class NlxHeader(OrderedDict):
             assert len(match) == 1, "impossible to find application name and version"
             self["ApplicationName"], app_version = match[0]
         # BML Ncs file contain neither property, but 'NLX_Base_Class_Type'
-        elif "NLX_Base_Class_Type" in txt_header:
+        elif "NLX_Base_Class_Type" in self:
             self["ApplicationName"] = "BML"
             app_version = "2.0"
         # Neuraview Ncs file contained neither property nor NLX_Base_Class_Type information
@@ -347,7 +346,8 @@ class NlxHeader(OrderedDict):
         Determines type of recording in Ncs file with this header.
 
         RETURN:
-            one of 'PRE4','BML','DIGITALLYNX','DIGITALLYNXSX','UNKNOWN'
+            one of 'PRE4','BML','DIGITALLYNX','DIGITALLYNXSX','CHEETAH64', 'RAWDATAFILE',
+            'CHEETAH560', 'UNKNOWN'
         """
 
         if "NLX_Base_Class_Type" in self:

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -216,11 +216,7 @@ class NlxHeader(OrderedDict):
         # ######## Neuralynx Data File Header
         # ## File Name: null
         # ## Time Opened: (m/d/y): 12/11/15  At Time: 11:37:39.000
-        "bml": dict(
-            datetime1_regex=r"## Time Opened: \(m/d/y\): (?P<date>\S+)" r"  At Time: (?P<time>\S+)",
-            filename_regex=r"## File Name: (?P<filename>\S+)",
-            datetimeformat="%m/%d/%y %H:%M:%S.%f",
-        ),
+
         # Cheetah after version 1 and before version 5 - example
         # ######## Neuralynx Data File Header
         # ## File Name F:\2000-01-01_18-28-39\RMH3.ncs
@@ -258,14 +254,6 @@ class NlxHeader(OrderedDict):
         # ## File Name C:\CheetahData\2016-11-28_21-50-00\CSC1.ncs
         # ## Time Opened (m/d/y): 11/28/2016  (h:m:s.ms) 21:50:33.322
         # ## Time Closed (m/d/y): 11/28/2016  (h:m:s.ms) 22:44:41.145
-
-        # Cheetah version 5 before and including v 5.6.4 as well as version 1
-        "bv5.6.4": dict(
-            datetime1_regex=r"## Time Opened \(m/d/y\): (?P<date>\S+)" r"  \(h:m:s\.ms\) (?P<time>\S+)",
-            datetime2_regex=r"## Time Closed \(m/d/y\): (?P<date>\S+)" r"  \(h:m:s\.ms\) (?P<time>\S+)",
-            filename_regex=r"## File Name (?P<filename>\S+)",
-            datetimeformat="%m/%d/%Y %H:%M:%S.%f",
-        ),
 
         # Cheetah version 5.7.4 - example
         # ######## Neuralynx Data File Header
@@ -312,11 +300,18 @@ class NlxHeader(OrderedDict):
             datetimeformat=r"%Y/%m/%d %H:%M:%S",
             datetime2format=r"%Y/%m/%d %H:%M:%S.%f",
         ),
-        # general version for in date and time in ## header lines
+        # general version for date and time in ## header lines
         "inHeader": dict(
             datetime1_regex=r"## Time Opened: \(m/d/y\): (?P<date>\S+)" r"  At Time: (?P<time>\S+)",
             datetimeformat="%m/%d/%y %H:%M:%S.%f",
-        )
+        ),
+        # version with time open and closed in ## header lines
+       "openClosedInHeader": dict(
+           datetime1_regex=r"## Time Opened \(m/d/y\): (?P<date>\S+)" r"  \(h:m:s\.ms\) (?P<time>\S+)",
+           datetime2_regex=r"## Time Closed \(m/d/y\): (?P<date>\S+)" r"  \(h:m:s\.ms\) (?P<time>\S+)",
+           filename_regex=r"## File Name (?P<filename>\S+)",
+           datetimeformat="%m/%d/%Y %H:%M:%S.%f",
+       )
     }
 
     def readTimeDate(self, txt_header):
@@ -330,7 +325,7 @@ class NlxHeader(OrderedDict):
         if an == "Cheetah":
             av = self["ApplicationVersion"]
             if av <= Version("2"):  # version 1 uses same as older versions
-                hpd = NlxHeader.header_pattern_dicts["bv5.6.4"]
+                hpd = NlxHeader.header_pattern_dicts["openClosedInHeader"]
             elif av < Version("5"):
                 hpd = NlxHeader.header_pattern_dicts["inHeader"]
             elif av <= Version("5.4.0"):
@@ -338,7 +333,7 @@ class NlxHeader(OrderedDict):
             elif av == Version("5.6.0"):
                 hpd = NlxHeader.header_pattern_dicts["inHeader"]
             elif av <= Version("5.6.4"):
-                hpd = NlxHeader.header_pattern_dicts["bv5.6.4"]
+                hpd = NlxHeader.header_pattern_dicts["openClosedInHeader"]
             else:
                 hpd = NlxHeader.header_pattern_dicts["inProps"]
         elif an == "BML":

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -174,11 +174,11 @@ class TestNeuralynxRawIO(
         self.assertEqual(len(rawio.header["event_channels"]), 0)
 
 
-class TestNcsRecordingType(TestNeuralynxRawIO, unittest.TestCase):
+class TestNcsRecordingType(BaseTestRawIO, unittest.TestCase):
     """
     Test of decoding of NlxHeader for type of recording.
     """
-
+    rawioclass = NeuralynxRawIO
     entities_to_test = []
 
     ncsTypeTestFiles = [
@@ -202,11 +202,11 @@ class TestNcsRecordingType(TestNeuralynxRawIO, unittest.TestCase):
             self.assertEqual(hdr.type_of_recording(), typeTest[1])
 
 
-class TestNcsSectionsFactory(TestNeuralynxRawIO, unittest.TestCase):
+class TestNcsSectionsFactory(BaseTestRawIO, unittest.TestCase):
     """
     Test building NcsBlocks for files of different revisions.
     """
-
+    rawioclass = NeuralynxRawIO
     entities_to_test = []
 
     def test_ncsblocks_partial(self):
@@ -323,11 +323,11 @@ class TestNcsSectionsFactory(TestNeuralynxRawIO, unittest.TestCase):
         self.assertTrue(NcsSectionsFactory._verifySectionsStructure(data1, nb1))
 
 
-class TestNcsSections(TestNeuralynxRawIO, unittest.TestCase):
+class TestNcsSections(BaseTestRawIO, unittest.TestCase):
     """
     Test building NcsBlocks for files of different revisions.
     """
-
+    rawioclass = NeuralynxRawIO
     entities_to_test = []
 
     def test_equality(self):
@@ -360,7 +360,9 @@ class TestNcsSections(TestNeuralynxRawIO, unittest.TestCase):
         ns0.sampFreqUsed = 400
         self.assertNotEqual(ns0, ns1)
 
-class TestNlxHeader(TestNeuralynxRawIO, unittest.TestCase):
+class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
+    rawioclass = NeuralynxRawIO
+
     def test_no_date_time(self):
         filename = self.get_local_path("neuralynx/NoDateHeader/NoDateHeader.nev")
 

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -386,10 +386,6 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         self.assertEqual(datetime.datetime(2015,12,14, 15,58,32), hdr['recording_closed'])
 
     # left in for possible future header tests
-    def get_text_header(self, filename):
-        with open(filename, "rb") as f:
-            txt_header = f.read(NlxHeader.HEADER_SIZE)
-        return txt_header.strip(b"\x00").decode("latin-1")
 
     # left in for possible future header tests
     def check_dateutil_parse(self, hdrTxt, openPat, closePat, openDate, closeDate):
@@ -408,7 +404,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
     def test_datetime_parsing(self):
         # neuraview2
         filename = self.get_local_path("neuralynx/Neuraview_v2/original_data/NeuraviewEventMarkers-sample.nev")
-        txt_header = self.get_text_header(filename)
+        txt_header = NlxHeader.get_text_header(filename)
         self.check_dateutil_parse(txt_header, NlxHeader.openDatetime1_pat, NlxHeader.closeDatetime1_pat,
                                   datetime.datetime(2015,12,14, 15,58,32),
                                   datetime.datetime(2015,12,14, 15,58,32))
@@ -420,7 +416,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
 
         # Cheetah 5.7.4 'inProps'
         filename = self.get_local_path("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs")
-        txt_header = self.get_text_header(filename)
+        txt_header = NlxHeader.get_text_header(filename)
         self.check_dateutil_parse(txt_header, NlxHeader.openDatetime2_pat, NlxHeader.closeDatetime2_pat,
                                   datetime.datetime(2017,2,16, 17,56,4),
                                   datetime.datetime(2017,2,16, 18,1,18))
@@ -432,7 +428,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
 
         # Cheetah 4.0.2
         filename = self.get_local_path("neuralynx/Cheetah_v4.0.2/original_data/CSC14_trunc.Ncs")
-        txt_header = self.get_text_header(filename)
+        txt_header = NlxHeader.get_text_header(filename)
         self.check_dateutil_parse(txt_header, NlxHeader.openDatetime1_pat, None,
                                   datetime.datetime(2003,10,4, 10,3,0, 578000),
                                   None)
@@ -443,7 +439,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
 
         # Cheetah 5.4.0 'openClosedInHeader'
         filename = self.get_local_path("neuralynx/Cheetah_v5.4.0/original_data/CSC5_trunc.Ncs")
-        txt_header = self.get_text_header(filename)
+        txt_header = NlxHeader.get_text_header(filename)
         self.check_dateutil_parse(txt_header, NlxHeader.openDatetime1_pat, NlxHeader.closeDatetime1_pat,
                                   datetime.datetime(2001,1,1, 0,0,0, 0),
                                   datetime.datetime(2001,1,1, 0,0,0, 0))

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -405,7 +405,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         # neuraview2
         filename = self.get_local_path("neuralynx/Neuraview_v2/original_data/NeuraviewEventMarkers-sample.nev")
         txt_header = NlxHeader.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, NlxHeader.openDatetime1_pat, NlxHeader.closeDatetime1_pat,
+        self.check_dateutil_parse(txt_header, NlxHeader._openDatetime1_pat, NlxHeader._closeDatetime1_pat,
                                   datetime.datetime(2015,12,14, 15,58,32),
                                   datetime.datetime(2015,12,14, 15,58,32))
         hdr = NlxHeader(filename)
@@ -417,7 +417,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         # Cheetah 5.7.4 'inProps'
         filename = self.get_local_path("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs")
         txt_header = NlxHeader.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, NlxHeader.openDatetime2_pat, NlxHeader.closeDatetime2_pat,
+        self.check_dateutil_parse(txt_header, NlxHeader._openDatetime2_pat, NlxHeader._closeDatetime2_pat,
                                   datetime.datetime(2017,2,16, 17,56,4),
                                   datetime.datetime(2017,2,16, 18,1,18))
         hdr = NlxHeader(filename)
@@ -429,7 +429,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         # Cheetah 4.0.2
         filename = self.get_local_path("neuralynx/Cheetah_v4.0.2/original_data/CSC14_trunc.Ncs")
         txt_header = NlxHeader.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, NlxHeader.openDatetime1_pat, None,
+        self.check_dateutil_parse(txt_header, NlxHeader._openDatetime1_pat, None,
                                   datetime.datetime(2003,10,4, 10,3,0, 578000),
                                   None)
         hdr = NlxHeader(filename)
@@ -440,7 +440,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         # Cheetah 5.4.0 'openClosedInHeader'
         filename = self.get_local_path("neuralynx/Cheetah_v5.4.0/original_data/CSC5_trunc.Ncs")
         txt_header = NlxHeader.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, NlxHeader.openDatetime1_pat, NlxHeader.closeDatetime1_pat,
+        self.check_dateutil_parse(txt_header, NlxHeader._openDatetime1_pat, NlxHeader._closeDatetime1_pat,
                                   datetime.datetime(2001,1,1, 0,0,0, 0),
                                   datetime.datetime(2001,1,1, 0,0,0, 0))
         hdr = NlxHeader(filename)

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from neo.rawio.neuralynxrawio.neuralynxrawio import NeuralynxRawIO
 from neo.rawio.neuralynxrawio.nlxheader import NlxHeader
-from neo.rawio.neuralynxrawio.ncssections import NcsSection, NcsSections, NcsSectionsFactory
+from neo.rawio.neuralynxrawio.ncssections import AcqType, NcsSection, NcsSections, NcsSectionsFactory
 from neo.test.rawiotest.common_rawio_test import BaseTestRawIO
 
 import logging
@@ -182,15 +182,15 @@ class TestNcsRecordingType(TestNeuralynxRawIO, unittest.TestCase):
     entities_to_test = []
 
     ncsTypeTestFiles = [
-        ("neuralynx/Cheetah_v4.0.2/original_data/CSC14_trunc.Ncs", "PRE4"),
-        ("neuralynx/Cheetah_v5.4.0/original_data/CSC5_trunc.Ncs", "DIGITALLYNX"),
-        ("neuralynx/Cheetah_v5.5.1/original_data/STet3a.nse", "DIGITALLYNXSX"),
-        ("neuralynx/Cheetah_v5.5.1/original_data/Tet3a.ncs", "DIGITALLYNXSX"),
-        ("neuralynx/Cheetah_v5.6.3/original_data/CSC1.ncs", "DIGITALLYNXSX"),
-        ("neuralynx/Cheetah_v5.6.3/original_data/TT1.ntt", "DIGITALLYNXSX"),
-        ("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs", "DIGITALLYNXSX"),
-        ("neuralynx/Cheetah_v6.3.2/incomplete_blocks/CSC1_reduced.ncs", "DIGITALLYNXSX"),
-        ("neuralynx/Pegasus_v2.1.1/Events_0008.nev", "ATLAS"),
+        ("neuralynx/Cheetah_v4.0.2/original_data/CSC14_trunc.Ncs", AcqType.PRE4),
+        ("neuralynx/Cheetah_v5.4.0/original_data/CSC5_trunc.Ncs", AcqType.DIGITALLYNX),
+        ("neuralynx/Cheetah_v5.5.1/original_data/STet3a.nse", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Cheetah_v5.5.1/original_data/Tet3a.ncs", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Cheetah_v5.6.3/original_data/CSC1.ncs", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Cheetah_v5.6.3/original_data/TT1.ntt", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Cheetah_v6.3.2/incomplete_blocks/CSC1_reduced.ncs", AcqType.DIGITALLYNXSX),
+        ("neuralynx/Pegasus_v2.1.1/Events_0008.nev", AcqType.ATLAS),
     ]
 
     def test_recording_types(self):
@@ -375,12 +375,3 @@ class TestNlxHeader(TestNeuralynxRawIO, unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-    # test = TestNeuralynxRawIO()
-    # test.test_scan_ncs_files()
-    # test.test_exclude_filenames()
-    # test.test_include_filenames()
-
-    # test = TestNcsSectionsFactory()
-    # test.test_ncsblocks_partial()
-    # test.test_build_given_actual_frequency()

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -199,7 +199,6 @@ class TestNcsRecordingType(BaseTestRawIO, unittest.TestCase):
     def test_recording_types(self):
 
         for typeTest in self.ncsTypeTestFiles:
-
             filename = self.get_local_path(typeTest[0])
             hdr = NlxHeader(filename)
             self.assertEqual(hdr.type_of_recording(), typeTest[1])
@@ -363,6 +362,7 @@ class TestNcsSections(BaseTestRawIO, unittest.TestCase):
         ns0.sampFreqUsed = 400
         self.assertNotEqual(ns0, ns1)
 
+
 class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
     rawioclass = NeuralynxRawIO
 
@@ -406,7 +406,6 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
             self.assertEqual(closeDate, date)
 
     def test_datetime_parsing(self):
-
         # neuraview2
         filename = self.get_local_path("neuralynx/Neuraview_v2/original_data/NeuraviewEventMarkers-sample.nev")
         txt_header = self.get_text_header(filename)
@@ -453,6 +452,32 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
                          hdr['recording_opened'])
         self.assertEqual(datetime.datetime(2001,1,1, 0,0,0, 0),
                          hdr['recording_closed'])
+
+    def test_filename_prop(self):
+        # neuraview2
+        filename = self.get_local_path("neuralynx/Neuraview_v2/original_data/NeuraviewEventMarkers-sample.nev")
+        hdr = NlxHeader(filename)
+        self.assertEqual(r"L:\McHugh Lab\Recording\2015-06-24_18-05-11\NeuraviewEventMarkers-20151214_SleepScore.nev",
+                         hdr['OriginalFileName'])
+
+        # Cheetah 5.7.4 'inProps'
+        filename = self.get_local_path("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs")
+        hdr = NlxHeader(filename)
+        self.assertEqual(r'C:\CheetahData\2017-02-16_17-55-55\CSC1.ncs',
+                         hdr['OriginalFileName'])
+
+        # Cheetah 4.0.2
+        filename = self.get_local_path("neuralynx/Cheetah_v4.0.2/original_data/CSC14_trunc.Ncs")
+        hdr = NlxHeader(filename)
+        self.assertEqual(r'D:\Cheetah_Data\2003-10-4_10-2-58\CSC14.Ncs',
+                         hdr['OriginalFileName'])
+
+        # Cheetah 5.4.0
+        filename = self.get_local_path("neuralynx/Cheetah_v5.4.0/original_data/CSC5_trunc.Ncs")
+        hdr = NlxHeader(filename)
+        self.assertEqual(r'C:\CheetahData\2000-01-01_00-00-00\CSC5.ncs',
+                         hdr['OriginalFileName'])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -392,13 +392,15 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
 
     def check_dateutil_parse(self, hdrTxt, hdrPatternName, openDate, closeDate):
         hpd = NlxHeader.header_pattern_dicts[hdrPatternName]
-        mtch = re.search(hpd["datetime1_regex"], hdrTxt)
+        mtch = re.search(hpd["openDatetime1_regex"], hdrTxt)
+        if mtch is None: mtch = re.search(hpd["openDatetime2_regex"], hdrTxt)
         self.assertIsNotNone(mtch)
         dt = mtch.groupdict()
         date = dateutil.parser.parse(f"{dt['date']} {dt['time']}")
         self.assertEqual(openDate, date)
         if closeDate is not None:
-            mtch = re.search(hpd["datetime2_regex"], hdrTxt)
+            mtch = re.search(hpd["closeDatetime1_regex"], hdrTxt)
+            if mtch is None: mtch = re.search(hpd["closeDatetime2_regex"], hdrTxt)
             self.assertIsNotNone(mtch)
             dt = mtch.groupdict()
             date = dateutil.parser.parse(f"{dt['date']} {dt['time']}")
@@ -406,10 +408,10 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
 
     def test_datetime_parsing(self):
 
-        # neuraview2 'neuraview2'
+        # neuraview2
         filename = self.get_local_path("neuralynx/Neuraview_v2/original_data/NeuraviewEventMarkers-sample.nev")
         txt_header = self.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, 'neuraview2',
+        self.check_dateutil_parse(txt_header, 'combined',
                                   datetime.datetime(2015,12,14, 15,58,32),
                                   datetime.datetime(2015,12,14, 15,58,32))
         hdr = NlxHeader(filename)
@@ -421,7 +423,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         # Cheetah 5.7.4 'inProps'
         filename = self.get_local_path("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs")
         txt_header = self.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, 'inProps',
+        self.check_dateutil_parse(txt_header, 'combined',
                                   datetime.datetime(2017,2,16, 17,56,4),
                                   datetime.datetime(2017,2,16, 18,1,18))
         hdr = NlxHeader(filename)
@@ -430,10 +432,10 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         self.assertEqual(datetime.datetime(2017,2,16, 18,1,18),
                          hdr['recording_closed'])
 
-        # Cheetah 4.0.2 'inHeader'
+        # Cheetah 4.0.2
         filename = self.get_local_path("neuralynx/Cheetah_v4.0.2/original_data/CSC14_trunc.Ncs")
         txt_header = self.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, 'inHeader',
+        self.check_dateutil_parse(txt_header, 'combined',
                                   datetime.datetime(2003,10,4, 10,3,0, 578000),
                                   None)
         hdr = NlxHeader(filename)
@@ -444,7 +446,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         # Cheetah 5.4.0 'openClosedInHeader'
         filename = self.get_local_path("neuralynx/Cheetah_v5.4.0/original_data/CSC5_trunc.Ncs")
         txt_header = self.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, 'openClosedInHeader',
+        self.check_dateutil_parse(txt_header, 'combined',
                                   datetime.datetime(2001,1,1, 0,0,0, 0),
                                   datetime.datetime(2001,1,1, 0,0,0, 0))
         hdr = NlxHeader(filename)
@@ -452,8 +454,6 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
                          hdr['recording_opened'])
         self.assertEqual(datetime.datetime(2001,1,1, 0,0,0, 0),
                          hdr['recording_closed'])
-
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -1,8 +1,10 @@
 import datetime
+import dateutil
 import unittest
 
 import os
 import numpy as np
+import re
 
 from neo.rawio.neuralynxrawio.neuralynxrawio import NeuralynxRawIO
 from neo.rawio.neuralynxrawio.nlxheader import NlxHeader
@@ -382,6 +384,76 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
 
         self.assertEqual(datetime.datetime(2015,12,14, 15,58,32), hdr['recording_opened'])
         self.assertEqual(datetime.datetime(2015,12,14, 15,58,32), hdr['recording_closed'])
+
+    def get_text_header(self, filename):
+        with open(filename, "rb") as f:
+            txt_header = f.read(NlxHeader.HEADER_SIZE)
+        return txt_header.strip(b"\x00").decode("latin-1")
+
+    def check_dateutil_parse(self, hdrTxt, hdrPatternName, openDate, closeDate):
+        hpd = NlxHeader.header_pattern_dicts[hdrPatternName]
+        mtch = re.search(hpd["datetime1_regex"], hdrTxt)
+        self.assertIsNotNone(mtch)
+        dt = mtch.groupdict()
+        date = dateutil.parser.parse(f"{dt['date']} {dt['time']}")
+        self.assertEqual(openDate, date)
+        if closeDate is not None:
+            mtch = re.search(hpd["datetime2_regex"], hdrTxt)
+            self.assertIsNotNone(mtch)
+            dt = mtch.groupdict()
+            date = dateutil.parser.parse(f"{dt['date']} {dt['time']}")
+            self.assertEqual(closeDate, date)
+
+    def test_datetime_parsing(self):
+
+        # neuraview2 'neuraview2'
+        filename = self.get_local_path("neuralynx/Neuraview_v2/original_data/NeuraviewEventMarkers-sample.nev")
+        txt_header = self.get_text_header(filename)
+        self.check_dateutil_parse(txt_header, 'neuraview2',
+                                  datetime.datetime(2015,12,14, 15,58,32),
+                                  datetime.datetime(2015,12,14, 15,58,32))
+        hdr = NlxHeader(filename)
+        self.assertEqual(datetime.datetime(2015,12,14, 15,58,32),
+                          hdr['recording_opened'])
+        self.assertEqual(datetime.datetime(2015,12,14, 15,58,32),
+                          hdr['recording_closed'])
+
+        # Cheetah 5.7.4 'inProps'
+        filename = self.get_local_path("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs")
+        txt_header = self.get_text_header(filename)
+        self.check_dateutil_parse(txt_header, 'inProps',
+                                  datetime.datetime(2017,2,16, 17,56,4),
+                                  datetime.datetime(2017,2,16, 18,1,18))
+        hdr = NlxHeader(filename)
+        self.assertEqual(datetime.datetime(2017,2,16, 17,56,4),
+                          hdr['recording_opened'])
+        self.assertEqual(datetime.datetime(2017,2,16, 18,1,18),
+                         hdr['recording_closed'])
+
+        # Cheetah 4.0.2 'inHeader'
+        filename = self.get_local_path("neuralynx/Cheetah_v4.0.2/original_data/CSC14_trunc.Ncs")
+        txt_header = self.get_text_header(filename)
+        self.check_dateutil_parse(txt_header, 'inHeader',
+                                  datetime.datetime(2003,10,4, 10,3,0, 578000),
+                                  None)
+        hdr = NlxHeader(filename)
+        self.assertEqual(datetime.datetime(2003,10,4, 10,3,0, 578000),
+                         hdr['recording_opened'])
+        self.assertIsNone(hdr.get('recording_closed'))
+
+        # Cheetah 5.4.0 'openClosedInHeader'
+        filename = self.get_local_path("neuralynx/Cheetah_v5.4.0/original_data/CSC5_trunc.Ncs")
+        txt_header = self.get_text_header(filename)
+        self.check_dateutil_parse(txt_header, 'openClosedInHeader',
+                                  datetime.datetime(2001,1,1, 0,0,0, 0),
+                                  datetime.datetime(2001,1,1, 0,0,0, 0))
+        hdr = NlxHeader(filename)
+        self.assertEqual(datetime.datetime(2001,1,1, 0,0,0, 0),
+                         hdr['recording_opened'])
+        self.assertEqual(datetime.datetime(2001,1,1, 0,0,0, 0),
+                         hdr['recording_closed'])
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 
 import os
@@ -374,6 +375,13 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         self.assertEqual(len(hdr), 11) # 9 properties plus channel_ids and channel_names
         self.assertEqual(hdr['ApplicationName'], 'Pegasus')
         self.assertEqual(hdr['FileType'], 'Event')
+
+    def test_neuraview2(self):
+        filename = self.get_local_path("neuralynx/Neuraview_v2/original_data/NeuraviewEventMarkers-sample.nev")
+        hdr = NlxHeader(filename)
+
+        self.assertEqual(datetime.datetime(2015,12,14, 15,58,32), hdr['recording_opened'])
+        self.assertEqual(datetime.datetime(2015,12,14, 15,58,32), hdr['recording_closed'])
 
 if __name__ == "__main__":
     unittest.main()

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -385,22 +385,21 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         self.assertEqual(datetime.datetime(2015,12,14, 15,58,32), hdr['recording_opened'])
         self.assertEqual(datetime.datetime(2015,12,14, 15,58,32), hdr['recording_closed'])
 
+    # left in for possible future header tests
     def get_text_header(self, filename):
         with open(filename, "rb") as f:
             txt_header = f.read(NlxHeader.HEADER_SIZE)
         return txt_header.strip(b"\x00").decode("latin-1")
 
-    def check_dateutil_parse(self, hdrTxt, hdrPatternName, openDate, closeDate):
-        hpd = NlxHeader.header_pattern_dicts[hdrPatternName]
-        mtch = re.search(hpd["openDatetime1_regex"], hdrTxt)
-        if mtch is None: mtch = re.search(hpd["openDatetime2_regex"], hdrTxt)
+    # left in for possible future header tests
+    def check_dateutil_parse(self, hdrTxt, openPat, closePat, openDate, closeDate):
+        mtch = openPat.search(hdrTxt)
         self.assertIsNotNone(mtch)
         dt = mtch.groupdict()
         date = dateutil.parser.parse(f"{dt['date']} {dt['time']}")
         self.assertEqual(openDate, date)
-        if closeDate is not None:
-            mtch = re.search(hpd["closeDatetime1_regex"], hdrTxt)
-            if mtch is None: mtch = re.search(hpd["closeDatetime2_regex"], hdrTxt)
+        if closePat is not None:
+            mtch = closePat.search(hdrTxt)
             self.assertIsNotNone(mtch)
             dt = mtch.groupdict()
             date = dateutil.parser.parse(f"{dt['date']} {dt['time']}")
@@ -411,7 +410,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         # neuraview2
         filename = self.get_local_path("neuralynx/Neuraview_v2/original_data/NeuraviewEventMarkers-sample.nev")
         txt_header = self.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, 'combined',
+        self.check_dateutil_parse(txt_header, NlxHeader.openDatetime1_pat, NlxHeader.closeDatetime1_pat,
                                   datetime.datetime(2015,12,14, 15,58,32),
                                   datetime.datetime(2015,12,14, 15,58,32))
         hdr = NlxHeader(filename)
@@ -423,7 +422,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         # Cheetah 5.7.4 'inProps'
         filename = self.get_local_path("neuralynx/Cheetah_v5.7.4/original_data/CSC1.ncs")
         txt_header = self.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, 'combined',
+        self.check_dateutil_parse(txt_header, NlxHeader.openDatetime2_pat, NlxHeader.closeDatetime2_pat,
                                   datetime.datetime(2017,2,16, 17,56,4),
                                   datetime.datetime(2017,2,16, 18,1,18))
         hdr = NlxHeader(filename)
@@ -435,7 +434,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         # Cheetah 4.0.2
         filename = self.get_local_path("neuralynx/Cheetah_v4.0.2/original_data/CSC14_trunc.Ncs")
         txt_header = self.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, 'combined',
+        self.check_dateutil_parse(txt_header, NlxHeader.openDatetime1_pat, None,
                                   datetime.datetime(2003,10,4, 10,3,0, 578000),
                                   None)
         hdr = NlxHeader(filename)
@@ -446,7 +445,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
         # Cheetah 5.4.0 'openClosedInHeader'
         filename = self.get_local_path("neuralynx/Cheetah_v5.4.0/original_data/CSC5_trunc.Ncs")
         txt_header = self.get_text_header(filename)
-        self.check_dateutil_parse(txt_header, 'combined',
+        self.check_dateutil_parse(txt_header, NlxHeader.openDatetime1_pat, NlxHeader.closeDatetime1_pat,
                                   datetime.datetime(2001,1,1, 0,0,0, 0),
                                   datetime.datetime(2001,1,1, 0,0,0, 0))
         hdr = NlxHeader(filename)


### PR DESCRIPTION
Adds the OriginalFileName property to the NlxHeader. Also cleans up private members and moves a useful method to NlxHeader from test. 

This is the last in this sequence of commits for a while now. This now provides a much clearer method of parsing the header which works with all extant files (@JuliaSprenger and thus provides that refactoring discussed a while back ;-). It should be more flexible for future possible variations and easier to modify if needed.

If one wanted to squish all of these since the divergence to master there would be much cleaner code to review, however, it would be major changes in one shot. 