### PR TITLE
Fix Plexon2 Cron: Remove Windows from Cron job

### DIFF
--- a/.github/workflows/plexon2-testing.yml
+++ b/.github/workflows/plexon2-testing.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os:  [ubuntu-latest]
         python-version: ['3.9', '3.12']
         numpy-version: ['1.26', '2.0']
     defaults:


### PR DESCRIPTION
Windows tests failing due to bad install. Our testing is only written to test wine on linux. So remove windows-latest from cron.