### PR TITLE
fix: create signal and waveform views with reshape

### DIFF
--- a/neo/core/analogsignal.py
+++ b/neo/core/analogsignal.py
@@ -211,7 +211,7 @@ class AnalogSignal(BaseSignal):
         obj = pq.Quantity(signal, units=units, dtype=dtype).view(cls)
 
         if obj.ndim == 1:
-            obj.shape = (-1, 1)
+            obj = obj.reshape(-1, 1)
 
         if t_start is None:
             raise ValueError("`t_start` cannot be None")

--- a/neo/rawio/alphaomegarawio.py
+++ b/neo/rawio/alphaomegarawio.py
@@ -911,8 +911,7 @@ class AlphaOmegaRawIO(BaseRawIO):
                         offset=file_position,
                     )
                     i += 1
-        waveforms.shape = nb_spikes, 1, spike_length
-        return waveforms
+        return waveforms.reshape(nb_spikes, 1, spike_length)
 
     def _event_count(self, block_index, seg_index, event_channel_index):
         event_id = int(self.header["event_channels"]["id"][event_channel_index])


### PR DESCRIPTION
Signal and waveform creation changes NumPy array dimensions through attribute assignment. Create 2D signal and 3D waveform views with reshape. This keeps both data paths on the supported NumPy array API and avoids the NumPy 2.5 deprecation. All tests pass.
