### PR TITLE
Fix spikeglx stream for isolated folder from multi probe case.

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -378,6 +378,7 @@ def scan_files(dirname):
 
 
     for info in info_list:
+        # we have two main device types `imec` and `nidq` that the user has control of enabling
         if info.get("device_kind") == "imec":
             info["device_index"] = info["device"].split("imec")[-1]
         else:

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -378,13 +378,14 @@ def scan_files(dirname):
 
 
     for info in info_list:
-        # we have two main device types `imec` and `nidq` that the user has control of enabling
+        # device_kind is imec, nidq
         if info.get("device_kind") == "imec":
             info["device_index"] = info["device"].split("imec")[-1]
         else:
             info["device_index"] = ""  # TODO: Handle multi nidq case, maybe use meta["typeNiEnabled"]
 
-    # Define stream base on device [imec|nidq], device_index and stream_kind [ap|lf] for imec
+    # Define stream base on device_kind [imec|nidq], device_index and stream_kind [ap|lf] for imec
+    # Stream format is "{device_kind}{device_index}.{stream_kind}"
     for info in info_list:
         device_kind = info["device_kind"]
         device_index = info["device_index"]

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -524,6 +524,7 @@ def extract_stream_info(meta_file, meta):
         # NIDQ case
         has_sync_trace = False
 
+    # This is the original name that the file had. It might not match the current name if the user changed it
     bin_file_path = meta["fileName"]
     fname = Path(bin_file_path).stem
 

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -376,26 +376,12 @@ def scan_files(dirname):
     for info in info_list:
         info["seg_index"] = segment_tuple_to_segment_index[get_segment_tuple(info)]
 
-    # Probe index calculation
-    # The calculation is ordered by slot, port, dock in that order, this is the number that appears in the filename
-    # after imec when using native names (e.g. imec0, imec1, etc.)
-    def get_probe_tuple(info):
-        slot = normalize(info.get("probe_slot"))
-        port = normalize(info.get("probe_port"))
-        dock = normalize(info.get("probe_dock"))
-        return (slot, port, dock)
-
-    # TODO: handle one box case
-    info_list_imec = [info for info in info_list if info.get("device") != "nidq"]
-    unique_probe_tuples = {get_probe_tuple(info) for info in info_list_imec}
-    sorted_probe_keys = sorted(unique_probe_tuples)
-    probe_tuple_to_probe_index = {key: idx for idx, key in enumerate(sorted_probe_keys)}
 
     for info in info_list:
-        if info.get("device") == "nidq":
-            info["device_index"] = ""  # TODO: Handle multi nidq case, maybe use meta["typeNiEnabled"]
+        if info.get("device_kind") == "imec":
+            info["device_index"] = info["device"].split("imec")[-1]
         else:
-            info["device_index"] = probe_tuple_to_probe_index[get_probe_tuple(info)]
+            info["device_index"] = ""  # TODO: Handle multi nidq case, maybe use meta["typeNiEnabled"]
 
     # Define stream base on device [imec|nidq], device_index and stream_kind [ap|lf] for imec
     for info in info_list:

--- a/neo/test/rawiotest/test_spikeglxrawio.py
+++ b/neo/test/rawiotest/test_spikeglxrawio.py
@@ -43,6 +43,19 @@ class TestSpikeGLXRawIO(BaseTestRawIO, unittest.TestCase):
         "spikeglx/multi_trigger_multi_gate/CatGT/Supercat-A",
     ]
 
+    def test_loading_only_one_probe_in_multi_probe_scenario(self):
+        from pathlib import Path
+        local_path_multi_probe_path = Path(self.get_local_path("spikeglx/multi_trigger_multi_gate/SpikeGLX/5-19-2022-CI0"))
+        gate_folder_path = local_path_multi_probe_path / "5-19-2022-CI0_g0"
+        probe_folder_path = gate_folder_path / "5-19-2022-CI0_g0_imec1"
+        
+        rawio = SpikeGLXRawIO(probe_folder_path)
+        rawio.parse_header()
+        
+        expected_stream_names = ["imec1.ap", "imec1.lf"]
+        actual_stream_names = rawio.header["signal_streams"]["name"].tolist()
+        assert actual_stream_names == expected_stream_names, f"Expected {expected_stream_names}, but got {actual_stream_names}" 
+
     def test_with_location(self):
         rawio = SpikeGLXRawIO(self.get_local_path("spikeglx/Noise4Sam_g0"), load_channel_location=True)
         rawio.parse_header()


### PR DESCRIPTION
Should fix #1661
See discussion here: #1656
Added a test as @zm711 requested.

This is restoring some behavior that we lost after #1608

Plus, reading the metadata history changes here:
https://billkarsh.github.io/SpikeGLX/help/parsing/

Calculating `device_index` through the original file name is robust up till the phase 3A whereas the current `probe_index` calculation might fail for some phases. So I think this is a good improvement overall and simplifies the code.