### PR TITLE
BiocamRawIO: reshape flat datasets instead of gathering channel by channel

### DIFF
--- a/doc/source/authors.rst
+++ b/doc/source/authors.rst
@@ -103,6 +103,7 @@ and may not be the current affiliation of a contributor.
 * Reema Gupta [50]
 * Sai Asish Yamani [51]
 * Kevin Doran [52]
+* Aditya Singh (github)
 
 1. Centre de Recherche en Neuroscience de Lyon, CNRS UMR5292 - INSERM U1028 - Université Claude Bernard Lyon 1
 2. Unité de Neuroscience, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France

--- a/neo/rawio/biocamrawio.py
+++ b/neo/rawio/biocamrawio.py
@@ -163,34 +163,27 @@ class BiocamRawIO(BaseRawIO):
         else:
             data = self._read_function(self._filehandle, i_start, i_stop, self._num_channels)
 
-        # older style data returns array of (n_samples, n_channels), should be a view
+        # Newer style data comes back as a flat array of length (n_samples * n_channels)
+        # laid out frame-major, i.e. every channel of frame 0, then every channel of
+        # frame 1, and so on. The read functions materialize it in memory already, so
+        # reshaping is a free view onto the same buffer and puts both file layouts on the
+        # same (n_samples, n_channels) footing.
+        if data.ndim == 1:
+            expected_size = (i_stop - i_start) * self._num_channels
+            if data.size != expected_size:
+                raise NeoReadWriteError(
+                    f"Read {data.size} values for frames {i_start}:{i_stop} of {self._num_channels} "
+                    f"channels but expected {expected_size}. The requested frame range is most likely "
+                    "out of bounds."
+                )
+            data = data.reshape(i_stop - i_start, self._num_channels)
+
+        # older style data is already (n_samples, n_channels), should be a view
         # but if memory issues come up we should doublecheck out how the file is being stored
-        if data.ndim > 1:
-            if channel_indexes is None:
-                channel_indexes = slice(None)
-            sig_chunk = data[:, channel_indexes]
+        if channel_indexes is None:
+            channel_indexes = slice(None)
 
-        # newer style data returns an initial flat array (n_samples * n_channels)
-        # we iterate through channels rather than slicing
-        # Due to the fact that Neo and SpikeInterface tend to prefer slices we need to add
-        # some careful checks around slicing of None in the case we need to iterate through
-        # channels. First check if None. Then check if slice and only if slice check that it is slice(None)
-        else:
-            if channel_indexes is None:
-                channel_indexes = [ch for ch in range(self._num_channels)]
-            elif isinstance(channel_indexes, slice):
-                start = channel_indexes.start or 0
-                stop = channel_indexes.stop or self._num_channels
-                step = channel_indexes.step or 1
-                channel_indexes = [ch for ch in range(start, stop, step)]
-
-            sig_chunk = np.zeros((i_stop - i_start, len(channel_indexes)), dtype=data.dtype)
-            # iterate through channels to prevent loading all channels into memory which can cause
-            # memory exhaustion. See https://github.com/SpikeInterface/spikeinterface/issues/3303
-            for index, channel_index in enumerate(channel_indexes):
-                sig_chunk[:, index] = data[channel_index :: self._num_channels]
-
-        return sig_chunk
+        return data[:, channel_indexes]
 
 
 def open_biocam_file_header(filename) -> dict:

--- a/neo/test/rawiotest/test_biocamrawio.py
+++ b/neo/test/rawiotest/test_biocamrawio.py
@@ -2,12 +2,14 @@
 Tests of neo.rawio.BiocamRawIO
 """
 
+import json
 import unittest
 import pytest
 
 import numpy as np
 import h5py
 
+from neo.core import NeoReadWriteError
 from neo.rawio.biocamrawio import BiocamRawIO
 from neo.test.rawiotest.common_rawio_test import BaseTestRawIO
 
@@ -59,6 +61,99 @@ def test_biocamrawio_gain(tmp_path):
     expected_gain = (max_volt - min_volt) / 2**bit_depth  # ~ 2.014
     gain = r.header["signal_channels"]["gain"][0]
     assert expected_gain == pytest.approx(gain)
+
+
+def _write_minimal_brw4(path, n_ch, n_frames):
+    """Write a minimal uncompressed BRW 4.x file whose ``Raw`` dataset is flat and frame-major.
+
+    Returns the reference (n_frames, n_ch) view of the samples that were written.
+    """
+    experiment_settings = {
+        "ValueConverter": {
+            "MaxAnalogValue": 4125.0,
+            "MinAnalogValue": -4125.0,
+            "MaxDigitalValue": 4096,
+            "MinDigitalValue": 0,
+            "ScaleFactor": 1.0,
+        },
+        "TimeConverter": {"FrameRate": 19753.775},
+    }
+    raw = np.arange(n_ch * n_frames, dtype=np.uint16)
+    with h5py.File(path, "w") as f:
+        f.create_dataset("ExperimentSettings", data=[json.dumps(experiment_settings).encode()])
+        f.create_dataset("TOC", data=np.array([[0, n_frames]], dtype=np.int64))
+        well = f.create_group("Well_A1")
+        well.create_dataset("StoredChIdxs", data=np.arange(n_ch, dtype=np.int32))
+        well.create_dataset("Raw", data=raw)
+    return raw.reshape(n_frames, n_ch)
+
+
+@pytest.mark.parametrize(
+    "channel_indexes",
+    [
+        None,
+        slice(None),
+        slice(0, 4),
+        slice(2, None),
+        slice(None, 3),
+        slice(None, None, 2),
+        slice(0, 0),
+        slice(0, -1),
+        slice(-2, None),
+        slice(None, None, -1),
+        [3, 1, 15],
+        np.array([0, 5]),
+    ],
+)
+def test_biocamrawio_flat_layout_channel_selection(tmp_path, channel_indexes):
+    """Selecting channels from a flat (frame-major) Biocam dataset must match a plain reshape.
+
+    A test case from Issue #1892 (https://github.com/NeuralEnsemble/python-neo/issues/1892).
+    The flat branch used to expand a slice with ``range(start or 0, stop or n_ch, step or 1)``,
+    which silently mishandles every slice carrying a negative or zero bound: ``slice(0, -1)``
+    and ``slice(None, None, -1)`` returned no channels, ``slice(0, 0)`` returned all of them,
+    and ``slice(-2, None)`` returned more columns than the file has channels.
+    """
+    n_ch, n_frames = 16, 40
+    path = tmp_path / "minimal_v4.brw"
+    reference = _write_minimal_brw4(path, n_ch, n_frames)
+
+    reader = BiocamRawIO(filename=path)
+    reader.parse_header()
+
+    i_start, i_stop = 5, 25
+    chunk = reader.get_analogsignal_chunk(
+        block_index=0,
+        seg_index=0,
+        i_start=i_start,
+        i_stop=i_stop,
+        stream_index=0,
+        channel_indexes=channel_indexes,
+    )
+
+    expected = reference[i_start:i_stop][:, slice(None) if channel_indexes is None else channel_indexes]
+    assert chunk.shape == expected.shape
+    assert np.array_equal(chunk, expected)
+
+
+def test_biocamrawio_flat_layout_out_of_bounds(tmp_path):
+    """A frame range past the end of a flat dataset raises instead of silently mis-shaping."""
+    n_ch, n_frames = 16, 40
+    path = tmp_path / "minimal_v4.brw"
+    _write_minimal_brw4(path, n_ch, n_frames)
+
+    reader = BiocamRawIO(filename=path)
+    reader.parse_header()
+
+    with pytest.raises(NeoReadWriteError):
+        reader.get_analogsignal_chunk(
+            block_index=0,
+            seg_index=0,
+            i_start=0,
+            i_stop=n_frames + 3,
+            stream_index=0,
+            channel_indexes=None,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`BiocamRawIO._get_analogsignal_chunk` has two branches. Older files hand back a 2D `(n_samples, n_channels)` array and are indexed directly. Newer files (BRW 4.x `Well_*/Raw`, and the v3 `101`/`102` formats) hand back a flat frame-major 1D array, and that branch first expands the caller's selection into a list with `range(start or 0, stop or n_ch, step or 1)`, then rebuilds the chunk with one strided gather per channel.

The `range(...)` expansion is wrong for any slice carrying a zero or negative bound, because `or` treats `0` as absent and `range` has no notion of negative indices. On a 16 channel file, `slice(0, -1)` returns 0 channels instead of 15, `slice(None, None, -1)` returns 0 instead of 16, `slice(0, 0)` returns all 16 instead of none, and `slice(-2, None)` returns 18 columns, which is more columns than the file has channels, with the first two silently filled from the wrong end of the flat buffer. None of these raise. Every one of them is correct today on an older 2D file, so the same reader answers the same question two different ways depending on which firmware wrote the recording.

The per-channel loop is also the reason issue #1892 was filed. Its comment says it avoids loading all channels into memory, but `self._read_function(...)` on the line above has already read the whole span into a numpy array, so the loop buys no memory and costs `n_channels` cache-hostile passes plus a second full-size allocation for the destination.

The fix reshapes the flat array to `(i_stop - i_start, n_channels)`, which is a view onto the buffer that was just read, and then lets both layouts share one indexing expression. numpy applies the caller's slice, index list, or array exactly as it does everywhere else in Neo, so the slice forms above stop disagreeing with the 2D branch. A frame range that runs past the end of the dataset used to surface as a numpy broadcast error from inside the loop, and now raises `NeoReadWriteError` naming the range that was asked for.

Verified on the two BioCam files in the gin test data, `biocam_hw3.0_fw1.6.brw` (36 channels, `readHDF5t_101`) and `biocam_hw3.0_fw1.7.0.12_raw.brw` (100 channels, `readHDF5t_brw4`). Against a verbatim copy of the old branch the output is bit identical for `None`, `slice(None)`, `slice(0, 4)`, `slice(2, None)`, `slice(None, None, 3)` and an explicit index list, and reading 2000 frames is 9x faster on the first file and 68x on the second. Full `rawio_compliance` passes on both, as does a `BiocamIO.read_block()`. The new tests build a minimal BRW 4.x file with h5py in the style of the existing `test_biocamrawio_gain`, so they need no downloaded data. Against 35cbce7f they are 5 failed 9 passed before the source change and 14 passed after, and `neo/test/rawiotest` plus `neo/test/coretest` is 637 passed 130 skipped 0 failed with the change in place.

I could not test the event-based sparse path against a real compressed recording, but that path is untouched: `readHDF5t_brw4_sparse` returns a 2D array and so has always taken the other branch.

Fixes #1892
