### PR TITLE
NeuralynxIO: Add `python-dateutil` dependency 

### DIFF
--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -53,7 +53,6 @@ from ..baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
-from operator import itemgetter
 import numpy as np
 import os
 import pathlib

--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -1,4 +1,3 @@
-import dateutil
 from packaging.version import Version
 import os
 import re
@@ -317,7 +316,7 @@ class NlxHeader(OrderedDict):
         """
         Read time and date from text of header
         """
-
+        import dateutil
         # opening time
         sr = NlxHeader._openDatetime1_pat.search(txt_header)
         if not sr: sr=NlxHeader._openDatetime2_pat.search(txt_header)

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -1,5 +1,4 @@
 import datetime
-import dateutil
 import unittest
 
 import os
@@ -390,6 +389,7 @@ class TestNlxHeader(BaseTestRawIO, unittest.TestCase):
 
     # left in for possible future header tests
     def check_dateutil_parse(self, hdrTxt, openPat, closePat, openDate, closeDate):
+        import dateutil
         mtch = openPat.search(hdrTxt)
         self.assertIsNotNone(mtch)
         dt = mtch.groupdict()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ maxwell = ["h5py"]
 biocam = ["h5py"]
 med = ["dhn_med_py<2.0"] # ci failing with 2.0 test future version when stable
 plexon2 = ["zugbruecke>=0.2; sys_platform!='win32'", "wenv; sys_platform!='win32'"]
+neuralynx = ["python-dateutil"] 
 
 all = [
     "coverage",
@@ -126,6 +127,7 @@ all = [
     "tqdm",
     "wenv; sys_platform!='win32'",
     "zugbruecke>=0.2; sys_platform!='win32'",
+    "python-dateutil",
 ]
 # we do not include 'stfio' in 'all' as it is not pip installable
 


### PR DESCRIPTION
We previously had `python-dateutil` has a dependency of one of our dependencies. I didn't track which one, but that means when you do a non-core install you have `dateutil` automatically installed. This means that in #1571 we assumed that we had this package around. This broke our core testing so this PR does 2 things:

1) Make this dependency explicit for neuralynx
2) moves testing into the function so that core tests don't break.