### PR TITLE
Raise a clear error on ABF files whose header reports an impossible signal size (integer overflow)

### DIFF
--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -46,6 +46,7 @@ reads abf files - would be good to cross-check
 
 """
 
+import os
 import struct
 import datetime
 from io import open, BufferedReader
@@ -160,9 +161,17 @@ class AxonRawIO(BaseRawWithBufferApiIO):
         self._t_starts = {}
         self._buffer_descriptions = {0: {}}
         self._stream_buffer_slice = {stream_id: None}
+        # Offsets and segment sizes come from header fields that can be corrupt
+        # (truncated file, header surgery). Do the arithmetic in Python ints so it
+        # cannot silently overflow as numpy int32 would, and validate the implied
+        # data extent against the file on disk so a bad header raises a clear error
+        # rather than returning garbage or negative signal sizes.
+        head_offset = int(head_offset)
+        file_size = os.path.getsize(self.filename)
+
         pos = 0
         for seg_index in range(nb_segment):
-            length = episode_array[seg_index]["len"]
+            length = int(episode_array[seg_index]["len"])
 
             if version < 2.0:
                 fSynchTimeUnit = info["fSynchTimeUnit"]
@@ -171,6 +180,11 @@ class AxonRawIO(BaseRawWithBufferApiIO):
 
             if (fSynchTimeUnit != 0) and (mode == 1):
                 length /= fSynchTimeUnit
+
+            if length < 0:
+                raise NeoReadWriteError(
+                    f"Negative segment size ({length}) parsed from {self.filename}; the file header is corrupt."
+                )
 
             self._buffer_descriptions[0][seg_index] = {}
             self._buffer_descriptions[0][seg_index][buffer_id] = {
@@ -189,6 +203,13 @@ class AxonRawIO(BaseRawWithBufferApiIO):
             else:
                 t_start = t_start * fSynchTimeUnit * 1e-6
             self._t_starts[seg_index] = t_start
+
+        implied_data_end = head_offset + pos * sig_dtype.itemsize
+        if implied_data_end > file_size:
+            raise NeoReadWriteError(
+                f"ABF header implies {pos} samples ending at byte {implied_data_end}, which exceeds the "
+                f"file size of {file_size} bytes for {self.filename}; the file header is corrupt or the file is truncated."
+            )
 
         # Create channel header
         if version < 2.0:

--- a/neo/test/rawiotest/test_axonrawio.py
+++ b/neo/test/rawiotest/test_axonrawio.py
@@ -1,6 +1,7 @@
 import unittest
 
 from neo.rawio.axonrawio import AxonRawIO
+from neo.core import NeoReadWriteError
 
 from neo.test.rawiotest.common_rawio_test import BaseTestRawIO
 
@@ -27,6 +28,29 @@ class TestAxonRawIO(
         reader.parse_header()
 
         reader.read_raw_protocol()
+
+    def test_integer_overflow_size_raises(self):
+        # An ABF header that claims more samples than the file can hold must raise a
+        # clear error instead of silently returning an overflowed signal size.
+        path = self.get_local_path("axon/intracellular_data/files_with_errors/integer_overflow_size.abf")
+        expected_error = (
+            "ABF header implies 3221225472 samples ending at byte 6442457600, which exceeds the "
+            f"file size of 8704 bytes for {path}; the file header is corrupt or the file is truncated."
+        )
+        reader = AxonRawIO(filename=path)
+        with self.assertRaises(NeoReadWriteError) as cm:
+            reader.parse_header()
+        self.assertEqual(str(cm.exception), expected_error)
+
+    def test_negative_segment_size_raises(self):
+        # An ABF header with a negative segment size must raise a clear error
+        # instead of silently returning a negative signal size.
+        path = self.get_local_path("axon/intracellular_data/files_with_errors/negative_synch_length.abf")
+        expected_error = f"Negative segment size (-1041598657) parsed from {path}; the file header is corrupt."
+        reader = AxonRawIO(filename=path)
+        with self.assertRaises(NeoReadWriteError) as cm:
+            reader.parse_header()
+        self.assertEqual(str(cm.exception), expected_error)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When an ABF file's header reports more data than the file can actually hold, `AxonRawIO` does the segment offset and size arithmetic in fixed-width integers that silently overflow, so `parse_header()` succeeds and reports a garbage (or even negative) signal size. The failure then surfaces far from its cause: a downstream read either crashes deep in the data path with an opaque `mmap length is greater than file size`, naming neither the file nor the reason, or in the worst case reads out of bounds and hands back wrong data with no error at all. This bit both @luiztauffer and me while writing ABF converters,

This change does the offset and size arithmetic in arbitrary-precision Python integers so it can no longer wrap, and validates the implied data extent against the file on disk during parsing. A damaged header is now rejected at the earliest possible point with an explicit error that names the file and says the header is corrupt or truncated, instead of parsing clean and detonating later (or silently). The error stays within the existing neo exception hierarchy, so callers that already guard their reads keep skipping bad files exactly as before, now with a message that actually explains what went wrong. Regression coverage uses two purpose-crafted fixtures on gin, one inflating the size into an overflow and one carrying a negative length, each asserting the specific error it should produce.
