### PR TITLE
Fix CircularRegionOfInterest.pixels_in_region omitting boundary pixels

### DIFF
--- a/neo/core/regionofinterest.py
+++ b/neo/core/regionofinterest.py
@@ -79,9 +79,13 @@ class CircularRegionOfInterest(RegionOfInterest):
 
     def pixels_in_region(self):
         """Returns a list of pixels whose *centres* are within the circle"""
+        # `is_inside` tests a closed disc, so a pixel centre exactly `radius` away is
+        # inside. `range` excludes its stop value, so the upper bounds need a `+ 1` for
+        # those extremes to be offered to `is_inside` at all. Without it the region is
+        # not symmetric about its own centre.
         pixel_in_list = []
-        for y in range(int(floor(self.y - self.radius)), int(ceil(self.y + self.radius))):
-            for x in range(int(floor(self.x - self.radius)), int(ceil(self.x + self.radius))):
+        for y in range(int(floor(self.y - self.radius)), int(ceil(self.y + self.radius)) + 1):
+            for x in range(int(floor(self.x - self.radius)), int(ceil(self.x + self.radius)) + 1):
                 if self.is_inside(x, y):
                     pixel_in_list.append([x, y])
 

--- a/neo/test/coretest/test_regionofinterest.py
+++ b/neo/test/coretest/test_regionofinterest.py
@@ -8,10 +8,47 @@ class Test_CircularRegionOfInterest(unittest.TestCase):
 
     def test_result(self):
         seq = ImageSequence([[[]]], spatial_scale=1, frame_duration=20 * pq.ms)
-        self.assertEqual((CircularRegionOfInterest(seq, 6, 6, 1).pixels_in_region()), [[6, 5], [5, 6], [6, 6]])
+        # `is_inside` tests a closed disc, so radius 1 and radius 1.01 enclose the same
+        # pixel centres. The radius 1 expectation used to be [[6, 5], [5, 6], [6, 6]],
+        # which contradicted both the line below it and `is_inside` itself.
+        self.assertEqual(
+            (CircularRegionOfInterest(seq, 6, 6, 1).pixels_in_region()), [[6, 5], [5, 6], [6, 6], [7, 6], [6, 7]]
+        )
         self.assertEqual(
             (CircularRegionOfInterest(seq, 6, 6, 1.01).pixels_in_region()), [[6, 5], [5, 6], [6, 6], [7, 6], [6, 7]]
         )
+
+    def test_pixels_in_region_matches_is_inside(self):
+        """Every pixel `is_inside` accepts must be enumerated by `pixels_in_region`."""
+        seq = ImageSequence([[[]]], spatial_scale=1, frame_duration=20 * pq.ms)
+        for x, y, radius in ((6, 6, 1), (10, 10, 5), (6, 6, 2.5), (7, 4, 3), (5, 5, 1.01)):
+            roi = CircularRegionOfInterest(seq, x, y, radius)
+            enumerated = {tuple(pixel) for pixel in roi.pixels_in_region()}
+            margin = int(radius) + 2
+            accepted = {
+                (px, py)
+                for py in range(y - margin, y + margin + 1)
+                for px in range(x - margin, x + margin + 1)
+                if roi.is_inside(px, py)
+            }
+            self.assertEqual(enumerated, accepted, f"disagreement for x={x}, y={y}, radius={radius}")
+
+    def test_pixels_in_region_is_symmetric_about_centre(self):
+        """The disc must reach as far right and up as it does left and down."""
+        seq = ImageSequence([[[]]], spatial_scale=1, frame_duration=20 * pq.ms)
+        roi = CircularRegionOfInterest(seq, 10, 10, 5)
+        pixels = roi.pixels_in_region()
+
+        # (15, 10) sits exactly `radius` from the centre, so the closed disc includes it.
+        self.assertTrue(roi.is_inside(15, 10))
+        self.assertIn([15, 10], pixels)
+        self.assertIn([10, 15], pixels)
+
+        xs = [pixel[0] for pixel in pixels]
+        ys = [pixel[1] for pixel in pixels]
+        self.assertEqual((min(xs), max(xs)), (5, 15))
+        self.assertEqual((min(ys), max(ys)), (5, 15))
+        self.assertEqual(len(pixels), 81)
 
 
 class Test_RectangularRegionOfInterest(unittest.TestCase):


### PR DESCRIPTION
Fixes #1889.

`CircularRegionOfInterest.is_inside()` tests a closed disc with `<=`, so a pixel centre exactly `radius` away is inside. But `pixels_in_region()` enumerated `range(int(floor(c - r)), int(ceil(c + r)))`, and `range` excludes its stop value, so pixels at the `+x` and `+y` extremes were never passed to `is_inside()` at all. They were not rejected, they were never asked about.

The region therefore came out asymmetric about its own centre. For `CircularRegionOfInterest(seq, 10, 10, 5)` it returned 79 pixels spanning x 5 to 14, while `is_inside()` accepts 81 spanning 5 to 15.

The fix adds 1 to both upper bounds, so every pixel `is_inside()` accepts is offered to it.

The repo's own test file contradicted itself on this. Line 11 expected 3 pixels at `radius=1` while line 13 expected 5 at `radius=1.01`. Under a closed disc both radii enclose exactly the same pixel centres, so those two lines could not both be right. **Updating the `radius=1` expectation to the same 5 pixels is an intentional part of this fix, not an accident.** That assertion is what encoded the bug.

I swept the other two ROI classes for the same off-by-one and they are unaffected, so this leaves them alone. `RectangularRegionOfInterest.is_inside()` uses a half-open interval that exactly matches what its `range()` bounds enumerate, with 0 disagreements across 11664 centre, width and height combinations. The polygon ray caster excludes its top and right edges to match its bounding box, with 0 disagreements across 400 random polygons.

Tests: the corrected `test_result`, plus `test_pixels_in_region_matches_is_inside`, which locks in the real invariant that the enumeration must equal the predicate's accept set, and `test_pixels_in_region_is_symmetric_about_centre`, which is the issue's exact reproduction.

Restoring `neo/core/regionofinterest.py` from master makes all three fail, with `[[6, 5], [5, 6], [6, 6]] != [[6, 5], [5, 6], [6, 6], [7, 6], [6, 7]]`. All five pass after. The core suite is green at 617 passed and 16 skipped, and the circle sweep goes from 486 of 4536 configurations disagreeing to 0 of 4536.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
