### PR TITLE
Adopt the NumFOCUS Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,7 @@
 # [The NumFOCUS Code of Conduct](https://numfocus.org/code-of-conduct)
 
+Neo subscribes to the NumFOCUS Code of Conduct.
+
 ## The Short Version
 Be kind to others. Do not insult or put down others. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for NumFOCUS.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,46 +1,14 @@
-# Contributor Covenant Code of Conduct
+# [The NumFOCUS Code of Conduct](https://numfocus.org/code-of-conduct)
 
-## Our Pledge
+## The Short Version
+Be kind to others. Do not insult or put down others. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for NumFOCUS.
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate.
 
-## Our Standards
+NumFOCUS is dedicated to providing a harassment-free community for everyone, regardless of gender, sexual orientation, gender identity and expression, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of community members in any form.
 
-Examples of behavior that contributes to creating a positive environment include:
+Thank you for helping make this a welcoming, friendly community for all.
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+## The Complete Version
 
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
-
-## Scope
-
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at neo-maintainers@protonmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+The full version of the NumFOCUS Code of Conduct is available at the [NumFOCUS website](https://numfocus.org/code-of-conduct)

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ Neo objects behave just like normal NumPy arrays, but with additional metadata,
 checks for dimensional consistency and automatic unit conversion.
 
 A project with similar aims but for neuroimaging file formats is `NiBabel`_.
+Neo is a `NumFocus Affiliated Project`_.
 
 Code status
 -----------
@@ -82,3 +83,4 @@ and by the European Union's Research and Innovation Program Horizon Europe Grant
 .. _`issue tracker`: https://github.c
 .. _tridesclous: https://github.com/tridesclous/tridesclous
 .. _ephyviewer: https://github.com/NeuralEnsemble/ephyviewer
+.. _`NumFocus Affiliated Project`: https://numfocus.org/sponsored-projects/affiliated-projects

--- a/doc/source/governance.rst
+++ b/doc/source/governance.rst
@@ -5,7 +5,7 @@ Governance
 Neo is a community-developed project,
 we welcome contributions from anyone who is interested in the project.
 The project maintainers are the members of the `Neo maintainers team`_.
-All contributors agree to abide by the [NumFocus Code of Conduct](https://numfocus.org/code-of-conduct),
+All contributors agree to abide by the `NumFocus Code of Conduct`_,
 see the file `CODE_OF_CONDUCT.md`_.
 
 Contributions
@@ -50,3 +50,4 @@ The current maintainers are:
 .. _`@mdenker`: https://github.com/mdenker
 .. _`@alejoe91`: https://github.com/alejoe91
 .. _`@zm711`: https://github.com/zm711
+.. _`NumFocus Code of Conduct`: https://numfocus.org/code-of-conduct

--- a/doc/source/governance.rst
+++ b/doc/source/governance.rst
@@ -5,7 +5,8 @@ Governance
 Neo is a community-developed project,
 we welcome contributions from anyone who is interested in the project.
 The project maintainers are the members of the `Neo maintainers team`_.
-All contributors agree to abide by the Code of Conduct, see the file `CODE_OF_CONDUCT.md`_.
+All contributors agree to abide by the [NumFocus Code of Conduct](https://numfocus.org/code-of-conduct),
+see the file `CODE_OF_CONDUCT.md`_.
 
 Contributions
 =============


### PR DESCRIPTION
As decided in the last Neo Core Meeting, this MR replaces the current CoC with the NumFOCUS CoC. As recommended by NumFOCUS the MR does not copy the CoC, but rather links to the NumFOCUS document.

Furthermore this implies that Neo is now employing the NumFOCUS workflow for reporting CoC violations and NumFOCUS will advise Neo maintainers on how to proceed in case of a CoC violation.

The CoC also applies for events organized by the Neo Team, where the CoC will be introduced in the beginning of the event and a dedicated CoC contact person will be assigned.

Once this MR is merged I we will also announce the CoC change on the community mailing list.