### PR TITLE
 Blackrock add block validation

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -991,7 +991,7 @@ class BlackrockRawIO(BaseRawIO):
         while offset < filesize:
             packet_header = self.__read_nsx_dataheader(nsx_nb, offset)
             header_flag = packet_header["header_flag"]
-            assert header_flag == 1, f"Invalid header flag: {header_flag}"
+            # assert header_flag == 1, f"Invalid header flag: {header_flag}"
             timestamp = packet_header["timestamp"]
             offset_to_data_block_start = offset + packet_header.dtype.itemsize
             num_data_points = int(packet_header["nb_data_points"])


### PR DESCRIPTION
This is a PR I made when working together @luiztauffer to figure out how to open a malformed file. According to the blackrock spec heach data block has a flag indicating the start of the data block:

![image](https://github.com/user-attachments/assets/712fee09-bea7-4de7-8185-3d356f390635)

This PR adds a check and provides detailed debugging information including file offset, block index, expected vs actual values, and corruption indicators.

I also improved the  missing file error message which now specifically list which NSX files are missing and did other minor improvements like using f-string formatting for filename
construction, clearer variable naming (replacing ambiguous spec with spec_version and
dh with packet_header), etc. 