### PR TITLE
Fix NWB parsing from pynwb/hmdf

### DIFF
--- a/neo/io/nwbio.py
+++ b/neo/io/nwbio.py
@@ -495,7 +495,7 @@ class NWBIO(BaseIO):
             if segment.block is not block:
                 raise TypeError(f"segment.block must be block it is {segment.block}")
             if not segment.name:
-                segment.name = f"{block.name} : segment{i}"
+                segment.name = f"{block.name}  segment{i}"
             self._write_segment(self._nwbfile, segment, electrodes)
         self.blocks_written += 1
 

--- a/neo/io/nwbio.py
+++ b/neo/io/nwbio.py
@@ -529,7 +529,7 @@ class NWBIO(BaseIO):
                 signal.name = f"{segment.name} {signal.name} {i}"
                 logging.warning(f"Warning signal name exists. New name: {signal.name}")
             else:
-                signal.name = f"{segment.name} : analogsignal{signal.name} {i}"
+                signal.name = f"{segment.name}  analogsignal{signal.name} {i}"
             self._write_signal(self._nwbfile, signal, electrodes)
 
         for i, train in enumerate(segment.spiketrains):

--- a/neo/io/nwbio.py
+++ b/neo/io/nwbio.py
@@ -536,7 +536,7 @@ class NWBIO(BaseIO):
             if train.segment is not segment:
                 raise TypeError(f"train.segment must be segment and is {train.segment}")
             if not train.name:
-                train.name = f"{segment.name} : spiketrain{i}"
+                train.name = f"{segment.name}  spiketrain{i}"
             self._write_spiketrain(self._nwbfile, train)
 
         for i, event in enumerate(segment.events):
@@ -546,12 +546,12 @@ class NWBIO(BaseIO):
                 event.name = f"{segment.name}  {event.name} {i}"
                 logging.warning(f"Warning event name exists. New name: {event.name}")
             else:
-                event.name = f"{segment.name} : event{event.name} {i}"
+                event.name = f"{segment.name}  event{event.name} {i}"
             self._write_event(self._nwbfile, event)
 
         for i, epoch in enumerate(segment.epochs):
             if not epoch.name:
-                epoch.name = f"{segment.name} : epoch{i}"
+                epoch.name = f"{segment.name}  epoch{i}"
             self._write_epoch(self._nwbfile, epoch)
 
     def _write_signal(self, nwbfile, signal, electrodes):


### PR DESCRIPTION
## Error
```
self = <[AttributeError("'TimeSeries' object has no attribute '_AbstractContainer__name'") raised in repr()] TimeSeries object at 0x7f032efad6a0>
kwargs = {'name': 'First block : segment0 Signal_a None 0'}
name = 'First block : segment0 Signal_a None 0'

    @docval({'name': 'name', 'type': str, 'doc': 'the name of this container'})
    def __init__(self, **kwargs):
        name = getargs('name', kwargs)
        if ('/' in name or ':' in name) and not self._in_construct_mode:
>           raise ValueError(f"name '{name}' cannot contain a '/' or ':'")
E           ValueError: name 'First block : segment0 Signal_a None 0' cannot contain a '/' or ':'
```
from here
```
/usr/share/miniconda/envs/neo-test-env/lib/python3.9/site-packages/hdmf/utils.py:668: in func_call
    return func(args[0], **pargs)
```
## Fix

Fixes part of #1618. It says that hmdf no longer accepts symbol `:` in text. In this case we just remove the offending :'s. This should be fine for old version too. Not quite as clean to read, but seems okay to me. 