### PR TITLE
BlackrockRawIO: Add `_get_blackrock_timestamps` for per-sample timestamp retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ doc/*.nwb
 *.smr
 B95.zip
 grouped_ephys
+uv.lock
+.venv


### PR DESCRIPTION
This PR adds a private method `_get_blackrock_timestamps` to `BlackrockRawIO` that returns per-sample timestamps in seconds as a float64 array, implementing pillar 3 ("expose original acquisition timestamps") of the gap-handling API proposal in #1773. For PTP formats, actual per-sample hardware timestamps are extracted; for all other formats, timestamps within each data block are interpolated from the first sample using the sampling rate. The method is private for now to allow discussion of a public API on `BaseRawIO` later, but downstream users can already use it in the meantime.

Another reason to add this logic first is that it paves the way for generalizing `gap_tolerance_ms` to standard format variants (v2.2/v2.3/v3.0). Currently gap handling only works for PTP; by establishing a uniform per-sample timestamp representation across all formats, the segmentation pipeline can be rewritten as a single code path that applies `np.diff` based gap detection to any variant, eliminating the format-specific branching in `_segment_nsx_data` and making the code simpler.
