### PR TITLE
Update neuralynx regex for 5.6.0

### DIFF
--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -98,7 +98,8 @@ class NlxHeader(OrderedDict):
         ),
         # Cheetah version 5.6.0, some range of versions in between
         "v5.6.0": dict(
-            datetime1_regex=r"## Time Opened: \(m/d/y\): (?P<date>\S+)" r" At Time: (?P<time>\S+)",
+            datetime1_regex=r"## Time Opened \(m/d/y\): (?P<date>\S+)" r"  \(h:m:s.ms\) (?P<time>\S+)",
+            datetime2_regex=r"## Time Closed \(m/d/y\): (?P<date>\S+)" r"  \(h:m:s.ms\) (?P<time>\S+)",
             filename_regex=r"## File Name: (?P<filename>\S+)",
             datetimeformat="%m/%d/%Y %H:%M:%S.%f",
         ),


### PR DESCRIPTION
Fixes #1675 

This is based on what a user shared.

![image](https://github.com/user-attachments/assets/503b4b9e-bfbc-432f-a055-391946d4d9a8)

We can see in the header we were missing the (h:m:s.ms) for the regex and were missing the closed time. Let's see what happens with the test suite.