### PR TITLE
Remove numpy scalar from stream name representation for neuralynx

### DIFF
--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -263,7 +263,7 @@ class NeuralynxRawIO(BaseRawIO):
                         t_start = copy.copy(file_mmap[0][0])
                     else:  # empty file
                         t_start = 0
-                    stream_prop = (info["sampling_rate"], n_packets, t_start)
+                    stream_prop = (float(info["sampling_rate"]), int(n_packets), float(t_start))
                     if stream_prop not in stream_props:
                         stream_props[stream_prop] = {"stream_id": len(stream_props), "filenames": [filename]}
                     else:


### PR DESCRIPTION
This is part of https://github.com/NeuralEnsemble/python-neo/issues/1678 but does not solve it completly. 