### PR TITLE
Prep Release 0.14.1

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -4,15 +4,15 @@
   "license": "https://spdx.org/licenses/BSD-3-Clause",
   "codeRepository": "https://github.com/NeuralEnsemble/python-neo",
   "contIntegration": "https://github.com/NeuralEnsemble/python-neo/actions",
-  "dateModified": "2025-01-20",
-  "downloadUrl": "https://files.pythonhosted.org/packages/3b/91/c3630d766b3b959f8e604d8d41580c78973ece5f1e070b13bd9755dba60b/neo-0.14.0.tar.gz",
+  "dateModified": "2025-03-28",
+  "downloadUrl": "",
   "issueTracker": "https://github.com/NeuralEnsemble/python-neo/issues",
   "name": "Neo",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "identifier": "RRID:SCR_000634",
   "description": "Neo is a Python package for working with electrophysiology data in Python, together with support for reading a wide range of neurophysiology file formats, including Spike2, NeuroExplorer, AlphaOmega, Axon, Blackrock, Plexon, Tdt, and support for writing to a subset of these formats plus non-proprietary formats including HDF5.\n\nThe goal of Neo is to improve interoperability between Python tools for analyzing, visualizing and generating electrophysiology data by providing a common, shared object model. In order to be as lightweight a dependency as possible, Neo is deliberately limited to represention of data, with no functions for data analysis or visualization.\n\nNeo is used by a number of other software tools, including SpykeViewer (data analysis and visualization), Elephant (data analysis), the G-node suite (databasing), PyNN (simulations), tridesclous_ (spike sorting) and ephyviewer (data visualization).\n\nNeo implements a hierarchical data model well adapted to intracellular and extracellular electrophysiology and EEG data with support for multi-electrodes (for example tetrodes). Neo's data objects build on the quantities package, which in turn builds on NumPy by adding support for physical dimensions. Thus Neo objects behave just like normal NumPy arrays, but with additional metadata, checks for dimensional consistency and automatic unit conversion.",
   "applicationCategory": "neuroscience",
-  "releaseNotes": "https://neo.readthedocs.io/en/latest/releases/0.14.0.html",
+  "releaseNotes": "https://neo.readthedocs.io/en/latest/releases/0.14.1.html",
   "funding": "https://cordis.europa.eu/project/id/945539",
   "developmentStatus": "active",
   "referencePublication": "https://doi.org/10.3389/fninf.2014.00010",
@@ -114,6 +114,10 @@
     { "@type": "Person", "givenName": "Anthony", "familyName": "Pinto"},
     { "@type": "Person", "givenName": "Chris", "familyName": "Heydrick"},
     {"@type": "Person", "givenName": "Nikhil", "familyName": "Chandra"},
-    {"@type": "Person", "givenName": "Luigi", "familyName": "Petrucco"}
+    {"@type": "Person", "givenName": "Luigi", "familyName": "Petrucco"},
+    {"@type": "Person", "givenName": "Tommaso", "familyName": "Lambresa"},
+    {"@type": "Person", "givenName": "Rémi", "familyName": "Proville"},
+    {"@type": "Person", "givenName": "Nina", "familyName": "Kudryashova"},
+    {"@type": "Person", "givenName": "Paul", "familyName": "Adkisson"}
   ]
 }

--- a/doc/source/authors.rst
+++ b/doc/source/authors.rst
@@ -93,6 +93,7 @@ and may not be the current affiliation of a contributor.
 * Tommaso Lambresa [43]
 * Nina Kudryashova [37]
 * Rémi Proville [44]
+* Paul Adkisson [24]
 
 1. Centre de Recherche en Neuroscience de Lyon, CNRS UMR5292 - INSERM U1028 - Université Claude Bernard Lyon 1
 2. Unité de Neuroscience, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -60,7 +60,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Neo"
-copyright = "2010-2024, " + AUTHORS
+copyright = "2010-2025, " + AUTHORS
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/source/releases.rst
+++ b/doc/source/releases.rst
@@ -6,6 +6,7 @@ Release notes
 .. toctree::
    :maxdepth: 1
 
+   releases/0.14.1.rst
    releases/0.14.0.rst
    releases/0.13.4.rst
    releases/0.13.3.rst

--- a/doc/source/releases/0.14.1.rst
+++ b/doc/source/releases/0.14.1.rst
@@ -1,0 +1,54 @@
+========================
+Neo 0.14.1 release notes
+========================
+
+xxCHANGE MExx April 25
+
+This release of Neo includes many bug fixes in various IOs, a new HTML based repr, and fixes to the CI all with an eye toward our 1.0 release.
+
+See all `pull requests`_ included in this release and the `list of closed issues`_.
+
+
+Updated dependencies
+--------------------
+
+setuptools >= 78.0.2
+
+Import improvements
+-------------------
+
+As part of our ongoing effort to improve the speed of importing Neo we have moved the library over to using :code:`importlib.util.find_spec`
+rather than eagerly importing packages.
+
+CI Improvements
+---------------
+
+The install for datalad/git-annex in the CI was fixed for our Python 3.12 tests allowing for all IOs to be tested on Python 3.9 and Python 3.12.
+The buidling of documentation was improved by fixing code style errors.
+
+
+HTML repr
+---------
+
+Thanks to the work of Heberto Mayorquin Neo now supports an html based repr. To see an example check out `html repr`_.
+
+
+Bug fixes and improvements in IO modules
+----------------------------------------
+
+Bug fixes and/or improvements have been made to :code:`BlackRockIO`, :code:`SpikeGLXIO`, :code:`MaxwellIO`, :code:`IntanIO`, :code:`TdtIO`,
+:code:`OpenEphysBinaryIO`, :code:`NeoMatlabIO`, :code:`EdfIO`, and :code:`SpikeGadgetsIO`.
+
+
+Acknowledgements
+----------------
+
+Thanks to Heberto Mayorquin, Zach McKenzie, Andrew Davison, Alessio Buccino, Rémi Proville, Paul Adkisson, Tommaso Lambresa, and Nina Kudryashova
+
+
+
+.. _`html repr` : https://github.com/NeuralEnsemble/python-neo/pull/1651
+
+.. _`pull requests` : https://github.com/NeuralEnsemble/python-neo/pulls?q=is%3Apr+is%3Aclosed+milestone%3A0.14.1
+
+.. _`list of closed issues` : https://github.com/NeuralEnsemble/python-neo/issues?q=is%3Aissue%20state%3Aclosed%20milestone%3A0.14.1

--- a/doc/source/releases/0.14.1.rst
+++ b/doc/source/releases/0.14.1.rst
@@ -2,7 +2,7 @@
 Neo 0.14.1 release notes
 ========================
 
-11 April 25
+14 April 25
 
 This release of Neo includes many bug fixes in various IOs, a new HTML based repr, and fixes to the CI all with an eye toward our 1.0 release.
 

--- a/doc/source/releases/0.14.1.rst
+++ b/doc/source/releases/0.14.1.rst
@@ -2,7 +2,7 @@
 Neo 0.14.1 release notes
 ========================
 
-xxCHANGE MExx April 25
+11 April 25
 
 This release of Neo includes many bug fixes in various IOs, a new HTML based repr, and fixes to the CI all with an eye toward our 1.0 release.
 
@@ -13,12 +13,13 @@ Updated dependencies
 --------------------
 
 setuptools >= 78.0.2
+numpy >= 1.24.4
 
 Import improvements
 -------------------
 
 As part of our ongoing effort to improve the speed of importing Neo we have moved the library over to using :code:`importlib.util.find_spec`
-rather than eagerly importing packages.
+rather than eagerly importing packages in :code:`try-except` blocks.
 
 CI Improvements
 ---------------
@@ -37,13 +38,14 @@ Bug fixes and improvements in IO modules
 ----------------------------------------
 
 Bug fixes and/or improvements have been made to :code:`BlackRockIO`, :code:`SpikeGLXIO`, :code:`MaxwellIO`, :code:`IntanIO`, :code:`TdtIO`,
-:code:`OpenEphysBinaryIO`, :code:`NeoMatlabIO`, :code:`EdfIO`, and :code:`SpikeGadgetsIO`.
+:code:`OpenEphysBinaryIO`, :code:`NeoMatlabIO`, :code:`EdfIO`, :code:`Neuralynx`, and :code:`SpikeGadgetsIO`.
 
 
 Acknowledgements
 ----------------
 
-Thanks to Heberto Mayorquin, Zach McKenzie, Andrew Davison, Alessio Buccino, Rémi Proville, Paul Adkisson, Tommaso Lambresa, and Nina Kudryashova
+Thanks to Heberto Mayorquin, Zach McKenzie, Andrew Davison, Alessio Buccino, Rémi Proville, Paul Adkisson, Baptiste Grimaud, 
+Robert Wolff, Tommaso Lambresa, and Nina Kudryashova.
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neo"
-version = "0.15.0.dev0"
+version = "0.14.1"
 authors = [{name = "Neo authors and contributors"}]
 description = "Neo is a package for representing electrophysiology data in Python, together with support for reading a wide range of neurophysiology file formats"
 readme = "README.rst"


### PR DESCRIPTION
Just so we have everything ready after our meeting. We've had touchups to 9 IOs so I think a point release is merited. We will see if we want to hold off a week after the meeting as I can imagine 2-3 more PRs for IOs that would like to be included.

Also I have the authors updated and the codemeta.json, but I want to wait to commit those until I hear back from one more person about being included.

I've fixed the milestones on issues and PRs already for 0.14.1. 