### PR TITLE
Drop python 3.8

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -26,13 +26,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # "macos-latest",
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         numpy-version: ['1.20.3', '1.21.6', '1.22.4', '1.23.5', '1.24.1', '1.25.1', '1.26.4']
         exclude:
-           - python-version: '3.8'
-             numpy-version: '1.25.1'
-           - python-version: '3.8'
-             numpy-version: '1.26.4'
            - python-version: '3.10'
              numpy-version: '1.20.3'
            - python-version: '3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "neo"
-version = "0.14.0dev"
+version = "0.14.0.dev0"
 authors = [{name = "Neo authors and contributors"}]
 description = "Neo is a package for representing electrophysiology data in Python, together with support for reading a wide range of neurophysiology file formats"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "BSD 3-Clause License"}
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "packaging",
-    "numpy>=1.19.5,<2.0.0",
+    "numpy>=1.20.3,<2.0.0",
     "quantities>=0.14.1,<0.16.0"
 ]
 


### PR DESCRIPTION
Since 3.8 goes EOL in October we should be good to drop this.