### PR TITLE
Black Formatting Manually

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -276,8 +276,8 @@ class BlackrockRawIO(BaseRawIO):
             self.internal_unit_ids = []  # pair of chan['packet_id'], spikes['unit_class_nb']
             for i in range(len(self.__nev_ext_header[b"NEUEVWAV"])):
 
-                # electrode_id values are stored at uint16 which can overflow when 
-                # multiplying by 1000 below. We convert to a regular python int which 
+                # electrode_id values are stored at uint16 which can overflow when
+                # multiplying by 1000 below. We convert to a regular python int which
                 # won't overflow
                 channel_id = int(self.__nev_ext_header[b"NEUEVWAV"]["electrode_id"][i])
 

--- a/neo/rawio/spikegadgetsrawio.py
+++ b/neo/rawio/spikegadgetsrawio.py
@@ -227,7 +227,9 @@ class SpikeGadgetsRawIO(BaseRawIO):
             if num_ephy_channels % num_chan_per_chip == 0:
                 all_hw_chans = [int(schan.attrib["hwChan"]) for trode in sconf for schan in trode]
                 missing_hw_chans = set(range(num_ephy_channels)) - set(all_hw_chans)
-                channel_ids = self._produce_ephys_channel_ids(num_ephy_channels_xml, num_chan_per_chip, missing_hw_chans)
+                channel_ids = self._produce_ephys_channel_ids(
+                    num_ephy_channels_xml, num_chan_per_chip, missing_hw_chans
+                )
                 raw_channel_ids = False
             else:
                 raw_channel_ids = True

--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -376,7 +376,6 @@ def scan_files(dirname):
     for info in info_list:
         info["seg_index"] = segment_tuple_to_segment_index[get_segment_tuple(info)]
 
-
     for info in info_list:
         # device_kind is imec, nidq
         if info.get("device_kind") == "imec":

--- a/neo/test/generate_datasets.py
+++ b/neo/test/generate_datasets.py
@@ -165,7 +165,7 @@ def random_segment():
         rec_datetime=random_datetime(),
         **random_annotations(4),
     )
-    
+
     n_sigs = random.randint(0, 5)
     for i in range(n_sigs):
         seg.analogsignals.append(random_signal())

--- a/neo/test/rawiotest/test_spikegadgetsrawio.py
+++ b/neo/test/rawiotest/test_spikegadgetsrawio.py
@@ -21,11 +21,12 @@ class TestSpikeGadgetsRawIO(
     def test_parse_header_missing_channels(self):
 
         file_path = Path(self.get_local_path("spikegadgets/SL18_D19_S01_F01_BOX_SLP_20230503_112642_stubbed.rec"))
-        reader = SpikeGadgetsRawIO(filename = file_path)
+        reader = SpikeGadgetsRawIO(filename=file_path)
         reader.parse_header()
 
         assert_array_equal(
-            reader.header['signal_channels']['id'],
+            reader.header["signal_channels"]["id"],
+            # fmt: off
             [
                 'ECU_Ain1', 'ECU_Ain2', 'ECU_Ain3', 'ECU_Ain4', 'ECU_Ain5', 'ECU_Ain6',
                 'ECU_Ain7', 'ECU_Ain8', 'ECU_Aout1', 'ECU_Aout2', 'ECU_Aout3', 'ECU_Aout4', '0',
@@ -46,6 +47,7 @@ class TestSpikeGadgetsRawIO(
                 '218', '250', '27', '59', '91', '123', '155', '187', '219', '251', '28', '60', '92',
                 '156', '188', '220', '252', '29', '61', '93', '125', '157', '189', '221', '253', '30',
                 '62', '94', '158', '190', '222', '254', '31', '63', '95', '127', '159', '191', '223',
-                '255',
+                '255'
             ]
+            # fmt: on
         )


### PR DESCRIPTION
@alejoe91 we both know Sam will close this :) :P 

Basically the issue was the new spike gadgets test for missing channels was going to lead to horrific formatting, so I had to close black formatting and add in the `fmt: off` in order to prevent that going forward :) 