### PR TITLE
Fix docutil parsing errors in code base

### DIFF
--- a/neo/core/irregularlysampledsignal.py
+++ b/neo/core/irregularlysampledsignal.py
@@ -103,7 +103,7 @@ class IrregularlySampledSignal(BaseSignal):
         The filesystem path or url of the orginal data
     array_annotations: dict | None, default: None
         Dict mapping strings to numpy arrays containing annotations for all data points
-    **annotations: dict
+    annotations: dict
         Optional additional metadata supplied by the user as a dict. Will be stored in
         the annotations attribute of the object
 

--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -42,7 +42,7 @@ class Segment(Container):
     index: int | None, default: None
         You can use this to define a temporal ordering of your Segment.
         For instance you could use this for trial numbers.
-    **annotations: dict | None,
+    annotations: dict | None,
         Other keyword annotations for the dataset
 
     Examples

--- a/neo/core/segment.py
+++ b/neo/core/segment.py
@@ -70,7 +70,7 @@ class Segment(Container):
     Notes
     -----
 
-    *Container of*:
+    Container of:
         :class:`Epoch`
         :class:`Event`
         :class:`AnalogSignal`

--- a/neo/core/spiketrain.py
+++ b/neo/core/spiketrain.py
@@ -276,7 +276,7 @@ class SpikeTrain(DataObject):
         The path or location of the original data file.
     array_annotations: dict
         A dictonary mapping of strings to numpy arrays containing annotations for all data points
-    **annotations: dict
+    annotations: dict
         Other user defined metadata given as a dict
 
     Notes

--- a/neo/core/view.py
+++ b/neo/core/view.py
@@ -31,7 +31,7 @@ class ChannelView(BaseNeo):
         Filesystem path or URL of the original data file.
     array_annotations: dict | None, default: None
         Dict mapping strings to numpy arrays containing annotations for all data points
-    **annotations: dict
+    annotations: dict
         Other use-specified metadata with keywords
     """
 

--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -45,7 +45,7 @@ Classes:
 * :attr:`NestIO`
 * :attr:`NeuralynxIO`
 * :attr:`NeuroExplorerIO`
-* :attr:`NeuroNexusIO
+* :attr:`NeuroNexusIO`
 * :attr:`NeuroScopeIO`
 * :attr:`NeuroshareIO`
 * :attr:`NixIO`
@@ -193,6 +193,7 @@ Classes:
     .. autoattribute:: extensions
 
 .. autoclass:: neo.io.NeuroNexusIO
+
     .. autoattribute:: extensions
 
 .. autoclass:: neo.io.NeuroScopeIO

--- a/neo/rawio/__init__.py
+++ b/neo/rawio/__init__.py
@@ -117,7 +117,7 @@ Classes:
 
 .. autoclass:: neo.rawio.NeuroNexusRawIO
 
-    .. autoattributes:: extensions
+    .. autoattribute:: extensions
 
 .. autoclass:: neo.rawio.NeuroScopeRawIO
 

--- a/neo/rawio/cedrawio.py
+++ b/neo/rawio/cedrawio.py
@@ -2,19 +2,18 @@
 Class for reading data from CED (Cambridge Electronic Design)
 http://ced.co.uk/
 
-This read *.smrx (and *.smr) from spike2 and signal software.
+This reads *.smrx (and *.smr) from spike2 and signal software.
 
 Note Spike2RawIO/Spike2IO is the old implementation in neo.
 It still works without any dependency and should be faster.
 Spike2IO only works for smr (32 bit) and not for smrx (64 bit) files.
 
-This implementation depends on the SONPY package:
-https://pypi.org/project/sonpy/
+This implementation depends on the SONPY package: https://pypi.org/project/sonpy/
 
 Please note that the SONPY package:
   * is NOT open source
   * internally uses a list instead of numpy.ndarray, potentially causing slow data reading
-  *  is maintained by CED
+  * is maintained by CED
 
 
 Author : Samuel Garcia
@@ -39,7 +38,7 @@ class CedRawIO(BaseRawIO):
     Parameters
     ----------
     filename: str, default: ''
-        The *.smr or *.smrx file to load
+        The .smr or .smrx file to load
     take_ideal_sampling_rate: bool, default: False
         If true use the `GetIdealRate` function from sonpy package
 

--- a/neo/rawio/elanrawio.py
+++ b/neo/rawio/elanrawio.py
@@ -43,11 +43,11 @@ class ElanRawIO(BaseRawWithBufferApiIO):
     Parameters
     ----------
     filename: str | None, default: None
-        The raw data to load (*.eeg)
+        The raw data to load (.eeg)
     entfile: str | None, default: None
-        The header file to load (*.eeg.ent)
+        The header file to load (.eeg.ent)
     posfile: str | None, deafult: None
-        The event file to load (*.eeg.pos)
+        The event file to load (.eeg.pos)
 
     Examples
     --------

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -11,10 +11,13 @@ RHD supported version  1.0 1.1 1.2 1.3 2.0 3.0, 3.1
 RHD headerless binary support 3.x
 RHS headerless binary support 3.x
 
+
 See:
+
   * http://intantech.com/files/Intan_RHD2000_data_file_formats.pdf
   * http://intantech.com/files/Intan_RHS2000_data_file_formats.pdf
 
+  
 Author: Samuel Garcia (Initial), Zach McKenzie & Heberto Mayorquin (Updates)
 
 """
@@ -50,6 +53,7 @@ class IntanRawIO(BaseRawIO):
         check we perform is that timestamps are continuous. Setting this to True will ignore this check and set
         the attribute `discontinuous_timestamps` to True if the timestamps are not continous. This attribute can be checked
         after parsing the header to see if the timestamps are continuous or not.
+
     Notes
     -----
     * The Intan reader can handle two file formats 'rhd' and 'rhs'. It will automatically
@@ -67,6 +71,7 @@ class IntanRawIO(BaseRawIO):
     * Intan files contain amplifier channels labeled 'A', 'B' 'C' or 'D'
     depending on the port in which they were recorded along with the following
     additional streams.
+
     0: 'RHD2000' amplifier channel
     1: 'RHD2000 auxiliary input channel',
     2: 'RHD2000 supply voltage channel',
@@ -88,6 +93,7 @@ class IntanRawIO(BaseRawIO):
     one long vector, which must be post-processed to extract individual digital channel information.
     See the intantech website for more information on performing this post-processing.
 
+    
     Examples
     --------
     >>> import neo.rawio

--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -13,7 +13,6 @@ RHS headerless binary support 3.x
 
 
 See:
-
   * http://intantech.com/files/Intan_RHD2000_data_file_formats.pdf
   * http://intantech.com/files/Intan_RHS2000_data_file_formats.pdf
 
@@ -57,20 +56,20 @@ class IntanRawIO(BaseRawIO):
     Notes
     -----
     * The Intan reader can handle two file formats 'rhd' and 'rhs'. It will automatically
-    check for the file extension and will gather the header information based on the
-    extension. Additionally it functions with RHS v 1.0 and v 3.x and RHD 1.0, 1.1, 1.2, 1.3, 2.0,
-    3.x files.
+      check for the file extension and will gather the header information based on the
+      extension. Additionally it functions with RHS v 1.0 and v 3.x and RHD 1.0, 1.1, 1.2, 1.3, 2.0,
+      3.x files.
 
     * The Intan reader can also handle the headerless binary formats 'one-file-per-signal' and
-    'one-file-per-channel' which have a header file called 'info.rhd' or 'info.rhs' and a series
-    of binary files with the '.dat' suffix
+      'one-file-per-channel' which have a header file called 'info.rhd' or 'info.rhs' and a series
+      of binary files with the '.dat' suffix
 
     * The reader can handle three file formats 'header-attached', 'one-file-per-signal' and
-    'one-file-per-channel'.
+      'one-file-per-channel'.
 
     * Intan files contain amplifier channels labeled 'A', 'B' 'C' or 'D'
-    depending on the port in which they were recorded along with the following
-    additional streams.
+      depending on the port in which they were recorded along with the following
+      additional streams.
 
     0: 'RHD2000' amplifier channel
     1: 'RHD2000 auxiliary input channel',
@@ -90,8 +89,8 @@ class IntanRawIO(BaseRawIO):
     11: 'Stim channel',
 
     * For the "header-attached" and "one-file-per-signal" formats, the structure of the digital input and output channels is
-    one long vector, which must be post-processed to extract individual digital channel information.
-    See the intantech website for more information on performing this post-processing.
+      one long vector, which must be post-processed to extract individual digital channel information.
+      See the intantech website for more information on performing this post-processing.
 
     
     Examples

--- a/neo/rawio/maxwellrawio.py
+++ b/neo/rawio/maxwellrawio.py
@@ -46,7 +46,7 @@ class MaxwellRawIO(BaseRawWithBufferApiIO):
     ----------
 
     filename: str, default: ''
-        The *.h5 file to be loaded
+        The .h5 file to be loaded
     rec_name: str | None, default: None
         If the file has multiple recordings, specify the one to read.
         For 24-well plates, the rec_name needs to be specified since different well

--- a/neo/rawio/neuronexusrawio.py
+++ b/neo/rawio/neuronexusrawio.py
@@ -73,6 +73,7 @@ class NeuroNexusRawIO(BaseRawWithBufferApiIO):
             * The *.xdat.json metadata file
             * The *_data.xdat binary file of all raw data
             * The *_timestamps.xdat binary file of the timestamp data
+            
         From the metadata the other two files are located within the same directory
         and loaded.
 

--- a/neo/rawio/rawbinarysignalrawio.py
+++ b/neo/rawio/rawbinarysignalrawio.py
@@ -38,7 +38,7 @@ class RawBinarySignalRawIO(BaseRawWithBufferApiIO):
     Parameters
     ----------
     filename: str, default: ''
-        The *.raw, *.bin, or *.dat binary file to load
+        The .raw, .bin, or .dat binary file to load
     dtype: np.dtype, default: 'int16'
         The dtype that the data is stored with. Must be acceptable by the numpy.dtype constructor
     sampling_rate: float, default: 10000.0

--- a/neo/rawio/rawmcsrawio.py
+++ b/neo/rawio/rawmcsrawio.py
@@ -34,7 +34,7 @@ class RawMCSRawIO(BaseRawWithBufferApiIO):
     Parameters
     ----------
     filename: str, default: ''
-        The *.raw MCS file to be loaded
+        The .raw MCS file to be loaded
 
     """
 

--- a/neo/rawio/spike2rawio.py
+++ b/neo/rawio/spike2rawio.py
@@ -41,7 +41,7 @@ class Spike2RawIO(BaseRawIO):
     Parameters
     ----------
     filename: str, default: ''
-        The *.smr file to be loaded
+        The .smr file to be loaded
     take_ideal_sampling_rate: bool, default: False
         If True takes the `ideal_rate` from info
     ced_units: bool, default: True

--- a/neo/rawio/winwcprawio.py
+++ b/neo/rawio/winwcprawio.py
@@ -30,7 +30,7 @@ class WinWcpRawIO(BaseRawWithBufferApiIO):
     Parameters
     ----------
     filename: str, default: ''
-        The *.wcp file to load
+        The .wcp file to load
 
     """
 


### PR DESCRIPTION
While dealing with the documentation meltdown the warnings were making it hard to see the errors, so I wanted to cleanup some of the warnings. 