### PR TITLE
fix TdtRawIO multi-block SEV file lookup (wrong path + case mismatch)

### DIFF
--- a/neo/rawio/tdtrawio.py
+++ b/neo/rawio/tdtrawio.py
@@ -288,12 +288,12 @@ class TdtRawIO(BaseRawIO):
                         block_path = self.dirname / segment_name
                         sev_regex = f"{tankname}_{segment_name}_{stream_name}_[cC]h{chan_id}.sev"
                         sev_filename = list(block_path.glob(sev_regex))
-if len(sev_filename) == 1:
-    sev_filename = sev_filename[0]
-elif len(sev_filename) == 0:
-    sev_filename = None   # Indirect flag for TEV Format, see issue 1087
-else:
-    raise ValueError(f"Multiple SEV files matched for channel {chan_id}: {sev_filename}")
+                        if len(sev_filename) == 1:
+                            sev_filename = sev_filename[0]
+                        elif len(sev_filename) == 0:
+                            sev_filename = None  # Indirect flag for TEV Format, see issue 1087
+                        else:
+                            raise ValueError(f"Multiple SEV files matched for channel {chan_id}: {sev_filename}")
                     else:
                         # for single block datasets the exact name of sev files is not known
                         sev_regex = f"*_[cC]h{chan_id}.sev"


### PR DESCRIPTION
Fixes multi-block SEV file lookup in TdtRawIO. Two bugs caused silent fallback to TEV, resulting in all channels reading identical data:

1. `path` variable at L290 was stale (from `iterdir()` loop at L103 or reassigned to tank root at L170),  never pointed to the block subdirectory where SEV files live
2. Filename used lowercase `ch` but TDT writes `Ch`,  not found on case-sensitive filesystems (Linux)

Fix: use `self.dirname / segment_name` for the correct block directory, and `[cC]h` glob to match both cases (same pattern the single-block path already uses).

Not caught by tests because `aep_05` (the only multi-block test dataset) has no SEV files.

Closes #1814 
