### PR TITLE
Drop NumPy < 1.22.4

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -27,19 +27,8 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
         # "macos-latest",
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        numpy-version: ['1.20.3', '1.21.6', '1.22.4', '1.23.5', '1.24.1', '1.25.1', '1.26.4']
+        numpy-version: ['1.22.4', '1.23.5', '1.24.1', '1.25.1', '1.26.4']
         exclude:
-           - python-version: '3.10'
-             numpy-version: '1.20.3'
-           - python-version: '3.11'
-             numpy-version: '1.20.3'
-           - python-version: '3.11'
-             numpy-version: '1.21.6'
-           - python-version: '3.12'
-             numpy-version: '1.20.3'
-           # python 3.12 only works on latest numpy
-           - python-version: '3.12'
-             numpy-version: '1.21.6'
            - python-version: '3.12'
              numpy-version: '1.22.4'
            - python-version: '3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "packaging",
-    "numpy>=1.20.3,<2.0.0",
+    "numpy>=1.22.4,<2.0.0",
     "quantities>=0.14.1,<0.16.0"
 ]
 


### PR DESCRIPTION
See comment [here](https://github.com/NeuralEnsemble/python-neo/pull/1573#issuecomment-2383263062) and resummarized below:

[NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) + 1 year policy, we should be on Python 3.9+ now. Also NumPy 1.22+