### PR TITLE
OpenEphysBinaryRawIO: Fixing ttl multichan

### DIFF
--- a/neo/rawio/openephysbinaryrawio.py
+++ b/neo/rawio/openephysbinaryrawio.py
@@ -252,47 +252,47 @@ class OpenEphysBinaryRawIO(BaseRawWithBufferApiIO):
                     # 'states' was introduced in OpenEphys v0.6. For previous versions, events used 'channel_states'
                     if "states" in info or "channel_states" in info:
                         states = info["channel_states"] if "channel_states" in info else info["states"]
-                            
+
                         if states.size > 0:
                             timestamps = info["timestamps"]
                             labels = info["labels"]
-                            
+
                             # Identify unique channels based on state values
                             channels = np.unique(np.abs(states))
-                            
+
                             rising_indices = []
                             falling_indices = []
-                            
+
                             for channel in channels:
                                 # Find rising and falling edges for each channel
                                 rising = np.where(states == channel)[0]
                                 falling = np.where(states == -channel)[0]
-                                
+
                                 # Ensure each rising has a corresponding falling
                                 if rising.size > 0 and falling.size > 0:
                                     if rising[0] > falling[0]:
                                         falling = falling[1:]
                                     if rising.size > falling.size:
                                         rising = rising[:-1]
-                                    
+
                                     rising_indices.extend(rising)
                                     falling_indices.extend(falling)
-                            
+
                             rising_indices = np.array(rising_indices)
                             falling_indices = np.array(falling_indices)
-                            
+
                             # Sort the indices to maintain chronological order
                             sorted_order = np.argsort(rising_indices)
                             rising_indices = rising_indices[sorted_order]
                             falling_indices = falling_indices[sorted_order]
-                            
+
                             durations = None
                             if len(rising_indices) == len(falling_indices):
                                 durations = timestamps[falling_indices] - timestamps[rising_indices]
                                 if not self._use_direct_evt_timestamps:
                                     timestamps = timestamps / info["sample_rate"]
                                     durations = durations / info["sample_rate"]
-                            
+
                             info["rising"] = rising_indices
                             info["timestamps"] = timestamps[rising_indices]
                             info["labels"] = labels[rising_indices]

--- a/neo/rawio/openephysbinaryrawio.py
+++ b/neo/rawio/openephysbinaryrawio.py
@@ -263,9 +263,9 @@ class OpenEphysBinaryRawIO(BaseRawWithBufferApiIO):
                             rising_indices = []
                             falling_indices = []
 
-                            # all channels are packed into the same `states` array. 
+                            # all channels are packed into the same `states` array.
                             # So the states array includes positive and negative values for each channel:
-                            #  for example channel one rising would be +1 and channel one falling would be -1, 
+                            #  for example channel one rising would be +1 and channel one falling would be -1,
                             # channel two rising would be +2 and channel two falling would be -2, etc.
                             # This is the case for sure for version >= 0.6.x.
                             for channel in channels:
@@ -280,6 +280,15 @@ class OpenEphysBinaryRawIO(BaseRawWithBufferApiIO):
                                     if rising.size > falling.size:
                                         rising = rising[:-1]
 
+                                    # ensure that the number of rising and falling edges are the same:
+                                    if len(rising) != len(falling):
+                                        warn(
+                                            f"Channel {channel} has {len(rising)} rising edges and "
+                                            f"{len(falling)} falling edges. The number of rising and "
+                                            f"falling edges should be equal. Skipping events from this channel."
+                                        )
+                                        continue
+
                                     rising_indices.extend(rising)
                                     falling_indices.extend(falling)
 
@@ -292,11 +301,11 @@ class OpenEphysBinaryRawIO(BaseRawWithBufferApiIO):
                             falling_indices = falling_indices[sorted_order]
 
                             durations = None
-                            if len(rising_indices) == len(falling_indices):
-                                durations = timestamps[falling_indices] - timestamps[rising_indices]
-                                if not self._use_direct_evt_timestamps:
-                                    timestamps = timestamps / info["sample_rate"]
-                                    durations = durations / info["sample_rate"]
+                            # if len(rising_indices) == len(falling_indices):
+                            durations = timestamps[falling_indices] - timestamps[rising_indices]
+                            if not self._use_direct_evt_timestamps:
+                                timestamps = timestamps / info["sample_rate"]
+                                durations = durations / info["sample_rate"]
 
                             info["rising"] = rising_indices
                             info["timestamps"] = timestamps[rising_indices]

--- a/neo/rawio/openephysbinaryrawio.py
+++ b/neo/rawio/openephysbinaryrawio.py
@@ -263,6 +263,11 @@ class OpenEphysBinaryRawIO(BaseRawWithBufferApiIO):
                             rising_indices = []
                             falling_indices = []
 
+                            # all channels are packed into the same `states` array. 
+                            # So the states array includes positive and negative values for each channel:
+                            #  for example channel one rising would be +1 and channel one falling would be -1, 
+                            # channel two rising would be +2 and channel two falling would be -2, etc.
+                            # This is the case for sure for version >= 0.6.x.
                             for channel in channels:
                                 # Find rising and falling edges for each channel
                                 rising = np.where(states == channel)[0]

--- a/neo/rawio/openephysbinaryrawio.py
+++ b/neo/rawio/openephysbinaryrawio.py
@@ -217,7 +217,6 @@ class OpenEphysBinaryRawIO(BaseRawWithBufferApiIO):
                         if name + "_npy" in info:
                             data = np.load(info[name + "_npy"], mmap_mode="r")
                             info[name] = data
-
                     # check that events have timestamps
                     assert "timestamps" in info, "Event stream does not have timestamps!"
                     # Updates for OpenEphys v0.6:
@@ -253,30 +252,50 @@ class OpenEphysBinaryRawIO(BaseRawWithBufferApiIO):
                     # 'states' was introduced in OpenEphys v0.6. For previous versions, events used 'channel_states'
                     if "states" in info or "channel_states" in info:
                         states = info["channel_states"] if "channel_states" in info else info["states"]
+                            
                         if states.size > 0:
                             timestamps = info["timestamps"]
                             labels = info["labels"]
-                            rising = np.where(states > 0)[0]
-                            falling = np.where(states < 0)[0]
-
-                            # infer durations
+                            
+                            # Identify unique channels based on state values
+                            channels = np.unique(np.abs(states))
+                            
+                            rising_indices = []
+                            falling_indices = []
+                            
+                            for channel in channels:
+                                # Find rising and falling edges for each channel
+                                rising = np.where(states == channel)[0]
+                                falling = np.where(states == -channel)[0]
+                                
+                                # Ensure each rising has a corresponding falling
+                                if rising.size > 0 and falling.size > 0:
+                                    if rising[0] > falling[0]:
+                                        falling = falling[1:]
+                                    if rising.size > falling.size:
+                                        rising = rising[:-1]
+                                    
+                                    rising_indices.extend(rising)
+                                    falling_indices.extend(falling)
+                            
+                            rising_indices = np.array(rising_indices)
+                            falling_indices = np.array(falling_indices)
+                            
+                            # Sort the indices to maintain chronological order
+                            sorted_order = np.argsort(rising_indices)
+                            rising_indices = rising_indices[sorted_order]
+                            falling_indices = falling_indices[sorted_order]
+                            
                             durations = None
-                            if len(states) > 0:
-                                # make sure first event is rising and last is falling
-                                if states[0] < 0:
-                                    falling = falling[1:]
-                                if states[-1] > 0:
-                                    rising = rising[:-1]
-
-                                if len(rising) == len(falling):
-                                    durations = timestamps[falling] - timestamps[rising]
-                                    if not self._use_direct_evt_timestamps:
-                                        timestamps = timestamps / info["sample_rate"]
-                                        durations = durations / info["sample_rate"]
-
-                            info["rising"] = rising
-                            info["timestamps"] = timestamps[rising]
-                            info["labels"] = labels[rising]
+                            if len(rising_indices) == len(falling_indices):
+                                durations = timestamps[falling_indices] - timestamps[rising_indices]
+                                if not self._use_direct_evt_timestamps:
+                                    timestamps = timestamps / info["sample_rate"]
+                                    durations = durations / info["sample_rate"]
+                            
+                            info["rising"] = rising_indices
+                            info["timestamps"] = timestamps[rising_indices]
+                            info["labels"] = labels[rising_indices]
                             info["durations"] = durations
 
         # no spike read yet

--- a/neo/test/rawiotest/common_rawio_test.py
+++ b/neo/test/rawiotest/common_rawio_test.py
@@ -66,11 +66,11 @@ class BaseTestRawIO:
         """
         cls.shortname = cls.rawioclass.__name__.lower().replace("rawio", "")
 
-        if HAVE_DATALAD and cls.use_network:
-            for remote_path in cls.entities_to_download:
-                download_dataset(repo=repo_for_test, remote_path=remote_path)
-        else:
-            raise unittest.SkipTest("Requires datalad download of data from the web")
+        # if HAVE_DATALAD and cls.use_network:
+        #     for remote_path in cls.entities_to_download:
+        #         download_dataset(repo=repo_for_test, remote_path=remote_path)
+        # else:
+        #     raise unittest.SkipTest("Requires datalad download of data from the web")
 
     def get_local_base_folder(self):
         return get_local_testing_data_folder()

--- a/neo/test/rawiotest/common_rawio_test.py
+++ b/neo/test/rawiotest/common_rawio_test.py
@@ -66,11 +66,11 @@ class BaseTestRawIO:
         """
         cls.shortname = cls.rawioclass.__name__.lower().replace("rawio", "")
 
-        # if HAVE_DATALAD and cls.use_network:
-        #     for remote_path in cls.entities_to_download:
-        #         download_dataset(repo=repo_for_test, remote_path=remote_path)
-        # else:
-        #     raise unittest.SkipTest("Requires datalad download of data from the web")
+        if HAVE_DATALAD and cls.use_network:
+            for remote_path in cls.entities_to_download:
+                download_dataset(repo=repo_for_test, remote_path=remote_path)
+        else:
+            raise unittest.SkipTest("Requires datalad download of data from the web")
 
     def get_local_base_folder(self):
         return get_local_testing_data_folder()


### PR DESCRIPTION
Addressing #1437.

Currently, all the logic in the events parser for OpenEphys data assumes that there is a single stream of events (simply positive or negative `states`), and it breaks down when acquiring multiple digital signals at once (`states` having different absolute values for different channels).

This is a simple fix that looks for rising and falling edges separately for each of the digital channels.

Add simple testing relying on existing test data, which fails before the fix and passes afterwards.