### PR TITLE
fix handling of broken file references in brainvisionrawio

### DIFF
--- a/neo/rawio/brainvisionrawio.py
+++ b/neo/rawio/brainvisionrawio.py
@@ -55,7 +55,7 @@ class BrainVisionRawIO(BaseRawWithBufferApiIO):
         marker_filename = self.filename.replace(bname, vhdr_header["Common Infos"]["MarkerFile"])
         binary_filename = self.filename.replace(bname, vhdr_header["Common Infos"]["DataFile"])
 
-        binary_filename = self._ensure_filename(binary_filename, "binary")
+        binary_filename = self._ensure_filename(binary_filename, "data")
         marker_filename = self._ensure_filename(marker_filename, "marker")
 
         if vhdr_header["Common Infos"]["DataFormat"] != "BINARY":

--- a/neo/rawio/brainvisionrawio.py
+++ b/neo/rawio/brainvisionrawio.py
@@ -55,8 +55,8 @@ class BrainVisionRawIO(BaseRawWithBufferApiIO):
         marker_filename = self.filename.replace(bname, vhdr_header["Common Infos"]["MarkerFile"])
         binary_filename = self.filename.replace(bname, vhdr_header["Common Infos"]["DataFile"])
 
-        binary_filename = self._ensure_filename(binary_filename, "data")
-        marker_filename = self._ensure_filename(marker_filename, "marker")
+        marker_filename = self._ensure_filename(marker_filename, "marker", "MarkerFile")
+        binary_filename = self._ensure_filename(binary_filename, "data", "DataFile")
 
         if vhdr_header["Common Infos"]["DataFormat"] != "BINARY":
             raise NeoReadWriteError(
@@ -239,7 +239,7 @@ class BrainVisionRawIO(BaseRawWithBufferApiIO):
     def _get_analogsignal_buffer_description(self, block_index, seg_index, buffer_id):
         return self._buffer_descriptions[block_index][seg_index][buffer_id]
 
-    def _ensure_filename(self, filename, kind):
+    def _ensure_filename(self, filename, kind, entry_name):
         if not os.path.exists(filename):
             # file not found, subsequent import stage would fail
             ext = os.path.splitext(filename)[1]
@@ -256,6 +256,29 @@ class BrainVisionRawIO(BaseRawWithBufferApiIO):
                     f"prefix matched the .vhdr ({os.path.basename(alt_name)}). Using "
                     f"this file instead.")
                 filename = alt_name
+            else:
+                # we neither found the file referenced in the .vhdr file nor a file of
+                # same name as header with the desired extension; most likely a file went
+                # missing or was renamed in an inconsistent fashion; generate a useful
+                # error message
+                header_dname = os.path.dirname(self.filename)
+                header_bname = os.path.basename(self.filename)
+                referenced_bname = os.path.basename(filename)
+                alt_bname = os.path.basename(alt_name)
+                if alt_bname != referenced_bname:
+                    # this is only needed when the two candidate file names differ
+                    detail = (f" is named either as per the {entry_name}={referenced_bname} "
+                              f"line in the .vhdr file, or")
+                else:
+                    # we omit it if we can to make it less confusing
+                    detail = ""
+                self.logger.error(
+                    f"Did not find the {kind} file associated with .vhdr (header) " 
+                    f"file {header_bname!r} in folder {header_dname!r}.\n  Please make "
+                    f"sure the file{detail} is named the same way as the .vhdr file, but "
+                    f"ending in {ext} (i.e. {alt_bname}).\n  The import will likely fail, "
+                    f"but if it goes through, you can ignore this message (the check "
+                    f"can misfire on networked file systems).")
         return filename
 
 

--- a/neo/rawio/brainvisionrawio.py
+++ b/neo/rawio/brainvisionrawio.py
@@ -55,6 +55,9 @@ class BrainVisionRawIO(BaseRawWithBufferApiIO):
         marker_filename = self.filename.replace(bname, vhdr_header["Common Infos"]["MarkerFile"])
         binary_filename = self.filename.replace(bname, vhdr_header["Common Infos"]["DataFile"])
 
+        binary_filename = self._ensure_filename(binary_filename, "binary")
+        marker_filename = self._ensure_filename(marker_filename, "marker")
+
         if vhdr_header["Common Infos"]["DataFormat"] != "BINARY":
             raise NeoReadWriteError(
                 f"Only `BINARY` format has been implemented. Current Data Format is {vhdr_header['Common Infos']['DataFormat']}"
@@ -235,6 +238,25 @@ class BrainVisionRawIO(BaseRawWithBufferApiIO):
 
     def _get_analogsignal_buffer_description(self, block_index, seg_index, buffer_id):
         return self._buffer_descriptions[block_index][seg_index][buffer_id]
+
+    def _ensure_filename(self, filename, kind):
+        if not os.path.exists(filename):
+            # file not found, subsequent import stage would fail
+            ext = os.path.splitext(filename)[1]
+            # Check if we can fall back to a file with the same prefix as the .vhdr.
+            # This can happen when users rename their files but forget to edit the
+            # .vhdr file to fix the path reference to the binary and marker files,
+            # in which case import will fail. These files come in triples, like:
+            # myfile.vhdr, myfile.eeg and myfile.vmrk; this code will thus pick
+            # the next best alternative.
+            alt_name = self.filename.replace(".vhdr", ext)
+            if os.path.exists(alt_name):
+                self.logger.warning(
+                    f"The {kind} file {filename} was not found, but found a file whose "
+                    f"prefix matched the .vhdr ({os.path.basename(alt_name)}). Using "
+                    f"this file instead.")
+                filename = alt_name
+        return filename
 
 
 def read_brainvsion_soup(filename):


### PR DESCRIPTION
This fixes a problem where BrainVision files that had been renamed but were not patched by the user will fail to import.
BrainVision EEG files come in triples, as in `myfile.vhdr`, `myfile.eeg`, and `myfile.vmrk`.

The problem is that the `.vdhr` file has a textual reference to the sidecar `.vmrk` and `.eeg` files, as in the following example:

File `l3_s02b12c01.vmrk`:
```ini
[Common Infos]
Codepage=UTF-8
DataFile=l3_s02b12c01.eeg
MarkerFile=l3_s02b12c01.vmrk
```


... but when users rename all 3 files (eg to fix a mistyped subject/session name or etc.), the resulting files can no longer be imported with Neo, unless the user also manually edits the `.vhdr` file and fixes the reference.

This is the same feature also found in some other BV importers, e.g. [the one](https://github.com/sccn/bva-io/blob/master/pop_loadbv.m#L179-L183) in EEGLAB.

This is unfortunately somewhat common with published datasets (e.g. on [OpenNeuro](https://openneuro.org/)) where users often rename their files for publication but sometimes fail to make the textual edit of their vhdr files.