### PR TITLE
Add linting to the CI setup, using ruff

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,49 @@
+name: Ruff lint
+
+# Ruff runs on every PR and every push to master.
+#
+# Two steps:
+#   * Strict: runs the rule subset for which the codebase is clean today.
+#     Failures block the workflow, so regressions of these rules cannot be
+#     merged.
+#   * Backlog (non-blocking): runs the full configured ruleset (E, F, I) and
+#     surfaces the existing backlog of cleanups (import sorting, unused imports,
+#     long lines, etc.). It is marked `continue-on-error: true`; as the backlog
+#     is cleared the rules can be migrated into the strict step.
+
+on:
+  pull_request:
+    branches: [master]
+    types: [synchronize, opened, reopened, ready_for_review]
+  push:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff-strict:
+    name: Ruff (strict — real-bug rules)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run ruff (strict subset)
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check --select F821,F403,F405 ."
+
+  ruff-backlog:
+    name: Ruff (full ruleset — non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run ruff (full configured ruleset)
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check ."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,3 +141,14 @@ neo = ["resources/*.json"]
 
 [tool.black]
 line-length = 120
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+extend-exclude = ["doc/old_stuffs", "doc/build", "dist", "tmp.py"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401", "F403"]


### PR DESCRIPTION
To improve overall code quality, I suggest adding a linter to the CI setup. I've gone with ruff, because I've had good experiences with it (in particular, it is fast), but I'm open to consider a different linter. (Note that ruff also does formatting, it's a drop-in replacement for black)

For now the setup is quite forgiving, but we can toughen it up later.

The CI job first tests there are no regressions in code quality, then produces a report on things that could be improved (linter warnings and errors). As we gradually fix these, the rules can be made stricter.