### PR TITLE
Add python 3.13 to CI

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -47,12 +47,12 @@ jobs:
              numpy-version: '1.25.1'
     steps:
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
             python-version: ${{ matrix.python-version }}
 
         - name: Checkout repository
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
 
         - name: Install numpy ${{ matrix.numpy-version }}
           run: |

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # "macos-latest",
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         numpy-version: ['1.22.4', '1.23.5', '1.24.1', '1.25.1', '1.26.4']
         exclude:
            - python-version: '3.12'
@@ -36,6 +36,14 @@ jobs:
            - python-version: '3.12'
              numpy-version: '1.24.1'
            - python-version: '3.12'
+             numpy-version: '1.25.1'
+           - python-version: '3.13'
+             numpy-version: '1.22.4'
+           - python-version: '3.13'
+             numpy-version: '1.23.5'
+           - python-version: '3.13'
+             numpy-version: '1.24.1'
+           - python-version: '3.13'
              numpy-version: '1.25.1'
     steps:
         - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get current year-month
         id: date
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         # Loading cache of ephys_testing_dataset
         id: cache-datasets
         with:
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "hash=${{hashFiles('**/pyproject.toml', '**/environment_testing.yml')}}" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         # the cache for python package is reset:
         #   * every month
         #   * when package dependencies change

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.9', '3.11']
+        python-version: ['3.9', '3.13']
     defaults:
       # by default run in bash mode (required for conda usage)
       run:

--- a/neo/rawio/plexon2rawio/plexon2rawio.py
+++ b/neo/rawio/plexon2rawio/plexon2rawio.py
@@ -54,7 +54,7 @@ class Plexon2RawIO(BaseRawIO):
     pl2_dll_file_path: str | Path | None, default: None
         The path to the necessary dll for loading pl2 files
         If None will find correct dll for architecture and if it does not exist will download it
-    reading_attempts: int, default: 25
+    reading_attempts: int, default: 35
         Number of attempts to read the file before raising an error
         This opening process is somewhat unreliable and might fail occasionally. Adjust this higher
         if you encounter problems in opening the file.
@@ -93,7 +93,7 @@ class Plexon2RawIO(BaseRawIO):
     extensions = ["pl2"]
     rawmode = "one-file"
 
-    def __init__(self, filename, pl2_dll_file_path=None, reading_attempts=25):
+    def __init__(self, filename, pl2_dll_file_path=None, reading_attempts=35):
 
         # signals, event and spiking data will be cached
         # cached signal data can be cleared using `clear_analogsignal_cache()()`


### PR DESCRIPTION
Python 3.13 released. See notes [here](https://www.python.org/downloads/release/python-3130/). We should be testing for it now :) 

I think we had mentioned we wanted our CI to be oldest and newest python at some point too. Let's see what happens...