### PR TITLE
Open folders with user altered filenames in SpikeGLX

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -85,7 +85,7 @@ class SpikeGLXRawIO(BaseRawWithBufferApiIO):
     * This IO reads the entire folder and subfolders locating the `.bin` and `.meta` files
     * Handles gates and triggers as segments (based on the `_gt0`, `_gt1`, `_t0` , `_t1` in filenames)
     * Handles all signals coming from different acquisition cards ("imec0", "imec1", etc) in a typical
-        PXIe chassis setup and also external signal like"nidq". 
+        PXIe chassis setup and also external signal like "nidq". 
     * For imec devices both "ap" and "lf" are extracted so even a one device setup will have several "streams"
 
     Examples

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -369,13 +369,15 @@ def scan_files(dirname):
     
 
     # Probe index calculation
-    # This ensures that all nidq entries come before any other keys, which corresponds to index 0.
+    # The calculation is ordered by slot, port, dock in that order, this is the number that appears in the filename
+    # after imec when using native names (e.g. imec0, imec1, etc.)
     def get_probe_tuple(info):
         slot = normalize(info.get("probe_slot"))
         port = normalize(info.get("probe_port"))
         dock = normalize(info.get("probe_dock"))
         return (slot, port, dock)
 
+    # TODO: handle one box case
     info_list_imec = [info for info in info_list if info.get("device") != "nidq"]
     unique_probe_tuples = {get_probe_tuple(info) for info in info_list_imec}
     sorted_probe_keys = sorted(unique_probe_tuples)
@@ -593,6 +595,7 @@ def extract_stream_info(meta_file, meta):
     info["trigger_num"] = trigger_num
     info["device"] = device
     info["stream_kind"] = stream_kind
+    # All non-production probes (phase 3B onwards) have "typeThis", otherwise revert to file parsing
     info["device_kind"] = meta.get("typeThis", device.split(".")[0])
     info["units"] = units
     info["channel_names"] = [txt.split(";")[0] for txt in meta["snsChanMap"]]

--- a/neo/test/rawiotest/test_spikeglxrawio.py
+++ b/neo/test/rawiotest/test_spikeglxrawio.py
@@ -32,6 +32,8 @@ class TestSpikeGLXRawIO(BaseTestRawIO, unittest.TestCase):
         "spikeglx/NP2_subset_with_sync",
         # NP-ultra
         "spikeglx/np_ultra_stub",
+        # Filename changed by the user, multi-dock
+        "spikeglx/multi_probe_multi_dock_multi_shank_filename_without_info",
         # CatGT
         "spikeglx/multi_trigger_multi_gate/CatGT/CatGT-A",
         "spikeglx/multi_trigger_multi_gate/CatGT/CatGT-B",


### PR DESCRIPTION
Should fix #1606

To solve #1606 this does two things:
1) It calculates device (probe) index from the metadata instead of relying on file parsing as we currently do. 
2) When the gate, port and dock are not available in the metadata it parses the filename as named in the metadata (as that was the original one) instead of from the filepath in the system as we are currently doing.

Both things should make the reader more robust. 

I am preparing some data for gin where the filename was changed. I will change this from draft once I add that.