### PR TITLE
ABF: Deduplicate non-unique signal channel ids instead of refusing the file

### DIFF
--- a/neo/rawio/axonrawio.py
+++ b/neo/rawio/axonrawio.py
@@ -190,11 +190,23 @@ class AxonRawIO(BaseRawWithBufferApiIO):
                 t_start = t_start * fSynchTimeUnit * 1e-6
             self._t_starts[seg_index] = t_start
 
-        # Create channel header
+        # Create channel header. By default assume channels 0..nbchannel-1 were sampled in order,
+        # which is always the case for version >= 2.0. For version < 2.0 the channel ids come from
+        # nADCSamplingSeq (the ADC sampling sequence) and are also used to index the per-channel
+        # metadata (name, units, gain). Some re-saved exports corrupt this sequence so every entry
+        # is the same value, which produces non-unique ids and makes every channel read channel 0's
+        # metadata; in that case we keep the sequential default instead.
+        channel_ids = list(range(nbchannel))
         if version < 2.0:
-            channel_ids = [chan_num for chan_num in info["nADCSamplingSeq"] if chan_num >= 0]
-        else:
-            channel_ids = list(range(nbchannel))
+            sampling_sequence_ids = [chan_num for chan_num in info["nADCSamplingSeq"] if chan_num >= 0]
+            non_unique_ids = len(set(sampling_sequence_ids)) != len(sampling_sequence_ids)
+            if non_unique_ids:
+                self.logger.warning(
+                    "nADCSamplingSeq has non-unique channel ids; assuming channels were sampled "
+                    "in order and using sequential ids instead."
+                )
+            else:
+                channel_ids = sampling_sequence_ids
 
         signal_channels = []
         adc_nums = []

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -709,10 +709,28 @@ class BaseRawIO:
                     f"do not have the same {_common_sig_characteristics} {unique_characteristics}"
                 )
 
-            # also check that channel_id is unique inside a stream
-            channel_ids = signal_channels[mask]["id"]
-            if np.unique(channel_ids).size != channel_ids.size:
-                raise ValueError(f"signal_channels do not have unique ids for stream {stream_index}")
+            # Channel ids must be unique inside a stream so a channel can be addressed by id
+            # (see channel_id_to_index). Some files, e.g. re-saved exports, store duplicate ids.
+            # Rather than refuse an otherwise-readable file, make the duplicates unique by
+            # suffixing them and warn, so the data stays readable and id-based selection works.
+            channel_indexes = np.flatnonzero(mask)
+            channel_ids = list(signal_channels["id"][channel_indexes])
+            if len(set(channel_ids)) != len(channel_ids):
+                used_ids = set()
+                deduplicated_ids = []
+                for channel_id in channel_ids:
+                    new_id = channel_id
+                    suffix = 0
+                    while new_id in used_ids:
+                        suffix += 1
+                        new_id = f"{channel_id}-{suffix}"
+                    used_ids.add(new_id)
+                    deduplicated_ids.append(new_id)
+                signal_channels["id"][channel_indexes] = deduplicated_ids
+                self.logger.warning(
+                    f"signal_channels in stream {stream_index} have non-unique ids; duplicates were "
+                    "made unique by suffixing so channels remain addressable by id."
+                )
 
         self._several_channel_groups = signal_streams.size > 1
 

--- a/neo/rawio/baserawio.py
+++ b/neo/rawio/baserawio.py
@@ -709,28 +709,10 @@ class BaseRawIO:
                     f"do not have the same {_common_sig_characteristics} {unique_characteristics}"
                 )
 
-            # Channel ids must be unique inside a stream so a channel can be addressed by id
-            # (see channel_id_to_index). Some files, e.g. re-saved exports, store duplicate ids.
-            # Rather than refuse an otherwise-readable file, make the duplicates unique by
-            # suffixing them and warn, so the data stays readable and id-based selection works.
-            channel_indexes = np.flatnonzero(mask)
-            channel_ids = list(signal_channels["id"][channel_indexes])
-            if len(set(channel_ids)) != len(channel_ids):
-                used_ids = set()
-                deduplicated_ids = []
-                for channel_id in channel_ids:
-                    new_id = channel_id
-                    suffix = 0
-                    while new_id in used_ids:
-                        suffix += 1
-                        new_id = f"{channel_id}-{suffix}"
-                    used_ids.add(new_id)
-                    deduplicated_ids.append(new_id)
-                signal_channels["id"][channel_indexes] = deduplicated_ids
-                self.logger.warning(
-                    f"signal_channels in stream {stream_index} have non-unique ids; duplicates were "
-                    "made unique by suffixing so channels remain addressable by id."
-                )
+            # also check that channel_id is unique inside a stream
+            channel_ids = signal_channels[mask]["id"]
+            if np.unique(channel_ids).size != channel_ids.size:
+                raise ValueError(f"signal_channels do not have unique ids for stream {stream_index}")
 
         self._several_channel_groups = signal_streams.size > 1
 

--- a/neo/test/rawiotest/test_axonrawio.py
+++ b/neo/test/rawiotest/test_axonrawio.py
@@ -28,6 +28,17 @@ class TestAxonRawIO(
 
         reader.read_raw_protocol()
 
+    def test_non_unique_channel_ids_are_deduplicated(self):
+        # Some ABF files (e.g. re-saved exports) store duplicate signal_channel ids. Rather than
+        # refuse an otherwise-readable file, neo makes the ids unique and warns, so the data stays
+        # readable and channels remain addressable by id.
+        path = self.get_local_path("axon/intracellular_data/files_with_errors/non_unique_channel_ids.abf")
+        reader = AxonRawIO(filename=path)
+        with self.assertLogs(reader.logger, level="WARNING"):
+            reader.parse_header()
+        channel_ids = list(reader.header["signal_channels"]["id"])
+        self.assertEqual(len(channel_ids), len(set(channel_ids)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/neo/test/rawiotest/test_axonrawio.py
+++ b/neo/test/rawiotest/test_axonrawio.py
@@ -28,10 +28,11 @@ class TestAxonRawIO(
 
         reader.read_raw_protocol()
 
-    def test_non_unique_channel_ids_are_deduplicated(self):
-        # Some ABF files (e.g. re-saved exports) store duplicate signal_channel ids. Rather than
-        # refuse an otherwise-readable file, neo makes the ids unique and warns, so the data stays
-        # readable and channels remain addressable by id.
+    def test_non_unique_channel_ids_fall_back_to_sequential_ids(self):
+        # Some version < 2.0 ABF files (e.g. re-saved exports) corrupt nADCSamplingSeq so every
+        # entry is identical, which yields non-unique channel ids. AxonRawIO detects this, warns,
+        # and falls back to sequential ids (the same default used for version >= 2.0) so the file
+        # stays readable and channels remain addressable by id.
         path = self.get_local_path("axon/intracellular_data/files_with_errors/non_unique_channel_ids.abf")
         reader = AxonRawIO(filename=path)
         with self.assertLogs(reader.logger, level="WARNING"):


### PR DESCRIPTION
`BaseRawIO` requires channel ids to be unique within a stream so a channel can be addressed by id, and currently raises `signal_channels do not have unique ids for stream {i}` the moment two channels collide. That turns a metadata defect into an unreadable file: some recordings, for example ABF files re-saved by Clampex, carry duplicate channel ids while the original export loads fine, and there is no way for a caller to get at the perfectly good signal behind the collision. The check lives in core `rawio`, so this affects every format, not just ABF.

This change makes the duplicates unique on the spot by suffixing them, warns that it did so, and proceeds, so the data stays readable and id-based channel selection keeps working. Well-formed files are untouched: the path only runs when ids actually collide, so the common case is unchanged and cannot newly warn or fail. Regression coverage uses a purpose-crafted fixture on gin whose channels all share one id, asserting the file now parses with a warning and that every channel ends up with a unique id.
