### PR TITLE
Improve `copy` deprecation message

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -200,7 +200,10 @@ class AnalogSignal(BaseSignal):
         """
         if copy is not None:
             raise ValueError(
-                "`copy` is now deprecated in Neo due to removal in NumPy 2.0 and will be removed in 0.15.0."
+                "`copy` is now deprecated in Neo due to removal in Quantites to support Numpy 2.0. "
+                "In order to facilitate the deprecation copy can be set to None but will raise an "
+                "error if set to True/False since this will silently do nothing. This argument will be completely "
+                "removed in Neo 0.15.0. Please update your code base as necessary."
             )
 
         signal = cls._rescale(signal, units=units)
@@ -210,7 +213,7 @@ class AnalogSignal(BaseSignal):
             obj.shape = (-1, 1)
 
         if t_start is None:
-            raise ValueError("t_start cannot be None")
+            raise ValueError("`t_start` cannot be None")
         obj._t_start = t_start
 
         obj._sampling_rate = _get_sampling_rate(sampling_rate, sampling_period)

--- a/neo/core/imagesequence.py
+++ b/neo/core/imagesequence.py
@@ -124,7 +124,10 @@ class ImageSequence(BaseSignal):
 
         if copy is not None:
             raise ValueError(
-                "`copy` is now deprecated in Neo due to removal in NumPy 2.0 and will be removed in 0.15.0."
+                "`copy` is now deprecated in Neo due to removal in Quantites to support Numpy 2.0. "
+                "In order to facilitate the deprecation copy can be set to None but will raise an "
+                "error if set to True/False since this will silently do nothing. This argument will be completely "
+                "removed in Neo 0.15.0. Please update your code base as necessary."
             )
 
         if spatial_scale is None:

--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -174,7 +174,10 @@ class IrregularlySampledSignal(BaseSignal):
 
         if copy is not None:
             raise ValueError(
-                "`copy` is now deprecated in Neo due to removal in NumPy 2.0 and will be removed in 0.15.0."
+                "`copy` is now deprecated in Neo due to removal in Quantites to support Numpy 2.0. "
+                "In order to facilitate the deprecation copy can be set to None but will raise an "
+                "error if set to True/False since this will silently do nothing. This argument will be completely "
+                "removed in Neo 0.15.0. Please update your code base as necessary."
             )
 
         signal = cls._rescale(signal, units=units)

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -194,7 +194,12 @@ def normalize_times_array(times, units=None, dtype=None, copy=None):
     """
 
     if copy is not None:
-        raise ValueError("`copy` is now deprecated in Neo due to removal in NumPy 2.0 and will be removed in 0.15.0.")
+        raise ValueError(
+            "`copy` is now deprecated in Neo due to removal in Quantites to support Numpy 2.0. "
+            "In order to facilitate the deprecation copy can be set to None but will raise an "
+            "error if set to True/False since this will silently do nothing. This argument will be completely "
+            "removed in Neo 0.15.0. Please update your code base as necessary."
+            )
 
     if dtype is None:
         if not hasattr(times, "dtype"):
@@ -352,7 +357,10 @@ class SpikeTrain(DataObject):
         """
         if copy is not None:
             raise ValueError(
-                "`copy` is now deprecated in Neo due to removal in NumPy 2.0 and will be removed in 0.15.0."
+                "`copy` is now deprecated in Neo due to removal in Quantites to support Numpy 2.0. "
+                "In order to facilitate the deprecation copy can be set to None but will raise an "
+                "error if set to True/False since this will silently do nothing. This argument will be completely "
+                "removed in Neo 0.15.0. Please update your code base as necessary."
             )
 
         if len(times) != 0 and waveforms is not None and len(times) != waveforms.shape[0]:


### PR DESCRIPTION
Fixes #1596 

In the linked issue it was indicated that a deprecation should not raise an error and instead should be a warning. Since we decided on this soft error which can be switched to warning by using None, I tried to improve the messaging. What do you think about this @sanjayankur31?

We need to wait for #1619 for testing to work for this.

This is ready to be reviewed now!