### PR TITLE
NeuroNexusIO: Add in appropriate streams to go with buffer API

### DIFF
--- a/neo/rawio/neuronexusrawio.py
+++ b/neo/rawio/neuronexusrawio.py
@@ -217,7 +217,7 @@ class NeuroNexusRawIO(BaseRawWithBufferApiIO):
         signal_streams["buffer_id"] = buffer_id
         self._stream_buffer_slice = {}
         for stream_index, stream_id in enumerate(stream_ids):
-            name = stream_id_to_stream_name.get(int(stream_id), "")
+            name = stream_id_to_stream_name.get(stream_id, "")
             signal_streams["name"][stream_index] = name
             chan_inds = np.flatnonzero(signal_channels["stream_id"] == stream_id)
             self._stream_buffer_slice[stream_id] = chan_inds

--- a/neo/rawio/neuronexusrawio.py
+++ b/neo/rawio/neuronexusrawio.py
@@ -182,11 +182,11 @@ class NeuroNexusRawIO(BaseRawWithBufferApiIO):
             # 'a.u.' makes the units clearer
             elif channel_info["chan_type"][channel_index][:2] == "di":
                 units = "a.u."
-                stream_id = "di"
+                stream_id = "din"
             elif channel_info["chan_type"][channel_index][:2] == "do":
                 # aux channel
                 units = "a.u."
-                stream_id = "do"
+                stream_id = "dout"
             else:
                 units = "V"
                 stream_id = "aux"
@@ -302,7 +302,7 @@ class NeuroNexusRawIO(BaseRawWithBufferApiIO):
 # here we map the stream_id to the more descriptive stream_name
 stream_id_to_stream_name = {
     "ai-pri": "NeuroNexus Allego Analog (pri) Data",
-    "di": "NeuroNexus Allego Digital-in (din) Data",
-    "do": "NeuroNexus Allego Digital-out (dout) Data",
+    "din": "NeuroNexus Allego Digital-in (din) Data",
+    "dout": "NeuroNexus Allego Digital-out (dout) Data",
     "aux": "NeuroNexus Allego Auxiliary (aux) Data",
 }

--- a/neo/rawio/neuronexusrawio.py
+++ b/neo/rawio/neuronexusrawio.py
@@ -299,7 +299,7 @@ class NeuroNexusRawIO(BaseRawWithBufferApiIO):
 
 # here we map the stream_id to the more descriptive stream_name
 stream_id_to_stream_name = {
-    "0": "Neuronexus Allego Analog (pri) Data",
+    "0": "NeuroNexus Allego Analog (pri) Data",
     "1": "NeuroNexus Allego Digital-in (din) Data",
     "2": "NeuroNexus Allego Digital-out (dout) Data",
     "3": "NeuroNexus Allego Auxiliary (aux) Data",

--- a/neo/rawio/neuronexusrawio.py
+++ b/neo/rawio/neuronexusrawio.py
@@ -297,9 +297,7 @@ class NeuroNexusRawIO(BaseRawWithBufferApiIO):
         return self._buffer_descriptions[block_index][seg_index][buffer_id]
 
 
-# this is pretty useless right now, but I think after a
-# refactor with sub streams we could adapt this for the sub-streams
-# so let's leave this here for now :)
+# here we map the stream_id to the more descriptive stream_name
 stream_id_to_stream_name = {
     "0": "Neuronexus Allego Analog (pri) Data",
     "1": "NeuroNexus Allego Digital-in (din) Data",


### PR DESCRIPTION
I first implemented this before the buffer api and since this is one buffer for all streams we left them all packed together. Now that we have the buffer api we should divide these streams into
ephys data (called analog in allego docs)
din
dout
aux

~~No rush on this so we can wait until we figure out plexon2 tests.~~