### PR TITLE
NeoMatlabIO: round-trip quantity, array and nested annotations

### DIFF
--- a/doc/source/authors.rst
+++ b/doc/source/authors.rst
@@ -103,6 +103,7 @@ and may not be the current affiliation of a contributor.
 * Reema Gupta [50]
 * Sai Asish Yamani [51]
 * Kevin Doran [52]
+* Aditya Singh (github)
 
 1. Centre de Recherche en Neuroscience de Lyon, CNRS UMR5292 - INSERM U1028 - Université Claude Bernard Lyon 1
 2. Unité de Neuroscience, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France

--- a/neo/io/neomatlabio.py
+++ b/neo/io/neomatlabio.py
@@ -334,11 +334,13 @@ class NeoMatlabIO(BaseIO):
                         new_value[key] = subvalue
                         if subunits:
                             new_value[f"{key}_units"] = subunits
-                    elif attrname == "annotations":
+                    else:
                         # In general we don't send None to MATLAB
                         # but we make an exception for annotations.
                         # However, we have to save then retrieve some
                         # special value as actual `None` is ignored by default.
+                        # Annotations are the only mapping-valued attribute Neo has,
+                        # so this holds at every level of a nested annotation too.
                         new_value[key] = PY_NONE
                 value = new_value
         return value, units
@@ -376,6 +378,37 @@ class NeoMatlabIO(BaseIO):
         struct[obj_name] = id(viewed_obj)
         struct["viewed_classname"] = viewed_obj.__class__.__name__
         return struct
+
+    def create_dict_from_struct(self, struct):
+        """
+        Rebuild a Python dict, typically the annotations, from the MATLAB struct that
+        :meth:`_get_matlab_value` wrote it to.
+
+        That method flattens a quantity into a plain magnitude plus a companion
+        ``<key>_units`` field, mirrors nested mappings as nested structs, and stores
+        `None` as a sentinel string because MATLAB has no equivalent. This undoes all
+        three so that a value survives a write/read round trip unchanged.
+        """
+        new_dict = {}
+        for field_name in struct._fieldnames:
+            if field_name.endswith("_units") and field_name[: -len("_units")] in struct._fieldnames:
+                # this field carries the units of another one and is consumed along with it
+                continue
+
+            value = getattr(struct, field_name)
+            if hasattr(value, "_fieldnames"):
+                # a nested mapping, which scipy returns as a struct of its own
+                value = self.create_dict_from_struct(value)
+            elif isinstance(value, str) and value == PY_NONE:
+                # `isinstance` first: an array compared to the sentinel gives an array,
+                # which is not usable as a condition
+                value = None
+            else:
+                units = getattr(struct, f"{field_name}_units", None)
+                if units is not None:
+                    value = pq.Quantity(value, str(units))
+            new_dict[field_name] = value
+        return new_dict
 
     def create_ob_from_struct(self, struct, classname):
         cl = class_by_name[classname]
@@ -508,13 +541,7 @@ class NeoMatlabIO(BaseIO):
                     else:
                         item = pq.Quantity(item, units)
                 elif attrtype == dict:
-                    new_item = {}
-                    for fn in item._fieldnames:
-                        value = getattr(item, fn)
-                        if value == PY_NONE:
-                            value = None
-                        new_item[fn] = value
-                    item = new_item
+                    item = self.create_dict_from_struct(item)
                 else:
                     item = attrtype(item)
 

--- a/neo/io/neomatlabio.py
+++ b/neo/io/neomatlabio.py
@@ -386,8 +386,12 @@ class NeoMatlabIO(BaseIO):
 
         That method flattens a quantity into a plain magnitude plus a companion
         ``<key>_units`` field, mirrors nested mappings as nested structs, and stores
-        `None` as a sentinel string because MATLAB has no equivalent. This undoes all
-        three so that a value survives a write/read round trip unchanged.
+        `None` as the sentinel string ``"Py_None"`` because MATLAB has no equivalent.
+
+        This reverses that flattening, transforming the string ``"Py_None"`` into
+        Python `None`, the magnitude/units pair into a Quantity scalar or array, and
+        the nested struct back into a dict, so that a value survives a write/read
+        round trip unchanged.
         """
         new_dict = {}
         for field_name in struct._fieldnames:

--- a/neo/test/iotest/test_neomatlabio.py
+++ b/neo/test/iotest/test_neomatlabio.py
@@ -4,6 +4,7 @@ Tests of neo.io.neomatlabio
 
 import os
 import unittest
+import pytest
 from numpy.testing import assert_array_equal
 import quantities as pq
 
@@ -33,7 +34,7 @@ class TestNeoMatlabIO(BaseTestIO, unittest.TestCase):
         block1 = Block(name="test_neomatlabio")
         seg = Segment("segment1")
         spiketrain1 = SpikeTrain([1] * pq.s, t_stop=10 * pq.s, sampling_rate=1 * pq.Hz)
-        spiketrain1.annotate(yep="yop", yip=None)
+        spiketrain1.annotate(yep="yop", yip=None, yop=[3, 4, 5] * pq.ms)
         sig1 = AnalogSignal([4, 5, 6] * pq.A, sampling_period=1 * pq.ms)
         irrsig1 = IrregularlySampledSignal([0, 1, 2] * pq.ms, [4, 5, 6] * pq.A)
         img_sequence_array = [[[column for column in range(2)] for _ in range(2)] for _ in range(2)]
@@ -76,6 +77,11 @@ class TestNeoMatlabIO(BaseTestIO, unittest.TestCase):
         spiketrain2 = block2.segments[0].spiketrains[0]
         assert spiketrain2.annotations["yep"] == "yop"
         assert spiketrain2.annotations["yip"] is None
+        # a quantity annotation keeps its units and does not leak its companion field,
+        # see https://github.com/NeuralEnsemble/python-neo/issues/852
+        assert "yop_units" not in spiketrain2.annotations
+        assert spiketrain2.annotations["yop"].dimensionality == pq.ms.dimensionality
+        assert_array_equal(spiketrain2.annotations["yop"].magnitude, [3, 4, 5])
 
         # test group retrieval
         group2 = block2.groups[0]
@@ -102,6 +108,66 @@ class TestNeoMatlabIO(BaseTestIO, unittest.TestCase):
             # the actual contents will differ since we're using Python object id as identifiers
             # but at least the file size should be the same
             assert os.stat(filename_orig).st_size == os.stat(filename_roundtripped).st_size
+
+
+@unittest.skipUnless(HAVE_SCIPY, "requires scipy")
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        "a string",
+        42,
+        None,
+        [3, 4, 5],
+        [3, 4, 5] * pq.ms,
+        3 * pq.ms,
+        {"a": 1, "b": None},
+        {"a": [1, 2] * pq.mV, "b": {"deep": 5 * pq.Hz}},
+    ],
+    ids=["str", "int", "none", "array", "quantity_array", "quantity_scalar", "dict", "nested_dict"],
+)
+def test_write_read_annotation_roundtrip(tmp_path, annotation):
+    """An annotation must survive a write then read unchanged.
+
+    A test case from Issue #852 (https://github.com/NeuralEnsemble/python-neo/issues/852).
+    Quantity annotations used to come back as bare magnitudes plus a stray ``<key>_units``
+    key, nested mappings came back as ``scipy.io`` structs, and any array-valued
+    annotation raised ``ValueError: The truth value of an array ... is ambiguous`` while
+    being compared against the sentinel that stands in for `None`.
+
+    This runs off a temporary file rather than the downloaded test data, so it also
+    covers installations without datalad.
+    """
+    block = Block(name="test_annotations")
+    segment = Segment(name="segment1")
+    block.segments.append(segment)
+    spiketrain = SpikeTrain([1, 2, 3] * pq.s, t_stop=10 * pq.s, yop=annotation)
+    segment.spiketrains.append(spiketrain)
+    segment.check_relationships()
+
+    filename = tmp_path / "annotations.mat"
+    NeoMatlabIO(filename=filename).write_block(block)
+    read_back = NeoMatlabIO(filename=filename).read_block().segments[0].spiketrains[0].annotations
+
+    assert list(read_back) == ["yop"], "no companion field should leak into the annotations"
+    _assert_annotation_equal(read_back["yop"], annotation)
+
+
+def _assert_annotation_equal(actual, expected):
+    if expected is None:
+        assert actual is None
+    elif isinstance(expected, dict):
+        assert isinstance(actual, dict)
+        assert sorted(actual) == sorted(expected)
+        for key in expected:
+            _assert_annotation_equal(actual[key], expected[key])
+    elif isinstance(expected, pq.Quantity):
+        assert isinstance(actual, pq.Quantity)
+        assert actual.dimensionality == expected.dimensionality
+        assert_array_equal(actual.magnitude, expected.magnitude)
+    elif isinstance(expected, list):
+        assert_array_equal(actual, expected)
+    else:
+        assert actual == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Fixes #852.

On master, `NeoMatlabIO` writes a quantity annotation as a plain magnitude plus a companion `<key>_units` field, and a nested annotation dict as a nested struct, but the read path reverses neither. An annotation `yop=[3, 4, 5] * pq.ms` comes back as `{'yop': array([3., 4., 5.]), 'yop_units': 'ms'}`, and a nested dict comes back as a raw `scipy.io.matlab.mat_struct`.

While fixing that I hit a second, more serious bug in the same branch of `create_ob_from_struct`. The `None` sentinel is tested with `if value == PY_NONE`, which evaluates to an array when the annotation is array-valued and raises `ValueError: The truth value of an array with more than one element is ambiguous`. Any object carrying an array annotation is therefore written without complaint and can never be read back.

## Solution

Decoding now mirrors encoding, in a new `create_dict_from_struct` alongside the existing `create_ob_from_struct`: `<key>_units` is folded back into the value it belongs to, nested structs are decoded recursively, and the sentinel is tested only on strings.

One change on the write side: `None` inside a nested annotation dict is currently dropped, because the guard identifying the annotations attribute does not survive the recursion into the nested mapping. Annotations are the only mapping-valued attribute any Neo class declares, so the guard can be dropped.

## Testing

`neo/test/iotest/test_neomatlabio.py` goes from 6 failed / 11 passed to 17 passed. The new parametrized test round-trips a range of value types, and checks that no companion field leaks into the annotations. It writes to a temporary file rather than the downloaded test data, so it also runs without datalad, where the counts are 5 failed / 3 passed to 8 passed with the other 9 skipped. The `yop` annotation from #852 is also added to `test_write_read_single_spike`, as the issue suggests.

## Other comments

A quantity and its units are two separate fields in the `.mat` file, so plain annotations `a` and `a_units` are indistinguishable on disk from a single _quantity_ annotation `a`, and now read back as the latter. The ambiguity is inherent to the storage convention the write side already uses but it is a behaviour change for that case.
