### PR TITLE
Prevent empty seg in `random_segment` which causes tests to fail stochastically

### DIFF
--- a/neo/test/generate_datasets.py
+++ b/neo/test/generate_datasets.py
@@ -165,6 +165,7 @@ def random_segment():
         rec_datetime=random_datetime(),
         **random_annotations(4),
     )
+    
     n_sigs = random.randint(0, 5)
     for i in range(n_sigs):
         seg.analogsignals.append(random_signal())
@@ -184,6 +185,10 @@ def random_segment():
     for i in range(n_imgs):
         seg.imagesequences.append(random_image_sequence())
     # todo: add some and ROI objects
+
+    # if we generate a completely empty segment then test suite fails
+    if n_sigs + n_irrsigs + n_events + n_epochs + n_spiketrains + n_imgs == 0:
+        seg = random_segment()
 
     return seg
 


### PR DESCRIPTION
Basically we have stochastic failures in this test https://github.com/NeuralEnsemble/python-neo/blob/74c97fdf4b549d632c1cfb85b9ab79cdab8f1a6b/neo/test/coretest/test_segment.py#L46-L66

because currently we sometimes generate a completely empty segment with nothing in it so the list of `t_starts` is empty which causes the `min` function to fail. This makes us have to re-run the test CI to  get a result. Instead I made the function recursive such that each segment needs to have at least one of the types of children objects for testing purposes (to be clear it just needs one so if the n_child is 0 for all types of children then it fails which is what causes the test to stochastically fail). 

The other option would be to change the test to accept the fact we have an empty segment. So let me know what you think @apdavison !