### PR TITLE
Stop Cron Job for Creating Conda Env

### DIFF
--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -10,57 +10,57 @@ on:
 
 jobs:
 
-  create-conda-env-cache-if-missing:
-    name: Caching conda env
-    runs-on: "ubuntu-latest"
-    strategy:
-      fail-fast: true
-    defaults:
-      # by default run in bash mode (required for conda usage)
-      run:
-        shell: bash -l {0}
-    steps:
-      - uses: actions/checkout@v3
+  # create-conda-env-cache-if-missing:
+  #   name: Caching conda env
+  #   runs-on: "ubuntu-latest"
+  #   strategy:
+  #     fail-fast: true
+  #   defaults:
+  #     # by default run in bash mode (required for conda usage)
+  #     run:
+  #       shell: bash -l {0}
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - name: Get current year-month
-        id: date
-        run: |
-          echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
+  #     - name: Get current year-month
+  #       id: date
+  #       run: |
+  #         echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
 
-      - name: Get current dependencies hash
-        id: dependencies
-        run: |
-          echo "hash=${{hashFiles('**/pyproject.toml', '**/environment_testing.yml')}}" >> $GITHUB_OUTPUT
+  #     - name: Get current dependencies hash
+  #       id: dependencies
+  #       run: |
+  #         echo "hash=${{hashFiles('**/pyproject.toml', '**/environment_testing.yml')}}" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
-        # the cache for python package is reset:
-        #   * every month
-        #   * when package dependencies change
-        id: cache-conda-env
-        with:
-          path: /usr/share/miniconda/envs/neo-test-env
-          key: ${{ runner.os }}-conda-env-${{ steps.dependencies.outputs.hash }}-${{ steps.date.outputs.date }}
+  #     - uses: actions/cache@v3
+  #       # the cache for python package is reset:
+  #       #   * every month
+  #       #   * when package dependencies change
+  #       id: cache-conda-env
+  #       with:
+  #         path: /usr/share/miniconda/envs/neo-test-env
+  #         key: ${{ runner.os }}-conda-env-${{ steps.dependencies.outputs.hash }}-${{ steps.date.outputs.date }}
 
-      - name: Cache found?
-        run: echo "Cache-hit == ${{steps.cache-conda-env.outputs.cache-hit == 'true'}}"
+  #     - name: Cache found?
+  #       run: echo "Cache-hit == ${{steps.cache-conda-env.outputs.cache-hit == 'true'}}"
 
-      # activate environment if not restored from cache
-      - uses: conda-incubator/setup-miniconda@v2.2.0
-        if: steps.cache-conda-env.outputs.cache-hit != 'true'
-        with:
-          activate-environment: neo-test-env
-          environment-file: environment_testing.yml
-          python-version: 3.9
+  #     # activate environment if not restored from cache
+  #     - uses: conda-incubator/setup-miniconda@v2.2.0
+  #       if: steps.cache-conda-env.outputs.cache-hit != 'true'
+  #       with:
+  #         activate-environment: neo-test-env
+  #         environment-file: environment_testing.yml
+  #         python-version: 3.9
 
-      - name: Create the conda environment to be cached
-        if: steps.cache-conda-env.outputs.cache-hit != 'true'
-        # create conda env, configure git and install pip, neo and test dependencies from master
-        # for PRs that change dependencies, this environment will be updated in the test workflow
-        run: |
-          git config --global user.email "neo_ci@fake_mail.com"
-          git config --global user.name "neo CI"
-          python -m pip install -U pip  # Official recommended way
-          pip install --upgrade -e .[test]
+      # - name: Create the conda environment to be cached
+      #   if: steps.cache-conda-env.outputs.cache-hit != 'true'
+      #   # create conda env, configure git and install pip, neo and test dependencies from master
+      #   # for PRs that change dependencies, this environment will be updated in the test workflow
+      #   run: |
+      #     git config --global user.email "neo_ci@fake_mail.com"
+      #     git config --global user.name "neo CI"
+      #     python -m pip install -U pip  # Official recommended way
+      #     pip install --upgrade -e .[test]
 
   create-data-cache-if-missing:
     name: Caching data env


### PR DESCRIPTION
Just checked our actions and realized we were creating a cache already. To be environmentally friendly let's not do this cron job while we decide whether to permanently remove the conda env cache.

for @samuelgarcia, but @alejoe91 since you'll see this first (most likely) feel free to make sure I didn't mess it up.

We should keep this in mind for #1628.