### PR TITLE
NeuroNexusRawIO: fix the get_signal_size

### DIFF
--- a/neo/rawio/neuronexusrawio.py
+++ b/neo/rawio/neuronexusrawio.py
@@ -237,8 +237,8 @@ class NeuroNexusRawIO(BaseRawIO):
 
     def _get_signal_size(self, block_index, seg_index, stream_index):
 
-        # All streams have the same size so just return the raw_data size
-        return self._raw_data.size
+        # All streams have the same size so just return the raw_data (num_samples, num_chans)
+        return self._raw_data.shape[0]
 
     def _get_analogsignal_chunk(self, block_index, seg_index, i_start, i_stop, stream_index, channel_indexes):
 


### PR DESCRIPTION
@alejoe91, if you have a moment this is a quick review.

Discovered here: https://github.com/SpikeInterface/spikeinterface/actions/runs/11106106976/job/30853717171?pr=3235

Should be `shape[0]` instead of `size` which is (shape[0] x shape[1]).