### PR TITLE
NumPy 2.0 support for IOs

### DIFF
--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.12', '3.13']
     defaults:
       # by default run in bash mode (required for conda usage)
       run:

--- a/environment_testing.yml
+++ b/environment_testing.yml
@@ -4,6 +4,3 @@ channels:
 dependencies:
   - datalad
   - pip
-  # temporary have this here for IO testing while we decide how to deal with
-  # external packages not 2.0 ready
-  - numpy=1.26.4


### PR DESCRIPTION
We also need to start seeing which IOs are potentially not 2.0 ready. This is just a draft to start assessing this.

This is much better than I was expecting :) 

```
FAILED neo/test/rawiotest/test_blackrockrawio.py::TestBlackrockRawIO::test_compare_blackrockio_with_matlabloader - KeyError: np.int64(-1)
FAILED neo/test/rawiotest/test_blackrockrawio.py::TestBlackrockRawIO::test_compare_blackrockio_with_matlabloader_v21 - OverflowError: Python integer -1 out of bounds for uint16
FAILED neo/test/rawiotest/test_blackrockrawio.py::TestBlackrockRawIO::test_read_all - KeyError: np.int64(-1)
FAILED neo/test/rawiotest/test_plexonrawio.py::TestPlexonRawIO::test_read_all - OverflowError: Python integer 4294967296 out of bounds for uint16
```