### PR TITLE
Cleanup import to use `importlib.util.find_spec`

### DIFF
--- a/neo/io/__init__.py
+++ b/neo/io/__init__.py
@@ -280,24 +280,17 @@ Classes:
 
 import pathlib
 from collections import Counter
+import importlib.util
 
-# try to import the neuroshare library.
+# check if neuroshare library exists
 # if it is present, use the neuroshareapiio to load neuroshare files
 # if it is not present, use the neurosharectypesio to load files
-try:
-    import neuroshare as ns
-except ModuleNotFoundError as err:
-    from neo.io.neurosharectypesio import NeurosharectypesIO as NeuroshareIO
 
-    # print("\n neuroshare library not found, loading data with ctypes" )
-    # print("\n to use the API be sure to install the library found at:")
-    # print("\n www.http://pythonhosted.org/neuroshare/")
-
-else:
+neuroshare_spec = importlib.util.find_spec("neuroshare")
+if neuroshare_spec is not None:
     from neo.io.neuroshareapiio import NeuroshareapiIO as NeuroshareIO
-
-    # print("neuroshare library successfully imported")
-    # print("\n loading with API...")
+else:
+    from neo.io.neurosharectypesio import NeurosharectypesIO as NeuroshareIO
 
 from neo.io.alphaomegaio import AlphaOmegaIO
 from neo.io.asciiimageio import AsciiImageIO

--- a/neo/io/baseio.py
+++ b/neo/io/baseio.py
@@ -13,11 +13,7 @@ If you want a model for developing a new IO start from exampleIO.
 
 from __future__ import annotations
 from pathlib import Path
-
-try:
-    from collections.abc import Sequence
-except ImportError:
-    from collections import Sequence
+from collections.abc import Sequence
 import logging
 
 from neo import logging_handler

--- a/neo/io/nixio.py
+++ b/neo/io/nixio.py
@@ -27,6 +27,8 @@ import itertools
 from uuid import uuid4
 import warnings
 from packaging.version import Version
+import importlib.util
+import importlib.metadata
 
 import quantities as pq
 import numpy as np
@@ -122,17 +124,15 @@ def dt_from_nix(nixdt, annotype):
 
 
 def check_nix_version():
-    try:
-        import nixio
-    except ImportError:
-        raise Exception(
+    nixio_spec = importlib.util.find_spec("nixio")
+    if nixio_spec is None:
+        raise ImportError(
             "Failed to import NIX. "
             "The NixIO requires the Python package for NIX "
             "(nixio on PyPi). Try `pip install nixio`."
         )
 
-    # nixio version numbers have a 'v' prefix which breaks the comparison
-    nixverstr = nixio.__version__.lstrip("v")
+    nixverstr = importlib.metadata.version("nixio")
     try:
         nixver = Version(nixverstr)
     except ValueError:

--- a/neo/io/stimfitio.py
+++ b/neo/io/stimfitio.py
@@ -26,6 +26,8 @@ Based on exampleio.py and axonio.py from neo.io
 08 Feb 2014, C. Schmidt-Hieber, University College London
 """
 
+import importlib.util
+
 import numpy as np
 import quantities as pq
 
@@ -92,7 +94,9 @@ class StimfitIO(BaseIO):
         """
         # We need this module, so try importing now so that it fails on
         # instantiation rather than read_block
-        import stfio  # noqa
+        stfio_spec = importlib.util.find_spec("stfio")
+        if stfio_spec is None:
+            raise ImportError("stfio must be installed to use StimfitIO")
 
         BaseIO.__init__(self)
 


### PR DESCRIPTION
Worked on this for spikeinterface so also doing this here. As of python 3.8 this is desired way to verify packages. Also as of python 3.10 they completely removed sequence from collections so I think we should be fine to remove that try-except. 