### PR TITLE
 Pin `setuptools<81` in test extras to unblock CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ test = [
     "h5py",
     "igor2",
     "klusta",
+    # klusta imports pkg_resources at module load; pkg_resources was moved
+    # out of setuptools>=81. Pin until klusta is removed or vendored.
+    "setuptools<81",
     "tqdm",
     "nixio",
     "matplotlib",


### PR DESCRIPTION
`NeoIoTest` has been failing on every recent PR (for example [#1831](https://github.com/NeuralEnsemble/python-neo/pull/1831), [#1832](https://github.com/NeuralEnsemble/python-neo/pull/1832), [#1833](https://github.com/NeuralEnsemble/python-neo/pull/1833), and older untouched branches like [#1694](https://github.com/NeuralEnsemble/python-neo/pull/1694)) with `ModuleNotFoundError: No module named 'pkg_resources'` from `neo/test/iotest/test_kwikio.py`. The error originates inside [`klusta`](https://github.com/kwikteam/klusta), which still does `import pkg_resources` at module load time. `pkg_resources` is no longer bundled with `setuptools>=81`, so the import fails. This PR adds `setuptools<81` to the `test` optional-dependencies group as an immediate workaround. 


