### PR TITLE
Fix, Neuralynx encoding error

### DIFF
--- a/neo/rawio/neuralynxrawio/nlxheader.py
+++ b/neo/rawio/neuralynxrawio/nlxheader.py
@@ -55,7 +55,13 @@ class NlxHeader(OrderedDict):
         ("DspHighCutNumTaps", "", None),
         ("DspHighCutFilterType", "", None),
         ("DspDelayCompensation", "", None),
-        ("DspFilterDelay_µs", "", None),
+        # DspFilterDelay key with flexible µ symbol matching
+        # Different Neuralynx versions encode the µ (micro) symbol differently:
+        # - Some files use single-byte encoding (latin-1): DspFilterDelay_µs (raw bytes: \xb5)
+        # - Other files use UTF-8 encoding: DspFilterDelay_µs (raw bytes: \xc2\xb5)
+        # When UTF-8 encoded µ (\xc2\xb5) is decoded with latin-1, it becomes "Âµ"
+        # This regex matches both variants: "µs" and "Âµs" but normalizes to "DspFilterDelay_µs"
+        (r"DspFilterDelay_[Â]?µs", "DspFilterDelay_µs", None),
         ("DisabledSubChannels", "", None),
         ("WaveformLength", "", int),
         ("AlignmentPt", "", None),

--- a/neo/test/rawiotest/test_neuralynxrawio.py
+++ b/neo/test/rawiotest/test_neuralynxrawio.py
@@ -31,6 +31,7 @@ class TestNeuralynxRawIO(
         "neuralynx/Cheetah_v5.6.3/original_data",
         "neuralynx/Cheetah_v5.7.4/original_data",
         "neuralynx/Cheetah_v6.3.2/incomplete_blocks",
+        "neuralynx/two_streams_different_header_encoding",
     ]
 
     def test_scan_ncs_files(self):


### PR DESCRIPTION
This is an issue with the same data discussed in #1778 


```
.
├── CSC145.ncs
├── CSC146.ncs
└── csc23_100.ncs
```

The problem is that the `DspFilterDelay_µs` is sometimes encoded in latin-1 and sometimes encoded in utf8. This means that we decoding with the current method (latin-1) sometimes this specific property is read without the micro symbol and creates a key error here:

https://github.com/NeuralEnsemble/python-neo/blob/72ec76a0cc30ebdaf321a91460b51632959ee5cb/neo/rawio/neuralynxrawio/neuralynxrawio.py#L543-L548


when aggregating annotations over the channels.

This patch fixes this by using a regex to match what Latin-1 will read if the data is encoded as UTF-8.

The deeper problem is that Neuralynx does not really maintain its promise of ASCII headers.

@weiglszonja 

<img width="1002" height="1276" alt="Screenshot from 2025-09-18 17-11-18" src="https://github.com/user-attachments/assets/036bf6eb-2ea1-45fc-bfa5-17686106054e" />
