### PR TITLE
Don't crash parsing ABF files with an invalid acquisition date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ B95.zip
 grouped_ephys
 uv.lock
 .venv
+.python-version

--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -665,21 +665,23 @@ def _parse_abf_v1(f, header_description):
     header["sProtocolPath"] = header["sProtocolPath"].replace(b"\\", b"/")
 
     # date and time
+    # ABF1 does not reliably store the calendar date here, so it is left at 1900-01-01 and only the
+    # time-of-day is read. A "no date" file writes the 0xFFFFFFFF sentinel, which reads as a
+    # negative time; a valid time-of-day is always in [0, 86400) seconds. Guard that range and fall
+    # back to rec_datetime=None, leaving any other value to build normally so real errors surface.
     YY = 1900
     MM = 1
     DD = 1
-    hh = int(header["lFileStartTime"] / 3600.0)
-    mm = int((header["lFileStartTime"] - hh * 3600) / 60)
-    ss = header["lFileStartTime"] - hh * 3600 - mm * 60
-    ms = int(np.mod(ss, 1) * 1e6)
-    ss = int(ss)
-    try:
-        header["rec_datetime"] = datetime.datetime(YY, MM, DD, hh, mm, ss, ms)
-    except (ValueError, OverflowError):
-        # Date/time header fields hold an out-of-range or "no date" sentinel
-        # (e.g. 0xFFFFFFFF). The acquisition date is non-essential annotation,
-        # so fall back to None rather than blocking the read of the signal.
+    seconds_per_day = 24 * 3600
+    if not (0 <= header["lFileStartTime"] < seconds_per_day):
         header["rec_datetime"] = None
+    else:
+        hh = int(header["lFileStartTime"] / 3600.0)
+        mm = int((header["lFileStartTime"] - hh * 3600) / 60)
+        ss = header["lFileStartTime"] - hh * 3600 - mm * 60
+        ms = int(np.mod(ss, 1) * 1e6)
+        ss = int(ss)
+        header["rec_datetime"] = datetime.datetime(YY, MM, DD, hh, mm, ss, ms)
 
     return header
 
@@ -1023,21 +1025,22 @@ def _parse_abf_v2(f, header_description):
         header["EpochInfo"].append(EpochInfo)
 
     # date and time
-    YY = int(header["uFileStartDate"] / 10000)
-    MM = int((header["uFileStartDate"] - YY * 10000) / 100)
-    DD = int(header["uFileStartDate"] - YY * 10000 - MM * 100)
-    hh = int(header["uFileStartTimeMS"] / 1000.0 / 3600.0)
-    mm = int((header["uFileStartTimeMS"] / 1000.0 - hh * 3600) / 60)
-    ss = header["uFileStartTimeMS"] / 1000.0 - hh * 3600 - mm * 60
-    ms = int(np.mod(ss, 1) * 1e6)
-    ss = int(ss)
-    try:
-        header["rec_datetime"] = datetime.datetime(YY, MM, DD, hh, mm, ss, ms)
-    except (ValueError, OverflowError):
-        # Date/time header fields hold an out-of-range or "no date" sentinel
-        # (e.g. 0xFFFFFFFF). The acquisition date is non-essential annotation,
-        # so fall back to None rather than blocking the read of the signal.
+    # A "no date" sentinel (0 = unset, 0xFFFFFFFF = all bits set) has no valid date to build, so
+    # fall back to rec_datetime=None. Any other value is trusted and left to raise if genuinely out
+    # of range, so a real parsing error surfaces rather than being masked.
+    no_date_sentinels = (0, 0xFFFFFFFF)
+    if header["uFileStartDate"] in no_date_sentinels:
         header["rec_datetime"] = None
+    else:
+        YY = int(header["uFileStartDate"] / 10000)
+        MM = int((header["uFileStartDate"] - YY * 10000) / 100)
+        DD = int(header["uFileStartDate"] - YY * 10000 - MM * 100)
+        hh = int(header["uFileStartTimeMS"] / 1000.0 / 3600.0)
+        mm = int((header["uFileStartTimeMS"] / 1000.0 - hh * 3600) / 60)
+        ss = header["uFileStartTimeMS"] / 1000.0 - hh * 3600 - mm * 60
+        ms = int(np.mod(ss, 1) * 1e6)
+        ss = int(ss)
+        header["rec_datetime"] = datetime.datetime(YY, MM, DD, hh, mm, ss, ms)
 
     return header
 

--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -665,14 +665,12 @@ def _parse_abf_v1(f, header_description):
     header["sProtocolPath"] = header["sProtocolPath"].replace(b"\\", b"/")
 
     # date and time
-    # ABF1 does not reliably store the calendar date here, so it is left at 1900-01-01 and only the
-    # time-of-day is read. A "no date" file writes the 0xFFFFFFFF sentinel, which reads as a
-    # negative time; a valid time-of-day is always in [0, 86400) seconds. Guard that range and fall
-    # back to rec_datetime=None, leaving any other value to build normally so real errors surface.
     YY = 1900
     MM = 1
     DD = 1
     seconds_per_day = 24 * 3600
+    # A "no date" file writes the 0xFFFFFFFF sentinel, which reads as a negative time; fall back to
+    # rec_datetime=None instead of crashing on the resulting out-of-range time-of-day.
     if not (0 <= header["lFileStartTime"] < seconds_per_day):
         header["rec_datetime"] = None
     else:

--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -673,7 +673,13 @@ def _parse_abf_v1(f, header_description):
     ss = header["lFileStartTime"] - hh * 3600 - mm * 60
     ms = int(np.mod(ss, 1) * 1e6)
     ss = int(ss)
-    header["rec_datetime"] = datetime.datetime(YY, MM, DD, hh, mm, ss, ms)
+    try:
+        header["rec_datetime"] = datetime.datetime(YY, MM, DD, hh, mm, ss, ms)
+    except (ValueError, OverflowError):
+        # Date/time header fields hold an out-of-range or "no date" sentinel
+        # (e.g. 0xFFFFFFFF). The acquisition date is non-essential annotation,
+        # so fall back to None rather than blocking the read of the signal.
+        header["rec_datetime"] = None
 
     return header
 
@@ -1025,7 +1031,13 @@ def _parse_abf_v2(f, header_description):
     ss = header["uFileStartTimeMS"] / 1000.0 - hh * 3600 - mm * 60
     ms = int(np.mod(ss, 1) * 1e6)
     ss = int(ss)
-    header["rec_datetime"] = datetime.datetime(YY, MM, DD, hh, mm, ss, ms)
+    try:
+        header["rec_datetime"] = datetime.datetime(YY, MM, DD, hh, mm, ss, ms)
+    except (ValueError, OverflowError):
+        # Date/time header fields hold an out-of-range or "no date" sentinel
+        # (e.g. 0xFFFFFFFF). The acquisition date is non-essential annotation,
+        # so fall back to None rather than blocking the read of the signal.
+        header["rec_datetime"] = None
 
     return header
 

--- a/neo/test/rawiotest/test_axonrawio.py
+++ b/neo/test/rawiotest/test_axonrawio.py
@@ -1,6 +1,6 @@
 import unittest
 
-from neo.rawio.axonrawio import AxonRawIO
+from neo.rawio.axonrawio import AxonRawIO, parse_axon_soup
 
 from neo.test.rawiotest.common_rawio_test import BaseTestRawIO
 
@@ -27,6 +27,18 @@ class TestAxonRawIO(
         reader.parse_header()
 
         reader.read_raw_protocol()
+
+    def test_invalid_date_falls_back_to_none(self):
+        # Some ABF files store an out-of-range / "no date" sentinel (e.g. 0xFFFFFFFF)
+        # in the acquisition date header fields. The date is non-essential annotation,
+        # so parsing must fall back to rec_datetime=None rather than raising and
+        # blocking access to the signal.
+        for fixture in [
+            "axon/intracellular_data/files_with_errors/invalid_date_abf1.abf",  # ABF v1
+            "axon/intracellular_data/files_with_errors/invalid_date_abf2.abf",  # ABF v2
+        ]:
+            header = parse_axon_soup(self.get_local_path(fixture))
+            self.assertIsNone(header["rec_datetime"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some ABF files store a "no date" sentinel (all bits set) in their date header fields, and `AxonRawIO` currently raises while building the recording datetime from those values, which blocks reading the file entirely even though the date is non-essential annotation. Both the ABF v1 and ABF v2 paths produce out-of-range values from this sentinel, so parsing now falls back to a `None` recording datetime rather than failing, keeping the signal accessible. 
