### PR TITLE
Fix CedRawIO with sonpy >= 1.9.12 and re-enable the CED tests

### DIFF
--- a/neo/rawio/cedrawio.py
+++ b/neo/rawio/cedrawio.py
@@ -19,6 +19,9 @@ Please note that the SONPY package:
 Author : Samuel Garcia
 """
 
+import functools
+import importlib
+
 import numpy as np
 
 from .baserawio import (
@@ -29,6 +32,41 @@ from .baserawio import (
     _spike_channel_dtype,
     _event_channel_dtype,
 )
+
+
+@functools.cache
+def _get_sonpy_namespace():
+    """Return the sonpy module namespace that exposes ``SonFile``.
+
+    The layout of the sonpy package changed in 1.9.12:
+
+    * ``<= 1.9.5`` shipped a single pure-Python wheel whose ``__init__.py``
+      dispatched on the platform and bound the binary to ``lib``.
+    * ``>= 1.9.12`` ships one binary wheel per interpreter. The top level does
+      ``from .sonpy import *`` on Windows and macOS, but the Linux wheel ships
+      an empty ``__init__.py``, so only the ``sonpy.sonpy`` extension module is
+      populated there.
+
+    Probing all three keeps old and new installations working.
+    """
+    import sonpy
+
+    candidates = [getattr(sonpy, "lib", None), sonpy]
+    try:
+        candidates.append(importlib.import_module("sonpy.sonpy"))
+    except ImportError:
+        pass
+
+    for namespace in candidates:
+        if namespace is not None and hasattr(namespace, "SonFile"):
+            return namespace
+
+    raise ImportError(
+        "The installed sonpy package exposes no 'SonFile' symbol "
+        "(tried sonpy.lib, sonpy and sonpy.sonpy). "
+        "Note that sonpy only publishes wheels for Windows, and for Linux and macOS "
+        "on Python 3.14 and above; the source distribution is not usable."
+    )
 
 
 class CedRawIO(BaseRawIO):
@@ -67,9 +105,9 @@ class CedRawIO(BaseRawIO):
         return self.filename
 
     def _parse_header(self):
-        import sonpy
+        sonpy_ns = _get_sonpy_namespace()
 
-        self.smrx_file = sonpy.lib.SonFile(sName=str(self.filename), bReadOnly=True)
+        self.smrx_file = sonpy_ns.SonFile(sName=str(self.filename), bReadOnly=True)
         smrx = self.smrx_file
 
         self._time_base = smrx.GetTimeBase()
@@ -82,7 +120,7 @@ class CedRawIO(BaseRawIO):
         for chan_ind in range(smrx.MaxChannels()):
             chan_type = smrx.ChannelType(chan_ind)
             chan_id = str(chan_ind)
-            if chan_type == sonpy.lib.DataType.Adc:
+            if chan_type == sonpy_ns.DataType.Adc:
                 physical_chan = smrx.PhysicalChannel(chan_ind)
                 divide = smrx.ChannelDivide(chan_ind)
                 if self.take_ideal_sampling_rate:
@@ -105,13 +143,13 @@ class CedRawIO(BaseRawIO):
                 buffer_id = ""
                 signal_channels.append((ch_name, chan_id, sr, dtype, units, gain, offset, stream_id, buffer_id))
 
-            elif chan_type == sonpy.lib.DataType.AdcMark:
+            elif chan_type == sonpy_ns.DataType.AdcMark:
                 # spike and waveforms : only spike times is used here
                 ch_name = smrx.GetChannelTitle(chan_ind)
                 first_time = smrx.FirstTime(chan_ind, 0, max_time)
                 max_time = smrx.ChannelMaxTime(chan_ind)
                 divide = smrx.ChannelDivide(chan_ind)
-                # here we don't use filter (sonpy.lib.MarkerFilter()) so we get all marker
+                # here we don't use filter (sonpy_ns.MarkerFilter()) so we get all marker
                 wave_marks = smrx.ReadWaveMarks(chan_ind, int(max_time / divide), 0, max_time)
 
                 # here we load in memory all spike once because the access is really slow

--- a/neo/rawio/cedrawio.py
+++ b/neo/rawio/cedrawio.py
@@ -21,7 +21,6 @@ Author : Samuel Garcia
 
 import importlib
 import importlib.util
-from functools import cache
 
 import numpy as np
 
@@ -35,7 +34,6 @@ from .baserawio import (
 )
 
 
-@cache
 def _get_sonpy_namespace():
     """Return the sonpy namespace exposing SonFile, whatever the installed layout."""
     if importlib.util.find_spec("sonpy") is None:

--- a/neo/rawio/cedrawio.py
+++ b/neo/rawio/cedrawio.py
@@ -21,6 +21,7 @@ Author : Samuel Garcia
 
 import functools
 import importlib
+import importlib.util
 
 import numpy as np
 
@@ -51,14 +52,16 @@ def _get_sonpy_namespace():
     """
     import sonpy
 
-    candidates = [getattr(sonpy, "lib", None), sonpy]
-    try:
-        candidates.append(importlib.import_module("sonpy.sonpy"))
-    except ImportError:
-        pass
-
-    for namespace in candidates:
+    for namespace in (getattr(sonpy, "lib", None), sonpy):
         if namespace is not None and hasattr(namespace, "SonFile"):
+            return namespace
+
+    # Only reached with the >= 1.9.12 Linux wheels, whose __init__.py is empty.
+    # find_spec imports the parent package, and raises if it is not a package,
+    # so guard on __path__ before probing the submodule.
+    if hasattr(sonpy, "__path__") and importlib.util.find_spec("sonpy.sonpy") is not None:
+        namespace = importlib.import_module("sonpy.sonpy")
+        if hasattr(namespace, "SonFile"):
             return namespace
 
     raise ImportError(

--- a/neo/rawio/cedrawio.py
+++ b/neo/rawio/cedrawio.py
@@ -19,9 +19,9 @@ Please note that the SONPY package:
 Author : Samuel Garcia
 """
 
-import functools
 import importlib
 import importlib.util
+from functools import cache
 
 import numpy as np
 
@@ -35,41 +35,31 @@ from .baserawio import (
 )
 
 
-@functools.cache
+@cache
 def _get_sonpy_namespace():
-    """Return the sonpy module namespace that exposes ``SonFile``.
+    """Return the sonpy namespace exposing SonFile, whatever the installed layout."""
+    if importlib.util.find_spec("sonpy") is None:
+        raise ImportError("sonpy is not installed. Install it with `pip install sonpy`.")
 
-    The layout of the sonpy package changed in 1.9.12:
+    sonpy = importlib.import_module("sonpy")
 
-    * ``<= 1.9.5`` shipped a single pure-Python wheel whose ``__init__.py``
-      dispatched on the platform and bound the binary to ``lib``.
-    * ``>= 1.9.12`` ships one binary wheel per interpreter. The top level does
-      ``from .sonpy import *`` on Windows and macOS, but the Linux wheel ships
-      an empty ``__init__.py``, so only the ``sonpy.sonpy`` extension module is
-      populated there.
+    # <= 1.9.5 binds the extension module as an attribute, not a submodule,
+    # so find_spec("sonpy.lib") cannot see it.
+    lib = getattr(sonpy, "lib", None)
+    if lib is not None and hasattr(lib, "SonFile"):
+        return lib
 
-    Probing all three keeps old and new installations working.
-    """
-    import sonpy
+    # >= 1.9.12 on Windows/macOS re-exports into the package namespace.
+    if hasattr(sonpy, "SonFile"):
+        return sonpy
 
-    for namespace in (getattr(sonpy, "lib", None), sonpy):
-        if namespace is not None and hasattr(namespace, "SonFile"):
-            return namespace
+    # >= 1.9.12 on Linux ships an empty __init__.py.
+    if importlib.util.find_spec("sonpy.sonpy") is not None:
+        nested = importlib.import_module("sonpy.sonpy")
+        if hasattr(nested, "SonFile"):
+            return nested
 
-    # Only reached with the >= 1.9.12 Linux wheels, whose __init__.py is empty.
-    # find_spec imports the parent package, and raises if it is not a package,
-    # so guard on __path__ before probing the submodule.
-    if hasattr(sonpy, "__path__") and importlib.util.find_spec("sonpy.sonpy") is not None:
-        namespace = importlib.import_module("sonpy.sonpy")
-        if hasattr(namespace, "SonFile"):
-            return namespace
-
-    raise ImportError(
-        "The installed sonpy package exposes no 'SonFile' symbol "
-        "(tried sonpy.lib, sonpy and sonpy.sonpy). "
-        "Note that sonpy only publishes wheels for Windows, and for Linux and macOS "
-        "on Python 3.14 and above; the source distribution is not usable."
-    )
+    raise ImportError("sonpy is installed but exposes no SonFile.")
 
 
 class CedRawIO(BaseRawIO):

--- a/neo/rawio/cedrawio.py
+++ b/neo/rawio/cedrawio.py
@@ -89,6 +89,13 @@ class CedRawIO(BaseRawIO):
 
     * This IO reads smr and smrx files
 
+    * sonpy is installed by the ``ced`` extra, but upstream only publishes wheels for Windows,
+      and for Linux and macOS from Python 3.14 onwards. Elsewhere the extra resolves to nothing
+      installable and this class raises an ImportError naming the constraint on first use; the
+      PyPI source distribution ships a Windows binary and is not usable.
+
+    * Old smr files can be read without sonpy using Spike2RawIO. Only smrx requires this class.
+
     """
 
     extensions = ["smr", "smrx"]

--- a/neo/test/iotest/test_cedio.py
+++ b/neo/test/iotest/test_cedio.py
@@ -1,17 +1,10 @@
 import unittest
-from platform import system
-from sys import maxsize
 
 try:
-    if system() == "Windows":
-        if maxsize > 2**32:
-            import sonpy.amd64.sonpy
-        else:
-            import sonpy.win32.sonpy
-    elif system() == "Darwin":
-        import sonpy.darwin.sonpy
-    elif system() == "Linux":
-        import sonpy.linux.sonpy
+    from neo.rawio.cedrawio import _get_sonpy_namespace
+
+    # Raises ImportError if sonpy is missing or exposes no usable namespace.
+    _get_sonpy_namespace()
     from neo.io import CedIO
 except ImportError:
     HAVE_SONPY = False

--- a/neo/test/rawiotest/test_cedrawio.py
+++ b/neo/test/rawiotest/test_cedrawio.py
@@ -5,7 +5,10 @@ from neo.rawio.cedrawio import CedRawIO
 from neo.test.rawiotest.common_rawio_test import BaseTestRawIO
 
 try:
-    import sonpy
+    from neo.rawio.cedrawio import _get_sonpy_namespace
+
+    # Raises ImportError if sonpy is missing or exposes no usable namespace.
+    _get_sonpy_namespace()
 
     HAVE_SONPY = True
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ test = [
     "coverage",
     "coveralls",
     "pillow",
-    "sonpy;python_version<'3.10'",
+    "sonpy; platform_system=='Windows' or python_version>='3.14'",
     "pynwb",
     "probeinterface",
     "zugbruecke>=0.2",


### PR DESCRIPTION
Closes #1890.

sonpy 1.9.12 reorganised its package layout and dropped the `lib` namespace that
`cedrawio.py` relies on, so every `sonpy.lib.*` access raises
`AttributeError: module 'sonpy' has no attribute 'lib'`.

While preparing the fix I found that the CED tests could not have caught this, for two
independent reasons — so this PR fixes the reader and restores the test coverage that would
have flagged it.

### 1. `neo/rawio/cedrawio.py` — resolve the namespace

A cached `_get_sonpy_namespace()` helper probes three candidates in order:

| candidate | covers |
|---|---|
| `sonpy.lib` | `<= 1.9.5`, the old per-platform dispatch |
| `sonpy` | `>= 1.9.12` on Windows and macOS (`from .sonpy import *`) |
| `sonpy.sonpy` | `>= 1.9.12` on Linux, whose wheel ships an empty `__init__.py` |

The third is not redundant: the `cp314-manylinux_2_39_x86_64` wheel has a 0-byte
`__init__.py`, so neither `sonpy.lib` nor `sonpy.SonFile` resolves there. If none of the
three exposes `SonFile`, an `ImportError` naming all three is raised, rather than letting an
`AttributeError` surface from the middle of `_parse_header`.

### 2. Both CED test guards

There are two, and each fails differently with 1.9.12:

- `neo/test/iotest/test_cedio.py` replicated the old per-platform dispatch
  (`import sonpy.linux.sonpy`, …), which no longer exists → `HAVE_SONPY = False` → skipped.
- `neo/test/rawiotest/test_cedrawio.py` used a bare `import sonpy`, which *succeeds* with
  1.9.12 → `HAVE_SONPY = True` → the test would run and fail with the `AttributeError`.

Both now delegate to `_get_sonpy_namespace()`, so "sonpy is usable" has one definition.

### 3. `pyproject.toml` — the `test` extra never installed sonpy

```toml
"sonpy;python_version<'3.10'",
```

with `requires-python = ">=3.10"`. The marker cannot be satisfied, so sonpy is absent from
every CI run and both guards were moot regardless of how they were written. This is why the
breakage went unnoticed.

Changed to match where sonpy actually publishes usable wheels:

```toml
"sonpy; platform_system=='Windows' or python_version>='3.14'",
```

1.9.12 ships `win_amd64` wheels for cp39–cp314, but `manylinux` and `macosx` only for cp314.
The marker is deliberately not just `"sonpy"`: on Linux 3.10–3.13 pip would fall back to the
source distribution, which ships a Windows `.pyd` (verified: `PE32+ executable (DLL) […] for
MS Windows`) and produces an unusable install.

The practical effect is that the automatic `ubuntu-latest` / Python 3.14 CI job will now
install sonpy and actually exercise `CedRawIO`.

### Verification

The existing test suite goes from failing to passing. Windows, Python 3.12, sonpy 1.9.12,
against `master` (`35cbce7`):

| | `pytest neo/test/rawiotest/test_cedrawio.py -v` |
|---|---|
| unpatched | `FAILED` — `AttributeError: module 'sonpy' has no attribute 'lib'` at `cedrawio.py:72` |
| patched | `PASSED` (1.07 s) — `test_read_all` across all three spike2 entities |

That covers both `.smrx` and the two `.smr` entities, so the reader is exercised end to end
and not just at import time.

Additionally:

- Windows, Python 3.10–3.14, sonpy 1.9.12: `sonpy.lib` absent on all five; the compiled
  library reads `spike2/m365_1sec.smrx` correctly through the new namespace
  (`GetOpenError() == 0`, `MaxChannels() == 101`), confirming an import-path problem rather
  than a functional regression in sonpy.
- Linux x86_64, Python 3.14, sonpy 1.9.12: the helper resolves to `sonpy.sonpy`; `SonFile`,
  `DataType.Adc`, `DataType.AdcMark` and `MarkerFilter` are all reachable, and
  `CedRawIO.parse_header()` runs to completion instead of raising.
- Both guards checked in both directions: `HAVE_SONPY` is `True` with sonpy 1.9.12 present
  and `False` when sonpy cannot be imported.
- The proposed marker evaluates `True` exactly where a usable wheel exists, across the six
  platform/version combinations in Neo's support range.
- `black --line-length 120 --check` clean on all changed files.
- After the three commits: `pytest neo/test/rawiotest/test_cedrawio.py neo/test/iotest/test_cedio.py -v` → **8 passed**.

### Not covered

macOS is untested. It is the one platform where the 1.9.12 wheel exists only for cp314, so
3.10–3.13 are excluded by the marker there. Happy to run it if someone has a machine.

### Open questions

1. Is `platform_system=='Windows' or python_version>='3.14'` acceptable, or would you rather
   keep the `test` extra minimal and add sonpy only to the CI workflow?
2. Should the `ced` extra (line 101, currently a bare `"sonpy"`) get the same marker for
   consistency? I left it alone to keep the diff focused.
