### PR TITLE
Remove setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup()


### PR DESCRIPTION
@apdavison, maybe you want to keep this around, but this has been deprecated since setuptools  58.3.0. And copying from their documentation

```
However, python setup.py and the use of setup.py as a command line tool are deprecated.

This means that commands such as the following MUST NOT be run anymore:

python setup.py install

python setup.py develop

python setup.py sdist

python setup.py bdist_wheel
```

So although you can use setup.py as config we are not using that way. We were using it as back-compatibility for the command line build. Since the command line build options are no longer allowed I think we can safely remove this file.

https://packaging.python.org/en/latest/discussions/setup-py-deprecated/