### PR TITLE
Update setuptools on `pyproject.toml`

### DIFF
--- a/neo/rawio/intanrawio.py
+++ b/neo/rawio/intanrawio.py
@@ -1,5 +1,4 @@
 """
-
 Support for intan tech rhd and rhs files.
 
 These 2 formats are more or less the same but:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ download = "http://pypi.python.org/pypi/neo"
 
 
 [build-system]
-requires = ["setuptools>=62.0"]
+requires = ["setuptools>=78.0.2"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Should fix #1664

The deprecation was delayed in the latest version:

https://setuptools.pypa.io/en/stable/history.html?utm_source=chatgpt.com#v78-0-2

But they are still on the process of making a new release.

https://github.com/pypa/setuptools/commit/3c88de1c62420c1e0161f48e34af6424ac009aa5

Should be ready soon.