### PR TITLE
Fix spikeglx events memmap

### DIFF
--- a/neo/rawio/spikeglxrawio.py
+++ b/neo/rawio/spikeglxrawio.py
@@ -251,7 +251,13 @@ class SpikeGLXRawIO(BaseRawWithBufferApiIO):
                     # For example: if there are 8 analog channels (indices 0-7), the digital word is at index 8
                     num_samples = info["sample_length"]
                     num_channels = info["num_chan"]
-                    data = np.memmap(info["bin_file"], dtype="int16", mode="r", shape=(num_samples, num_channels), order="C")
+                    data = np.memmap(
+                        info["bin_file"],
+                        dtype="int16",
+                        mode="r",
+                        shape=(num_samples, num_channels),
+                        order="C",
+                    )
                     digital_word_channel_index = len(info["analog_channels"])
                     self._events_memmap_digital_word = data[:, digital_word_channel_index]
         event_channels = np.array(event_channels, dtype=_event_channel_dtype)


### PR DESCRIPTION
This PR fixes the memory inefficiency issue reported in #1610 where parsing NIDQ files with digital channels would allocate excessive memory during `parse_header()`. For a 2.8 GiB NIDQ file, initialization would allocate ~3.9 GiB of RSS, making it impossible to work with large recordings without running out of memory.

The fix implements lazy loading of event data by deferring the `np.unpackbits()` operation from `_parse_header()` to `_get_event_timestamps()`. During initialization, we now only create a memmap view of the digital word channel (virtual memory, no RAM allocation). The actual unpacking into individual event bits only happens when events are accessed, significantly reducing memory footprint during initialization. Additionally, `sample_length` is now calculated from the actual file size instead of metadata to handle stub/modified files correctly ( we did something similar before I don't know if you remember)

I ran some benchmarks using memray for some work files (a 844 MB NIDQ file): Peak memory reduced from 2.9 GB to 906 MB (68.7% reduction), with real RSS at initialization dropping from ~3.9 GB to ~20 MB (99.5% reduction).