### PR TITLE
Improve docstings of `OpenEphysBinaryRawIO`

### DIFF
--- a/neo/rawio/openephysbinaryrawio.py
+++ b/neo/rawio/openephysbinaryrawio.py
@@ -1096,24 +1096,6 @@ def explore_folder(dirname, experiment_names=None):
 
 
 def check_folder_consistency(folder_structure, possible_experiment_names=None):
-    """
-    Validate consistency of the discovered OpenEphys folder structure.
-
-    Ensures that multi-node recordings have consistent experiment/recording
-    structures and that streams are consistent across segments and blocks.
-
-    Parameters
-    ----------
-    folder_structure : dict
-        Folder structure from explore_folder()
-    possible_experiment_names : list, optional
-        Available experiment names for error messages
-
-    Raises
-    ------
-    ValueError
-        If folder structure is inconsistent
-    """
     # check that experiment names are the same for differend record nodes
     if len(folder_structure) > 1:
         experiments = None


### PR DESCRIPTION
While working on fixing [a neuroconv issue](https://github.com/catalystneuro/neuroconv/issues/1498), I noticed that the `OpenEphysBinaryRawIO` class lacks clear documentation about how the folder structure of the Open Ephys binary format is parsed and use internally. 

This PR improves the situation in two ways:  

1. The docstring now more explicitly describes the type of structure being parsed and clarifies that `dirname` can point to different levels within the folder tree, each yielding different parsing results.  

2. The current `explore_folder` function mixes two responsibilities:  
   - Parsing the folder structure.  
   - Mapping that structure into Neo.  

   To separate concerns, I split this logic into two private functions. Each now has a dedicated docstring that clearly explains its role.  **There is no change in implementation** the function is just split in two.

