### PR TITLE
Update IO tests for Python 3.13

### DIFF
--- a/.github/workflows/io-test.yml
+++ b/.github/workflows/io-test.yml
@@ -18,8 +18,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.9', '3.12']
-        numpy-version: ['1.26', '2.0']
+        python-version: ['3.9', '3.13']
+        numpy-version: ['1.26', '2.2']
+        exclude:
+           - python-version: '3.9'
+             numpy-version: '2.2'
+           - python-version: '3.13'
+             numpy-version: '1.26'
     defaults:
       # by default run in bash mode (required for conda usage)
       run:


### PR DESCRIPTION
I think we should really test python 3.13 since 3.14 is almost out. We still need to test the oldest python with 1.26.

Or we add in other tests to be safe.
