### PR TITLE
Fix  `NeuralynxRawIO`  reading in one-dir mode with nested directories

### DIFF
--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -160,7 +160,7 @@ class NeuralynxRawIO(BaseRawIO):
             else:
                 exclude_filenames = exclude_filename
             warnings.warn(
-                "`exclude_filename` is deprecated and will be removed in v1.0. Please use `exclude_filenames` instead"
+                "`exclude_filename` is deprecated and will be removed in version 1.0. Please use `exclude_filenames` instead"
             )
 
         if include_filenames is None:

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -56,6 +56,7 @@ from ..baserawio import (
 import numpy as np
 import os
 import pathlib
+from pathlib import Path
 import copy
 import warnings
 from collections import namedtuple, OrderedDict
@@ -151,7 +152,7 @@ class NeuralynxRawIO(BaseRawIO):
 
         if filename is not None:
             include_filenames = [filename]
-            warnings.warn("`filename` is deprecated and will be removed. Please use `include_filenames` instead")
+            warnings.warn("`filename` is deprecated and will be removed in v1.0. Please use `include_filenames` instead")
 
         if exclude_filename is not None:
             if isinstance(exclude_filename, str):
@@ -159,7 +160,7 @@ class NeuralynxRawIO(BaseRawIO):
             else:
                 exclude_filenames = exclude_filename
             warnings.warn(
-                "`exclude_filename` is deprecated and will be removed. Please use `exclude_filenames` instead"
+                "`exclude_filename` is deprecated and will be removed in v1.0. Please use `exclude_filenames` instead"
             )
 
         if include_filenames is None:
@@ -214,30 +215,42 @@ class NeuralynxRawIO(BaseRawIO):
         unit_annotations = []
         event_annotations = []
 
-        if self.rawmode == "one-dir":
-            filenames = sorted(os.listdir(self.dirname))
-        else:
-            filenames = self.include_filenames
+        # 1) Get file paths based on mode and validate existence for multiple-files mode
+        if self.rawmode == "multiple-files":
+            # For multiple-files mode, validate that all explicitly provided files exist
+            file_paths = []
+            for filename in self.include_filenames:
+                full_path = Path(self.dirname) / filename
+                if not full_path.is_file():
+                    raise ValueError(
+                        f"Provided Filename is not a file: "
+                        f"{full_path}. If you want to provide a "
+                        f"directory use the `dirname` keyword"
+                    )
+                file_paths.append(full_path)
+        else:  # one-dir mode
+            # For one-dir mode, get all files from directory
+            dir_path = Path(self.dirname)
+            file_paths = [item for item in sorted(dir_path.iterdir()) if item.is_file()]
 
-        filenames = [f for f in filenames if f not in self.exclude_filenames]
-        full_filenames = [os.path.join(self.dirname, f) for f in filenames]
+        # 2) Filter by exclude filenames
+        file_paths = [fp for fp in file_paths if fp.name not in self.exclude_filenames]
 
-        for filename in full_filenames:
-            if not os.path.isfile(filename):
-                raise ValueError(
-                    f"Provided Filename is not a file: "
-                    f"{filename}. If you want to provide a "
-                    f"directory use the `dirname` keyword"
-                )
+        # 3) Filter to keep only files with correct extensions
+        # Note: suffix[1:] removes the leading dot from file extension (e.g., ".ncs" -> "ncs")
+        valid_file_paths = [
+            fp for fp in file_paths
+            if fp.suffix[1:].lower() in self.extensions
+        ]
+
+        # Convert back to strings for backwards compatibility with existing code
+        full_filenames = [str(fp) for fp in valid_file_paths]
 
         stream_props = {}  # {(sampling_rate, n_samples, t_start): {stream_id: [filenames]}
 
         for filename in full_filenames:
             _, ext = os.path.splitext(filename)
-            ext = ext[1:]  # remove dot
-            ext = ext.lower()  # make lower case for comparisons
-            if ext not in self.extensions:
-                continue
+            ext = ext[1:].lower()  # remove dot and make lower case
 
             # Skip Ncs files with only header. Other empty file types
             # will have an empty dataset constructed later.

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -55,7 +55,6 @@ from ..baserawio import (
 )
 import numpy as np
 import os
-import pathlib
 from pathlib import Path
 import copy
 import warnings
@@ -588,7 +587,7 @@ class NeuralynxRawIO(BaseRawIO):
         Create memory maps when needed
         see also https://github.com/numpy/numpy/issues/19340
         """
-        filename = pathlib.Path(filename)
+        filename = Path(filename)
         suffix = filename.suffix.lower()[1:]
 
         if suffix == "ncs":

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -152,7 +152,7 @@ class NeuralynxRawIO(BaseRawIO):
 
         if filename is not None:
             include_filenames = [filename]
-            warnings.warn("`filename` is deprecated and will be removed in v1.0. Please use `include_filenames` instead")
+            warnings.warn("`filename` is deprecated and will be removed in version 1.0. Please use `include_filenames` instead")
 
         if exclude_filename is not None:
             if isinstance(exclude_filename, str):

--- a/neo/rawio/neuralynxrawio/neuralynxrawio.py
+++ b/neo/rawio/neuralynxrawio/neuralynxrawio.py
@@ -231,7 +231,8 @@ class NeuralynxRawIO(BaseRawIO):
         else:  # one-dir mode
             # For one-dir mode, get all files from directory
             dir_path = Path(self.dirname)
-            file_paths = [item for item in sorted(dir_path.iterdir()) if item.is_file()]
+            file_paths = [p for p in dir_path.iterdir() if p.is_file()]
+            file_paths = sorted(file_paths, key=lambda p: p.name)
 
         # 2) Filter by exclude filenames
         file_paths = [fp for fp in file_paths if fp.name not in self.exclude_filenames]

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -175,6 +175,43 @@ class TestNeuralynxRawIO(
         self.assertEqual(len(rawio.header["spike_channels"]), 8)
         self.assertEqual(len(rawio.header["event_channels"]), 0)
 
+    def test_directory_in_data_folder(self):
+        """
+        Test that directories inside the data folder are properly ignored
+        and don't cause errors during parsing.
+        """
+        import tempfile
+        import shutil
+
+        # Use existing test data directory
+        dname = self.get_local_path("neuralynx/Cheetah_v5.6.3/original_data/")
+
+        # Create a temporary copy to avoid modifying test data
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_data_dir = os.path.join(temp_dir, "test_data")
+            shutil.copytree(dname, temp_data_dir)
+
+            # Create a subdirectory inside the test data
+            test_subdir = os.path.join(temp_data_dir, "raw fscv data with all recorded ch")
+            os.makedirs(test_subdir, exist_ok=True)
+
+            # Create some files in the subdirectory to make it more realistic
+            with open(os.path.join(test_subdir, "some_file.txt"), "w") as f:
+                f.write("test file content")
+
+            # This should not raise an error despite the directory presence
+            rawio = NeuralynxRawIO(dirname=temp_data_dir)
+            rawio.parse_header()
+
+            # Verify that the reader still works correctly
+            self.assertEqual(rawio._nb_segment, 2)
+            self.assertEqual(len(rawio.ncs_filenames), 2)
+            self.assertEqual(len(rawio.nev_filenames), 1)
+            sigHdrs = rawio.header["signal_channels"]
+            self.assertEqual(sigHdrs.size, 2)
+            self.assertEqual(len(rawio.header["spike_channels"]), 8)
+            self.assertEqual(len(rawio.header["event_channels"]), 2)
+
 
 class TestNcsRecordingType(BaseTestRawIO, unittest.TestCase):
     """


### PR DESCRIPTION
Users sometimes place extra directories and files under the Neuralynx root. Today, we exclude by extension, but in “one-dir” mode the reader asserts that every entry must be a file, which raises an error:

https://github.com/NeuralEnsemble/python-neo/blob/72ec76a0cc30ebdaf321a91460b51632959ee5cb/neo/rawio/neuralynxrawio/neuralynxrawio.py#L217-L231

We should fix this to (1) make the workflow more forgiving for users and (2) align behavior with `include_filenames`, which already allows nested folders.

Proposed change: restructure file discovery into three steps.

1) Gather candidates by mode:
   - **multiple-files**: validate existence only for the explicitly provided filenames.
   - **one-dir**: list directory entries and keep only regular files via `Path.is_file()` (silently ignore subdirectories).

2) Apply the excluded-filenames filter.

3) Keep only paths with valid Neuralynx extensions.

This ensures directories are ignored in “one-dir” mode while preserving strict validation in “multiple-files” mode, and it removes redundant extension checks from the main processing loop.

cc @weiglszonja 
