### PR TITLE
Increase `_signal_stream_dtype` name length

### DIFF
--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -94,7 +94,7 @@ _signal_buffer_dtype = [
 ]
 # To be left an empty array if the concept of buffer is undefined for a reader.
 _signal_stream_dtype = [
-    ("name", "U64"),  # not necessarily unique
+    ("name", "U128"),  # not necessarily unique
     ("id", "U64"),  # must be unique
     (
         "buffer_id",


### PR DESCRIPTION
Closes @bparks13's issue on spikeinteface https://github.com/SpikeInterface/spikeinterface/issues/4185

The `_signal_stream_dtype` `name` in `baserawio` isn't long enough for certain files. Should more types be extended? All `U64`s?