### PR TITLE
Fix test_time_slice_deepcopy_data() failure on numpy 2.4.x

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -26,11 +26,13 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        numpy-version: ['1.25.2', '1.26.4', '2.0.2','2.1.3', '2.2.6', '2.3.3']
+        numpy-version: ['1.25.2', '1.26.4', '2.0.2','2.1.3', '2.2.6', '2.3.3', '2.4.4']
         # 1.25: 3.11, 1.26: 3.12
         exclude:
            - python-version: '3.10'
              numpy-version: '2.3.3'
+           - python-version: '3.10'
+             numpy-version: '2.4.4'
            - python-version: '3.12'
              numpy-version: '1.25.2'
            - python-version: '3.13'

--- a/neo/test/coretest/test_analogsignal.py
+++ b/neo/test/coretest/test_analogsignal.py
@@ -545,15 +545,17 @@ class TestAnalogSignalArrayMethods(unittest.TestCase):
     def test__time_slice_deepcopy_data(self):
         result = self.signal1.time_slice(None, None)
 
-        # Change values of original array
+        # Take a copy of sliced array before any modifications
+        result_data = result.magnitude.copy()
+
+        # Change values of original array, sliced array should be unaffected (proves deep copy)
         self.signal1[2] = 7.3 * self.signal1.units
+        np.testing.assert_array_equal(result.magnitude, result_data)
 
-        np.testing.assert_raises(AssertionError, assert_array_equal, self.signal1, result)
-
-        # Change values of sliced array
+        # Take a copy of original array, then change values of sliced array, original array should be unaffected
+        signal1_data = self.signal1.magnitude.copy()
         result[3] = 9.5 * result.units
-
-        np.testing.assert_raises(AssertionError, assert_array_equal, self.signal1, result)
+        np.testing.assert_array_equal(self.signal1.magnitude, signal1_data)
 
     def test__slice_should_change_sampling_period(self):
         result1 = self.signal1[:2, 0]


### PR DESCRIPTION
numpy 2.4.x changed `assert_array_compare`, which in some circumstances causes a shape mismatch IndexError when comparing AnalogSignal objects, instead of the expected AssertionError.

This change tests deepcopy more directly, by taking a snapshot of the object before mutation and asserting it is unchanged afterwards.

Also add numpy 2.4.4 to the core-test CI matrix.

Fixes #1848