### PR TITLE
Fix setting python version for environment in CI

### DIFF
--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install Python Version
         run: |
-          conda install --force-reinstall python=${{ matrix.python-version }} pip 
+          conda install --force-reinstall python=${{ matrix.python-version }} pip pytest
 
       - name: Install testing dependencies
         # testing environment is only created from yml if no cache was found

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          activate-environment: neo-test-env
+          activate-environment: neo-test-env-${{ matrix.python-version }}
           python-version: "${{ matrix.python-version }}"
 
       - name: Get current dependencies hash
@@ -62,16 +62,12 @@ jobs:
         #   * when package dependencies change
         id: cache-conda-env
         with:
-          path: /usr/share/miniconda/envs/neo-test-env
+          path: /usr/share/miniconda/envs/neo-test-env-${{ matrix.python-version }}
           key: ${{ runner.os }}-conda-env-${{ steps.dependencies.outputs.hash }}-${{ steps.date.outputs.date }}
           # restore-keys match any key that starts with the restore-key
           restore-keys: |
             ${{ runner.os }}-conda-env-${{ steps.dependencies.outputs.hash }}-
             ${{ runner.os }}-conda-env-
-
-      - name: Install Python Version
-        run: |
-          conda install --force-reinstall python=${{ matrix.python-version }} pip pytest
 
       - name: Install testing dependencies
         # testing environment is only created from yml if no cache was found

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -74,7 +74,7 @@ jobs:
         # restore-key hits should result in `cache-hit` == 'false'
         if: steps.cache-conda-env.outputs.cache-hit != 'true'
         run: |
-          conda env update --name neo-test-env --file environment_testing.yml --prune
+          conda env update --name neo-test-env-${{ matrix.python-version }} --file environment_testing.yml --prune
 
       - name: Configure git
         run: |

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install Python Version
         run: |
-          conda install python=${{ matrix.python-version }}
+          conda install python=${{ matrix.python-version }} pip
 
       - name: Install testing dependencies
         # testing environment is only created from yml if no cache was found

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install Python Version
         run: |
-          conda install python=${{ matrix.python-version }} pip
+          conda install --force-reinstall python=${{ matrix.python-version }} pip 
 
       - name: Install testing dependencies
         # testing environment is only created from yml if no cache was found

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -69,13 +69,16 @@ jobs:
             ${{ runner.os }}-conda-env-${{ steps.dependencies.outputs.hash }}-
             ${{ runner.os }}-conda-env-
 
+      - name: Install Python Version
+        run: |
+          conda install python=${{ matrix.python-version }}
+
       - name: Install testing dependencies
         # testing environment is only created from yml if no cache was found
         # restore-key hits should result in `cache-hit` == 'false'
         if: steps.cache-conda-env.outputs.cache-hit != 'true'
         run: |
           conda env update --name neo-test-env --file environment_testing.yml --prune
-          conda install python=${{ matrix.python-version }}
 
       - name: Configure git
         run: |


### PR DESCRIPTION
This will fail until we figure out #1619 and #1618. Then this will fix #1618.

We are still having issues with python version so instead I add an explicit step to set our python version number in the environment. I'm not 100% sure this will work. I think the ideal scenario would be to actually create different cached environments for python versions instead so I might try that strategy in parallel in which case we could close this PR. Opinions?