### PR TITLE
SpikegadgetsRawIO: Fix infinite loop during header reading

### DIFF
--- a/neo/rawio/spikegadgetsrawio.py
+++ b/neo/rawio/spikegadgetsrawio.py
@@ -111,10 +111,18 @@ class SpikeGadgetsRawIO(BaseRawIO):
         # parse file until "</Configuration>"
         header_size = None
         with open(self.filename, mode="rb") as f:
+            # see https://github.com/NeuralEnsemble/python-neo/issues/1757 for bug with while loop
+            # instead we seek the end of the file so we know when we are at the end
+            # then readline returns an empty string at EOF so we confirm empty string + EOF location
+            f.seek(0,2)
+            end_of_file = f.tell()
+            f.seek(0)
             while True:
                 line = f.readline()
                 if b"</Configuration>" in line:
                     header_size = f.tell()
+                    break
+                if line == "" and f.tell() == end_of_file:
                     break
 
             if header_size is None:


### PR DESCRIPTION
As described in #1757. `f.readline()` never reaches EOF. Instead it returns `''`. So it will create an infinite while loop. Instead we can check the length of the xml file and once we reach an empty string that is at the length of the file then we know to break the while loop. 

I thought about just switching to a for loop but then `f.tell()` was giving OS errors. So I figured we could keep the `readline` but at in the check to prevent an infinite loop.

 @MGAMZ could you test this for me?