### PR TITLE
Fix: In openephysbinaryrawio.py

### DIFF
--- a/neo/rawio/openephysbinaryrawio.py
+++ b/neo/rawio/openephysbinaryrawio.py
@@ -292,15 +292,15 @@ class OpenEphysBinaryRawIO(BaseRawWithBufferApiIO):
                                     rising_indices.extend(rising)
                                     falling_indices.extend(falling)
 
-                            rising_indices = np.array(rising_indices)
-                            falling_indices = np.array(falling_indices)
+                            rising_indices = np.array(rising_indices, dtype=np.intp)
+                            falling_indices = np.array(falling_indices, dtype=np.intp)
 
                             # Sort the indices to maintain chronological order
                             sorted_order = np.argsort(rising_indices)
                             rising_indices = rising_indices[sorted_order]
                             falling_indices = falling_indices[sorted_order]
 
-                            durations = None
+                            # durations = None
                             # if len(rising_indices) == len(falling_indices):
                             durations = timestamps[falling_indices] - timestamps[rising_indices]
                             if not self._use_direct_evt_timestamps:

--- a/neo/rawio/openephysbinaryrawio.py
+++ b/neo/rawio/openephysbinaryrawio.py
@@ -292,8 +292,8 @@ class OpenEphysBinaryRawIO(BaseRawWithBufferApiIO):
                                     rising_indices.extend(rising)
                                     falling_indices.extend(falling)
 
-                            rising_indices = np.array(rising_indices, dtype=np.intp)
-                            falling_indices = np.array(falling_indices, dtype=np.intp)
+                            rising_indices = np.array(rising_indices, dtype=np.int64)
+                            falling_indices = np.array(falling_indices, dtype=np.int64)
 
                             # Sort the indices to maintain chronological order
                             sorted_order = np.argsort(rising_indices)


### PR DESCRIPTION
falling and rising indices of events must be arrays of integers, even if empty, otherwise it fails when trying to use them to compute durations. This issue is only triggered when trying to access recordings without any events. The small change was enough to fix the issue in the dataset I was exploring but there might be other places that need updating.