### PR TITLE
Fix over-segmentation in BlackRock

### DIFF
--- a/neo/rawio/blackrockrawio.py
+++ b/neo/rawio/blackrockrawio.py
@@ -849,11 +849,8 @@ class BlackrockRawIO(BaseRawIO):
         nsx_ext_header : numpy memmap
             Extended header information
         """
-        # Construct filename based on spec version
-        if spec == "2.1":
-            filename = ".".join([self._filenames["nsx"], f"ns{nsx_nb}"])
-        else:  # 2.2, 2.3, 3.0
-            filename = f"{self._filenames['nsx']}.ns{nsx_nb}"
+        # Construct filename
+        filename = f"{self._filenames['nsx']}.ns{nsx_nb}"
         
         # Get basic header structure for this spec
         basic_header_dtype = NSX_BASIC_HEADER_TYPES[spec]


### PR DESCRIPTION
This will fix #1770

Testing data is on https://gin.g-node.org/NeuralEnsemble/ephy_testing_data/pulls/167

I will add tests once that is merged.

This PR fixes #1770 using the methodology discussed on #1773. To do this, we do three things:
1) We separate the parsing of the data blocks from the segementation of the data
2) I also continue the refactor in #1772 and #1771 to not have dynamically loaded functions but to have the headers specified outside of the code in a global variable.
3) the reporting is now added to not only the PTP but also to the older formats that have timestamps.
4) I used a buffered version of the memmaps so we don't need to create a memamp per block but only views.

This is a large PR but I think that @samuelgarcia prefers them that way and he is the person that might end up reviewing it. I am happy to break it apart if whoever is gona review this prefers it that way.

