### PR TITLE
Fix ci testing-datalad install for python 3.12 + git-annex

### DIFF
--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -76,7 +76,7 @@ jobs:
         # restore-key hits should result in `cache-hit` == 'false'
         #if: steps.cache-conda-env.outputs.cache-hit != 'true'
         run: |
-          conda install pip numpy=${{ matrix.numpy-version }} -c conda-forge
+          conda install datalad pip numpy=${{ matrix.numpy-version }} -c conda-forge
         # this command is for updating cache. We are resting removal.
         # conda env update --name neo-test-env-${{ matrix.python-version }} --file environment_testing.yml --prune
 
@@ -85,20 +85,6 @@ jobs:
           git config --global user.email "neo_ci@fake_mail.com"
           git config --global user.name "neo CI"
 
-      - name: Install git-annex
-        shell: bash
-        run: |
-          pip install datalad-installer
-          wget https://downloads.kitenet.net/git-annex/linux/current/git-annex-standalone-amd64.tar.gz
-          mkdir /home/runner/work/installation
-          mv git-annex-standalone-amd64.tar.gz /home/runner/work/installation/
-          workdir=$(pwd)
-          cd /home/runner/work/installation
-          tar xvzf git-annex-standalone-amd64.tar.gz
-          echo "$(pwd)/git-annex.linux" >> $GITHUB_PATH
-          cd $workdir
-          git config --global filter.annex.process "git-annex filter-process"  # recommended for efficiency
-          
       - name: Python version
         run: |
           which python

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -76,9 +76,23 @@ jobs:
         # restore-key hits should result in `cache-hit` == 'false'
         #if: steps.cache-conda-env.outputs.cache-hit != 'true'
         run: |
-          conda install datalad pip numpy=${{ matrix.numpy-version }} -c conda-forge
+          conda install pip numpy=${{ matrix.numpy-version }} -c conda-forge
         # this command is for updating cache. We are resting removal.
         # conda env update --name neo-test-env-${{ matrix.python-version }} --file environment_testing.yml --prune
+
+      - name: Install git-annex
+        shell: bash
+        run: |
+          pip install datalad-installer
+          wget https://downloads.kitenet.net/git-annex/linux/current/git-annex-standalone-amd64.tar.gz
+          mkdir /home/runner/work/installation
+          mv git-annex-standalone-amd64.tar.gz /home/runner/work/installation/
+          workdir=$(pwd)
+          cd /home/runner/work/installation
+          tar xvzf git-annex-standalone-amd64.tar.gz
+          echo "$(pwd)/git-annex.linux" >> $GITHUB_PATH
+          cd $workdir
+          git config --global filter.annex.process "git-annex filter-process"  # recommended for efficiency
 
       - name: Configure git
         run: |

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -81,6 +81,7 @@ jobs:
         # conda env update --name neo-test-env-${{ matrix.python-version }} --file environment_testing.yml --prune
 
       - name: Install git-annex
+        # this is the trick from the spikeinterface repo for getting git-annex to work with datalad
         shell: bash
         run: |
           pip install datalad-installer

--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -76,7 +76,7 @@ jobs:
         # restore-key hits should result in `cache-hit` == 'false'
         #if: steps.cache-conda-env.outputs.cache-hit != 'true'
         run: |
-          conda install datalad pip numpy=${{ matrix.numpy-version }} -c conda-forge
+          conda install pip numpy=${{ matrix.numpy-version }} -c conda-forge
         # this command is for updating cache. We are resting removal.
         # conda env update --name neo-test-env-${{ matrix.python-version }} --file environment_testing.yml --prune
 
@@ -85,6 +85,20 @@ jobs:
           git config --global user.email "neo_ci@fake_mail.com"
           git config --global user.name "neo CI"
 
+      - name: Install git-annex
+        shell: bash
+        run: |
+          pip install datalad-installer
+          wget https://downloads.kitenet.net/git-annex/linux/current/git-annex-standalone-amd64.tar.gz
+          mkdir /home/runner/work/installation
+          mv git-annex-standalone-amd64.tar.gz /home/runner/work/installation/
+          workdir=$(pwd)
+          cd /home/runner/work/installation
+          tar xvzf git-annex-standalone-amd64.tar.gz
+          echo "$(pwd)/git-annex.linux" >> $GITHUB_PATH
+          cd $workdir
+          git config --global filter.annex.process "git-annex filter-process"  # recommended for efficiency
+          
       - name: Python version
         run: |
           which python

--- a/neo/test/rawiotest/common_rawio_test.py
+++ b/neo/test/rawiotest/common_rawio_test.py
@@ -19,6 +19,8 @@ __test__ = False
 
 import logging
 import unittest
+import importlib.util
+import warnings
 
 from neo.utils.datasets import download_dataset, get_local_testing_data_folder, default_testing_repo
 
@@ -26,12 +28,12 @@ from neo.test.rawiotest.tools import can_use_network
 
 from neo.test.rawiotest import rawio_compliance as compliance
 
-try:
-    import datalad
-
+datalad_spec = importlib.util.find_spec("datalad")
+if datalad_spec is not None:
     HAVE_DATALAD = True
-except:
+else:
     HAVE_DATALAD = False
+    warnings.warn("datalad failure")
 
 # url_for_tests = "https://portal.g-node.org/neo/" #This is the old place
 repo_for_test = default_testing_repo

--- a/neo/test/rawiotest/common_rawio_test.py
+++ b/neo/test/rawiotest/common_rawio_test.py
@@ -33,7 +33,9 @@ if datalad_spec is not None:
     HAVE_DATALAD = True
 else:
     HAVE_DATALAD = False
-    warnings.warn("datalad failure")
+    # pytest skip doesn't explain why we are skipping. 
+    # warnings are easy to skip for users that don't want to have to read them.
+    warnings.warn("datalad failure. Please see installation instructions to run io-testing")
 
 # url_for_tests = "https://portal.g-node.org/neo/" #This is the old place
 repo_for_test = default_testing_repo

--- a/neo/test/rawiotest/common_rawio_test.py
+++ b/neo/test/rawiotest/common_rawio_test.py
@@ -21,6 +21,7 @@ import logging
 import unittest
 import importlib.util
 import warnings
+import os
 
 from neo.utils.datasets import download_dataset, get_local_testing_data_folder, default_testing_repo
 
@@ -34,8 +35,11 @@ if datalad_spec is not None:
 else:
     HAVE_DATALAD = False
     # pytest skip doesn't explain why we are skipping. 
-    # warnings are easy to skip for users that don't want to have to read them.
-    warnings.warn("datalad failure. Please see installation instructions to run io-testing")
+    # raise error if in CI to prevent tests from spuriously skipping and appearing
+    # as passing.
+    if os.environ.get("GITHUB_ACTIONS") == 'true':
+        raise RuntimeError("Datalad is required for running the CI.")
+    
 
 # url_for_tests = "https://portal.g-node.org/neo/" #This is the old place
 repo_for_test = default_testing_repo

--- a/neo/test/rawiotest/tools.py
+++ b/neo/test/rawiotest/tools.py
@@ -4,6 +4,8 @@ Common tools that are useful for neo.io object tests
 
 import logging
 import os
+import importlib.util
+
 
 logger = logging.getLogger("neo.test")
 
@@ -13,14 +15,18 @@ def can_use_network():
     Return True if network access is allowed
     """
 
+    # env variable for local dev
     if os.environ.get("NEO_TESTS_NO_NETWORK", False):
         return False
-    try:
-        import datalad
-
+    
+    # check for datalad presence
+    datalad_spec = importlib.util.find_spec("datalad")
+    if datalad_spec is not None:
         HAVE_DATALAD = True
-    except:
+    else:
         HAVE_DATALAD = False
+
     if not HAVE_DATALAD:
         return False
+    
     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     # "dhn_med_py<2.0", # ci failing with 2.0 test future version when stable
     "pytest",
     "pytest-cov",
-    # datalad   # this dependency is covered by conda (environment_testing.yml)-- maybe moving straight to ci
+    "datalad"
     "scipy>=1.0.0",
     "pyedflib",
     "h5py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     # "dhn_med_py<2.0", # ci failing with 2.0 test future version when stable
     "pytest",
     "pytest-cov",
-    "datalad"
+    "datalad",
     "scipy>=1.0.0",
     "pyedflib",
     "h5py",


### PR DESCRIPTION
I noticed our 3.12 testing is just skipping rather than running. I'll track down what is happening here.