### PR TITLE
KwikIO: Limit IO to numpy < 2.3.0

### DIFF
--- a/neo/io/kwikio.py
+++ b/neo/io/kwikio.py
@@ -20,8 +20,12 @@ import os
 from neo.io.baseio import BaseIO
 
 # to import from core
-from neo.core import Segment, SpikeTrain, AnalogSignal, Block, Group
+from neo.core import Segment, SpikeTrain, AnalogSignal, Block, Group, NeoReadWriteError
 
+import importlib.metadata
+from packaging.version import Version, parse
+
+numpy_version = parse(importlib.metadata.version('numpy'))
 
 class KwikIO(BaseIO):
     """
@@ -58,6 +62,12 @@ class KwikIO(BaseIO):
         Arguments:
             filename : the filename
         """
+
+        if numpy_version >= Version("2.3.0"):
+            deprecation_msg = ("As the kwik package is no longer actively maintained it only works with NumPy < 2.3.0 and your environment "
+            f"has {numpy_version}. Downgrade your NumPy version to use this IO")
+            raise NeoReadWriteError(deprecation_msg)
+        
         from klusta import kwik
 
         BaseIO.__init__(self)

--- a/neo/test/iotest/test_kwikio.py
+++ b/neo/test/iotest/test_kwikio.py
@@ -3,12 +3,17 @@ Tests of neo.io.kwikio
 """
 
 import unittest
+import importlib.util
+import importlib.metadata
+from packaging.version import Version, parse
 
-try:
-    from klusta import kwik
-
+kwik_spec = importlib.util.find_spec('klusta')
+# kwik no longer works with recent versions of numpy
+numpy_version = parse(importlib.metadata.version('numpy'))
+numpy_okay = numpy_version < Version('2.3.0')
+if kwik_spec is not None and numpy_okay:
     HAVE_KWIK = True
-except ImportError:
+else:
     HAVE_KWIK = False
 
 from neo.io import kwikio


### PR DESCRIPTION
@alejoe91 @samuelgarcia @h-mayorquin,

So kwik hasn't been updated in 6 years and it is using code that has now been removed from NumPy breaking our testing. I've added in this strategy to block usage for inappropriate numpy unless you all think there is a better strategy? I make the error occur at init of the class, but I guess I could do some sort of import level magic.